### PR TITLE
fix(elixir): align Chunk field from text to content for API parity

### DIFF
--- a/docs/reference/api-elixir.md
+++ b/docs/reference/api-elixir.md
@@ -1581,10 +1581,10 @@ if result.chunks do
   result.chunks
   |> Stream.each(fn chunk ->
     # Process each chunk
-    text = chunk["text"]
+    content = chunk["content"]
     metadata = chunk["metadata"]
 
-    IO.puts("Chunk: #{String.length(text)} chars")
+    IO.puts("Chunk: #{String.length(content)} chars")
     IO.puts("Byte range: #{metadata["byte_start"]}-#{metadata["byte_end"]}")
   end)
   |> Stream.run()

--- a/docs/snippets/elixir/advanced/10_chunking_config.exs
+++ b/docs/snippets/elixir/advanced/10_chunking_config.exs
@@ -26,8 +26,8 @@ IO.puts("Total chunks: #{length(chunks)}")
 
 Enum.each(chunks, fn chunk ->
   IO.inspect(%{
-    text_length: String.length(chunk["text"]),
+    text_length: String.length(chunk["content"]),
     page: chunk["page"],
-    boundaries_respected: !String.ends_with?(chunk["text"], [" ", "\n"])
+    boundaries_respected: !String.ends_with?(chunk["content"], [" ", "\n"])
   })
 end)

--- a/docs/snippets/elixir/advanced/9_vector_database_integration.exs
+++ b/docs/snippets/elixir/advanced/9_vector_database_integration.exs
@@ -19,10 +19,10 @@ config = %ExtractionConfig{
 # Prepare chunks for vector database ingestion
 documents = Enum.map(result.chunks || [], fn chunk ->
   %{
-    text: chunk["text"],
+    content: chunk["content"],
     metadata: %{
       page: chunk["page"],
-      char_count: String.length(chunk["text"])
+      char_count: String.length(chunk["content"])
     }
   }
 end)

--- a/docs/snippets/elixir/advanced/chunking_rag.exs
+++ b/docs/snippets/elixir/advanced/chunking_rag.exs
@@ -15,7 +15,7 @@ chunks_for_embedding = result.chunks
   |> Enum.map(fn chunk ->
     %{
       "id" => chunk["id"],
-      "text" => chunk["text"],
+      "content" => chunk["content"],
       "metadata" => %{
         "page" => chunk["page"],
         "source" => "document.pdf"

--- a/docs/snippets/elixir/advanced/embedding_with_chunking.exs
+++ b/docs/snippets/elixir/advanced/embedding_with_chunking.exs
@@ -12,7 +12,7 @@ embedded_chunks = result.chunks
   |> Enum.map(fn {chunk, idx} ->
     %{
       "chunk_id" => idx,
-      "text" => chunk["text"],
+      "content" => chunk["content"],
       "embedding" => chunk["embedding"],
       "page" => chunk["page"],
       "metadata" => %{

--- a/docs/snippets/elixir/configuration/chunking_config.exs
+++ b/docs/snippets/elixir/configuration/chunking_config.exs
@@ -19,7 +19,7 @@ if result.chunks do
   IO.puts("Generated #{length(result.chunks)} chunks")
 
   Enum.each(result.chunks, fn chunk ->
-    IO.puts("Chunk: #{String.slice(chunk["text"], 0..50)}...")
+    IO.puts("Chunk: #{String.slice(chunk["content"], 0..50)}...")
   end)
 end
 ```

--- a/docs/snippets/elixir/utils/chunking.exs
+++ b/docs/snippets/elixir/utils/chunking.exs
@@ -42,8 +42,8 @@ defmodule ChunkingUtils do
           last_size = chunk_text_length(last)
 
           if last_size < threshold do
-            merged_text = "#{last["text"]} #{chunk["text"]}"
-            merged_chunk = Map.put(chunk, "text", merged_text)
+            merged_text = "#{last["content"]} #{chunk["content"]}"
+            merged_chunk = Map.put(chunk, "content", merged_text)
             [merged_chunk | rest]
           else
             [chunk, last | rest]
@@ -66,7 +66,7 @@ defmodule ChunkingUtils do
   # Private helper
   defp chunk_text_length(chunk) do
     chunk
-    |> Map.get("text", "")
+    |> Map.get("content", "")
     |> String.length()
   end
 end

--- a/packages/elixir/test/unit/extraction_result_test.exs
+++ b/packages/elixir/test/unit/extraction_result_test.exs
@@ -182,17 +182,17 @@ defmodule KreuzbergTest.Unit.ExtractionResultTest do
 
     test "adds chunks from options" do
       chunks = [
-        %{"text" => "chunk1", "embedding" => [0.1, 0.2]},
-        %{"text" => "chunk2", "embedding" => [0.3, 0.4]}
+        %{"content" => "chunk1", "embedding" => [0.1, 0.2]},
+        %{"content" => "chunk2", "embedding" => [0.3, 0.4]}
       ]
 
       opts = [chunks: chunks]
       result = ExtractionResult.new("content", "text/plain", %{}, [], opts)
 
       assert length(result.chunks) == 2
-      assert Enum.at(result.chunks, 0).text == "chunk1"
+      assert Enum.at(result.chunks, 0).content == "chunk1"
       assert Enum.at(result.chunks, 0).embedding == [0.1, 0.2]
-      assert Enum.at(result.chunks, 1).text == "chunk2"
+      assert Enum.at(result.chunks, 1).content == "chunk2"
       assert Enum.at(result.chunks, 1).embedding == [0.3, 0.4]
     end
 
@@ -229,7 +229,7 @@ defmodule KreuzbergTest.Unit.ExtractionResultTest do
     test "combines all options together" do
       metadata = %{"title" => "Test"}
       tables = [%{"headers" => ["A"]}]
-      chunks = [%{"text" => "chunk"}]
+      chunks = [%{"content" => "chunk"}]
       images = [%{"path" => "image.png"}]
       pages = [%{"number" => 1}]
       languages = ["en", "de"]
@@ -250,7 +250,7 @@ defmodule KreuzbergTest.Unit.ExtractionResultTest do
       assert Enum.at(result.tables, 0).headers == ["A"]
       assert result.detected_languages == languages
       assert length(result.chunks) == 1
-      assert Enum.at(result.chunks, 0).text == "chunk"
+      assert Enum.at(result.chunks, 0).content == "chunk"
       assert length(result.images) == 1
       assert length(result.pages) == 1
       assert Enum.at(result.pages, 0).number == 1

--- a/packages/elixir/test/unit/struct_refactoring_test.exs
+++ b/packages/elixir/test/unit/struct_refactoring_test.exs
@@ -99,7 +99,7 @@ defmodule KreuzbergTest.Unit.StructRefactoringTest do
     test "creates chunk struct with new/2" do
       chunk = Kreuzberg.Chunk.new("chunk text", embedding: [0.1, 0.2], metadata: %{"page" => 1})
 
-      assert chunk.text == "chunk text"
+      assert chunk.content == "chunk text"
       assert chunk.embedding == [0.1, 0.2]
       assert chunk.metadata == %{"page" => 1}
       assert is_struct(chunk, Kreuzberg.Chunk)
@@ -107,27 +107,27 @@ defmodule KreuzbergTest.Unit.StructRefactoringTest do
 
     test "creates chunk from map" do
       map = %{
-        "text" => "content",
+        "content" => "content",
         "embedding" => [0.3, 0.4, 0.5],
         "token_count" => 15
       }
 
       chunk = Kreuzberg.Chunk.from_map(map)
 
-      assert chunk.text == "content"
+      assert chunk.content == "content"
       assert chunk.embedding == [0.3, 0.4, 0.5]
       assert chunk.token_count == 15
     end
 
     test "converts chunk to map" do
       chunk = %Kreuzberg.Chunk{
-        text: "text",
+        content: "text",
         embedding: [0.1, 0.2]
       }
 
       map = Kreuzberg.Chunk.to_map(chunk)
 
-      assert map["text"] == "text"
+      assert map["content"] == "text"
       assert map["embedding"] == [0.1, 0.2]
     end
   end
@@ -289,7 +289,7 @@ defmodule KreuzbergTest.Unit.StructRefactoringTest do
     end
 
     test "normalizes chunks to structs" do
-      chunk_map = %{"text" => "chunk", "embedding" => [0.1, 0.2]}
+      chunk_map = %{"content" => "chunk", "embedding" => [0.1, 0.2]}
 
       result =
         Kreuzberg.ExtractionResult.new(
@@ -303,7 +303,7 @@ defmodule KreuzbergTest.Unit.StructRefactoringTest do
       assert result.chunks != nil
       chunk = Enum.at(result.chunks, 0)
       assert is_struct(chunk, Kreuzberg.Chunk)
-      assert chunk.text == "chunk"
+      assert chunk.content == "chunk"
     end
 
     test "normalizes images to structs" do
@@ -407,7 +407,7 @@ defmodule KreuzbergTest.Unit.StructRefactoringTest do
         metadata: %Kreuzberg.Metadata{},
         tables: [],
         detected_languages: ["en"],
-        chunks: [%Kreuzberg.Chunk{text: "chunk"}],
+        chunks: [%Kreuzberg.Chunk{content: "chunk"}],
         images: [%Kreuzberg.Image{format: "png"}],
         pages: [%Kreuzberg.Page{number: 1, content: "page"}]
       }


### PR DESCRIPTION
  Rename the Chunk struct field from `text` to `content` to achieve 1:1 API
  parity with the Rust core and all other language bindings (Go, Python,
  TypeScript, etc.).

  Changes:
  - Renamed Chunk struct field from `:text` to `:content`
  - Updated `Chunk.from_map/1` to accept both "content" (from Rust FFI) and "text" (for backward compatibility), preferring "content"
  - Updated `Chunk.to_map/1` to output "content" field for cross-package consistency
  - Updated all documentation, code examples, and snippets to use "content"
  - Updated all tests to use "content" and added comprehensive FFI compatibility tests

  Backward Compatibility:
  The `from_map/1` function now supports both field names during the
  migration period, with "content" taking precedence when both are present.
  This ensures existing code using "text" continues to work while new code
  from Rust FFI using "content" is properly mapped.

Fixes #334