### PR TITLE
feat: add Djot format support

### DIFF
--- a/crates/kreuzberg/Cargo.toml
+++ b/crates/kreuzberg/Cargo.toml
@@ -39,7 +39,6 @@ office = [
     "dep:docx-lite",
     "dep:quick-xml",
     "dep:pulldown-cmark",
-    "dep:jotdown",
     "dep:biblatex",
     "dep:org",
     "dep:rtf-parser",
@@ -49,6 +48,7 @@ office = [
     "html",
     "tokio-runtime",
 ]
+djot = ["dep:jotdown", "tokio-runtime"]
 email = ["dep:mail-parser", "dep:msg_parser"]
 html = ["dep:html-to-markdown-rs"]
 xml = ["dep:quick-xml", "dep:roxmltree"]
@@ -86,6 +86,7 @@ full = [
     "pdf",
     "excel",
     "office",
+    "djot",
     "email",
     "html",
     "xml",

--- a/crates/kreuzberg/src/extractors/djot.rs
+++ b/crates/kreuzberg/src/extractors/djot.rs
@@ -10,21 +10,21 @@
 //! Djot is a modern markup language with simpler parsing rules than CommonMark.
 //! See https://djot.net for the specification.
 //!
-//! Requires the `office` feature.
+//! Requires the `djot` feature.
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use crate::Result;
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use crate::core::config::ExtractionConfig;
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use crate::plugins::{DocumentExtractor, Plugin};
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use crate::types::{ExtractionResult, Metadata, Table};
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use async_trait::async_trait;
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use jotdown::{Container, Event, Parser};
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 use serde_yaml_ng::Value as YamlValue;
 
 /// Djot markup extractor with metadata and table support.
@@ -34,10 +34,10 @@ use serde_yaml_ng::Value as YamlValue;
 /// - Plain text content
 /// - Tables as structured data
 /// - Document structure (headings, links, code blocks)
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 pub struct DjotExtractor;
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 impl DjotExtractor {
     /// Create a new Djot extractor.
     pub fn new() -> Self {
@@ -291,14 +291,14 @@ impl DjotExtractor {
     }
 }
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 impl Default for DjotExtractor {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 impl Plugin for DjotExtractor {
     fn name(&self) -> &str {
         "djot-extractor"
@@ -325,7 +325,7 @@ impl Plugin for DjotExtractor {
     }
 }
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 #[async_trait]
 impl DocumentExtractor for DjotExtractor {
     #[cfg_attr(feature = "otel", tracing::instrument(
@@ -388,7 +388,7 @@ impl DocumentExtractor for DjotExtractor {
     }
 }
 
-#[cfg(all(test, feature = "office"))]
+#[cfg(all(test, feature = "djot"))]
 mod tests {
     use super::*;
 

--- a/crates/kreuzberg/src/extractors/mod.rs
+++ b/crates/kreuzberg/src/extractors/mod.rs
@@ -94,7 +94,7 @@ pub mod epub;
 #[cfg(feature = "office")]
 pub mod fictionbook;
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 pub mod djot;
 
 #[cfg(feature = "office")]
@@ -169,7 +169,7 @@ pub use epub::EpubExtractor;
 #[cfg(feature = "office")]
 pub use fictionbook::FictionBookExtractor;
 
-#[cfg(feature = "office")]
+#[cfg(feature = "djot")]
 pub use djot::DjotExtractor;
 
 #[cfg(feature = "office")]
@@ -287,9 +287,11 @@ pub fn register_default_extractors() -> Result<()> {
     #[cfg(feature = "excel")]
     registry.register(Arc::new(ExcelExtractor::new()))?;
 
+    #[cfg(feature = "djot")]
+    registry.register(Arc::new(DjotExtractor::new()))?;
+
     #[cfg(feature = "office")]
     {
-        registry.register(Arc::new(DjotExtractor::new()))?;
         registry.register(Arc::new(EnhancedMarkdownExtractor::new()))?;
         registry.register(Arc::new(BibtexExtractor::new()))?;
         registry.register(Arc::new(EpubExtractor::new()))?;
@@ -377,10 +379,15 @@ mod tests {
             assert!(extractor_names.contains(&"excel-extractor".to_string()));
         }
 
+        #[cfg(feature = "djot")]
+        {
+            expected_count += 1;
+            assert!(extractor_names.contains(&"djot-extractor".to_string()));
+        }
+
         #[cfg(feature = "office")]
         {
-            expected_count += 11;
-            assert!(extractor_names.contains(&"djot-extractor".to_string()));
+            expected_count += 10;
             assert!(extractor_names.contains(&"markdown-extractor".to_string()));
             assert!(extractor_names.contains(&"bibtex-extractor".to_string()));
             assert!(extractor_names.contains(&"epub-extractor".to_string()));


### PR DESCRIPTION
## Summary

- Add new `DjotExtractor` for parsing Djot markup documents
- Uses the `jotdown` crate (pull-parser similar to `pulldown-cmark`)
- Supports YAML frontmatter metadata extraction
- Supports table extraction as structured data
- Registered under the `office` feature flag

## Implementation Details

Djot is a modern markup language designed by John MacFarlane (creator of Pandoc and CommonMark). It has simpler parsing rules than CommonMark while supporting similar features.

The implementation follows the same pattern as the existing `MarkdownExtractor`:
- YAML frontmatter parsing for metadata (title, author, date, keywords, etc.)
- Event-based text extraction from the AST
- Table extraction with markdown output format
- Title extraction from first heading if not in frontmatter

MIME types: `text/djot`, `text/x-djot`

## Test plan

- [ ] Unit tests included in the PR
- [ ] `cargo test -p kreuzberg --features office` passes
- [ ] Manual testing with sample `.djot` files

Closes #262