### PR TITLE
feat(docs): add unified Google Analytics and Google Ads tag

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,6 +1,16 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-8G4NQW55PF"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-8G4NQW55PF');
+    gtag('config', 'AW-17853694443');
+  </script>
+
   <meta property="og:type" content="website" />
   <meta property="og:title" content="{{ config.site_name }}{% if page and page.title and not page.is_homepage %} - {{ page.title | striptags }}{% endif %}" />
   <meta property="og:description" content="{% if page and page.meta and page.meta.description %}{{ page.meta.description }}{% else %}{{ config.site_description }}{% endif %}" />

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -152,9 +152,6 @@ extra:
     provider: mike
     default: latest
     alias: true
-  analytics:
-    provider: google
-    property: !ENV [GOOGLE_ANALYTICS_KEY, ""]
   status:
     new: Recently added
     deprecated: Deprecated


### PR DESCRIPTION
## Situation

Google Analytics 4 and Google Ads have been linked at the account level. The documentation site needed a unified tracking implementation that supports both GA4 and Google Ads conversion tracking without double-loading the gtag.js script.

## Task

Install a single unified Google tag on the documentation site that enables both GA4 analytics and Google Ads tracking to work correctly together.

## Action

- Added unified Google tag script to `docs/overrides/main.html` in the `extrahead` block
- Configured both GA4 and Google Ads tracking within a single gtag.js load
- Removed the previous Material for MkDocs analytics configuration from `mkdocs.yaml` to prevent duplicate script loading

## Result

The documentation site now has unified tracking for both Google Analytics 4 and Google Ads, loaded efficiently with a single gtag.js script on every page.

## Acceptance Criteria

- [ ] Google tag script loads on all documentation pages
- [ ] GA4 tracking is functional
- [ ] Google Ads conversion tracking is functional
- [ ] No duplicate gtag.js loading

---
🤖 Generated with [Claude Code](https://claude.ai/code)