### PR TITLE
fix(docker): install ONNX Runtime from GitHub releases

### DIFF
--- a/docker/Dockerfile.core
+++ b/docker/Dockerfile.core
@@ -44,6 +44,19 @@ RUN mkdir -p /build/pdfium && \
 # Set environment variable to use prebuilt pdfium
 ENV KREUZBERG_PDFIUM_PREBUILT=/build/pdfium
 
+# Download and extract ONNX Runtime
+ARG ONNXRUNTIME_VERSION=1.23.2
+RUN mkdir -p /build/onnxruntime && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        ONNX_ARCH="aarch64"; \
+    else \
+        ONNX_ARCH="x64"; \
+    fi && \
+    curl -fL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
+        -o /build/onnxruntime.tgz && \
+    tar -xzf /build/onnxruntime.tgz -C /build/onnxruntime --strip-components=1 && \
+    rm /build/onnxruntime.tgz
+
 # Copy workspace manifests and crates
 COPY Cargo.toml Cargo.lock ./
 COPY crates/kreuzberg/ crates/kreuzberg/
@@ -90,8 +103,6 @@ RUN apt-get update && \
         tesseract-ocr-ara \
         tesseract-ocr-rus \
         tesseract-ocr-hin \
-        libonnxruntime1.23 \
-        libonnxruntime-dev \
         && \
     # Clean up
     apt-get clean && \
@@ -99,6 +110,10 @@ RUN apt-get update && \
 
 # Copy pdfium library from builder
 COPY --from=builder /build/pdfium/lib/libpdfium.so /usr/local/lib/
+
+# Copy ONNX Runtime from builder
+COPY --from=builder /build/onnxruntime/lib/* /usr/local/lib/
+COPY --from=builder /build/onnxruntime/include/* /usr/local/include/
 RUN ldconfig
 
 # Copy binary from builder

--- a/docker/Dockerfile.full
+++ b/docker/Dockerfile.full
@@ -44,6 +44,19 @@ RUN mkdir -p /build/pdfium && \
 # Set environment variable to use prebuilt pdfium
 ENV KREUZBERG_PDFIUM_PREBUILT=/build/pdfium
 
+# Download and extract ONNX Runtime
+ARG ONNXRUNTIME_VERSION=1.23.2
+RUN mkdir -p /build/onnxruntime && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        ONNX_ARCH="aarch64"; \
+    else \
+        ONNX_ARCH="x64"; \
+    fi && \
+    curl -fL "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VERSION}/onnxruntime-linux-${ONNX_ARCH}-${ONNXRUNTIME_VERSION}.tgz" \
+        -o /build/onnxruntime.tgz && \
+    tar -xzf /build/onnxruntime.tgz -C /build/onnxruntime --strip-components=1 && \
+    rm /build/onnxruntime.tgz
+
 # Copy workspace manifests and crates
 COPY Cargo.toml Cargo.lock ./
 COPY crates/kreuzberg/ crates/kreuzberg/
@@ -91,8 +104,6 @@ RUN apt-get update && \
         tesseract-ocr-ara \
         tesseract-ocr-rus \
         tesseract-ocr-hin \
-        libonnxruntime1.23 \
-        libonnxruntime-dev \
         fontconfig \
         libxinerama1 \
         libgl1 \
@@ -119,6 +130,10 @@ RUN apt-get update && \
 
 # Copy pdfium library from builder
 COPY --from=builder /build/pdfium/lib/libpdfium.so /usr/local/lib/
+
+# Copy ONNX Runtime from builder
+COPY --from=builder /build/onnxruntime/lib/* /usr/local/lib/
+COPY --from=builder /build/onnxruntime/include/* /usr/local/include/
 RUN ldconfig
 
 # Copy binary from builder


### PR DESCRIPTION
## Summary
  - Install ONNX Runtime 1.23.2 from GitHub releases instead of apt
  - libonnxruntime1.23 package is unavailable in Debian repositories
  - Download in builder stage, copy lib/include files to runtime stage

  ## Test plan
  - [x] Build Dockerfile.core for amd64
  - [x] Build Dockerfile.full for amd64
  - [x] Verify running /extract with embedding enabled with the REST endpoint.