### PR TITLE
fix failing ci on v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,7 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "html-to-markdown-rs"
-version = "2.3.2"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83bfa83b2b9c3d1667afd2ee26b7a0fc445038d7d0070720012280cbc7a35e5"
 dependencies = [
  "ammonia",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ encoding_rs = "0.8.35"
 fast_image_resize = "5.3.0"
 hex = "0.4.3"
 html-escape = "0.2.13"
-html-to-markdown-rs = { path = "../html-to-markdown/crates/html-to-markdown", features = ["inline-images"] }
+html-to-markdown-rs = { version = "2.3.4", features = ["inline-images"] }
 image = { version = "0.25.8", default-features = false, features = ["png", "jpeg", "webp", "bmp", "tiff", "gif", "rayon"] }
 libc = "0.2"
 mail-parser = "0.11.1"


### PR DESCRIPTION
changed the dependency from a local path to the published crates.io version