### PR TITLE
feat: add concurrency settings to cancel in-progress workflow runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-e2e-tests.yml
+++ b/.github/workflows/docker-e2e-tests.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-docker-images:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:

--- a/.github/workflows/test-docker-builds.yml
+++ b/.github/workflows/test-docker-builds.yml
@@ -3,6 +3,10 @@ name: Test Docker Builds (No Push)
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-build-all-images:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds concurrency configuration to GitHub workflows to automatically cancel in-progress runs when new commits are pushed to the same PR or branch.

## Changes
- **CI workflow**: Added concurrency group to cancel previous runs on new commits
- **Docker E2E Tests workflow**: Added concurrency to cancel previous test runs
- **Docs workflow**: Changed `cancel-in-progress` from `false` to `true`
- **Test Docker Builds workflow**: Added concurrency for build tests

## Benefits
- ✅ Saves CI resources by canceling outdated runs
- ✅ Reduces wait times for developers
- ✅ Prevents queue buildup when multiple commits are pushed quickly
- ✅ More efficient use of GitHub Actions minutes

## Configuration Details
Uses the pattern:
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

This creates unique concurrency groups per workflow and PR/branch combination.

## Test plan
- [x] All YAML files validated for correct syntax
- [x] Verified concurrency group patterns are appropriate for each workflow
- [ ] Will be tested when this PR triggers the CI workflow

🤖 Generated with [Claude Code](https://claude.ai/code)