### PR TITLE
docs(csharp): update NuGet package name

### DIFF
--- a/packages/csharp/README.md
+++ b/packages/csharp/README.md
@@ -65,13 +65,13 @@ Extract text, tables, images, and metadata from 56 file formats including PDF, O
 Install via NuGet:
 
 ```bash
-dotnet add package Goldziher.Kreuzberg
+dotnet add package Kreuzberg
 ```
 
 Or via NuGet Package Manager:
 
 ```
-Install-Package Goldziher.Kreuzberg
+Install-Package Kreuzberg
 ```
 
 


### PR DESCRIPTION
It seems that the package name in NuGet was changed at some point of time, but README was not updated, resulting in error `There are no stable versions available, 4.0.0-rc.6 is the best available`.