### PR TITLE
fix(csharp): add XML file generation to csproj

### DIFF
--- a/packages/csharp/Kreuzberg/Kreuzberg.csproj
+++ b/packages/csharp/Kreuzberg/Kreuzberg.csproj
@@ -18,6 +18,7 @@
     <PackageTags>kreuzberg;document;extraction;rust;ffi;pdf;ocr;office;docx;excel;document-processing;document-intelligence;text-extraction;metadata;parsing;tesseract;dotnet;netcore</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>Version 4.0.0: Stable release of C# bindings with .NET 9+ FFM API support, comprehensive documentation, and full test suite (268+ tests).</PackageReleaseNotes>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The XML documentation is there in C# code, but the documentation XML file was not generated and included in the final NuGet package, resulting in no documentation visible in the IDE.