### PR TITLE
fix markdown list rendering

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -421,6 +421,7 @@ Access format-specific metadata from extracted documents:
     ```
 
 Kreuzberg extracts format-specific metadata for:
+
 - **PDF**: page count, title, author, subject, keywords, dates
 - **HTML**: Rich metadata including SEO tags, Open Graph, Twitter Card, structured data, headers, links, images
 - **Excel**: sheet count, sheet names


### PR DESCRIPTION
currently web page https://docs.kreuzberg.dev/getting-started/quickstart/#working-with-metadata looks like this 
```
Kreuzberg extracts format-specific metadata for: - PDF: page count, title, author, subject, keywords, dates - HTML: Rich metadata including SEO tags, Open Graph, Twitter Card, structured data, headers, links, images - Excel: sheet count, sheet names - Email: from, to, CC, BCC, message ID, attachments - PowerPoint: title, author, description, fonts - Images: dimensions, format, EXIF data - Archives: format, file count, file list, sizes - XML: element count, unique elements - Text/Markdown: word count, line count, headers, links
```