### PR TITLE
fix: enable musl CLI build with cross-compiler toolchain

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -813,7 +813,9 @@ jobs:
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             use_cross: false
-          # TODO: Re-enable x86_64-unknown-linux-musl once build issues are resolved
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use_cross: false
           - os: macos-latest
             target: aarch64-apple-darwin
             use_cross: false

--- a/crates/kreuzberg-tesseract/build.rs
+++ b/crates/kreuzberg-tesseract/build.rs
@@ -447,14 +447,21 @@ mod build_tesseract {
         let target_windows = is_windows_target(&target);
         let target_msvc = is_msvc_target(&target);
         let target_mingw = is_mingw_target(&target);
-        let target_musl = target.contains("musl");
 
         if target_macos {
             cmake_cxx_flags.push_str("-stdlib=libc++ ");
             cmake_cxx_flags.push_str("-std=c++17 ");
         } else if target_linux {
             cmake_cxx_flags.push_str("-std=c++17 ");
-            if target_musl || env::var("CC").map(|cc| cc.contains("clang")).unwrap_or(false) {
+            // Determine whether to use clang/libc++ or g++/libstdc++.
+            // Use clang only if CXX or CC explicitly contains "clang".
+            // Default to g++ (works in Alpine, musl.cc cross-compilers, and glibc).
+            let use_clang = env::var("CXX")
+                .map(|cxx| cxx.contains("clang"))
+                .or_else(|_| env::var("CC").map(|cc| cc.contains("clang")))
+                .unwrap_or(false);
+
+            if use_clang {
                 cmake_cxx_flags.push_str("-stdlib=libc++ ");
                 let cxx_compiler = env::var("CXX").unwrap_or_else(|_| {
                     if let Ok(target) = env::var("TARGET") {
@@ -550,11 +557,19 @@ mod build_tesseract {
         if target_macos {
             println!("cargo:rustc-link-lib=c++");
         } else if target_linux {
-            if target_musl || env::var("CC").map(|cc| cc.contains("clang")).unwrap_or(false) {
+            let use_clang = env::var("CXX")
+                .map(|cxx| cxx.contains("clang"))
+                .or_else(|_| env::var("CC").map(|cc| cc.contains("clang")))
+                .unwrap_or(false);
+
+            if use_clang {
                 println!("cargo:rustc-link-lib=c++");
             } else {
                 println!("cargo:rustc-link-lib=stdc++");
-                println!("cargo:rustc-link-lib=stdc++fs");
+                if !target_musl {
+                    // stdc++fs merged into libstdc++ in GCC 9+; musl cross-compilers may not ship it
+                    println!("cargo:rustc-link-lib=stdc++fs");
+                }
             }
             println!("cargo:rustc-link-lib=pthread");
             println!("cargo:rustc-link-lib=m");

--- a/crates/kreuzberg/build.rs
+++ b/crates/kreuzberg/build.rs
@@ -772,8 +772,14 @@ fn link_system_frameworks(target: &str) {
         println!("cargo:rustc-link-lib=framework=AppKit");
         println!("cargo:rustc-link-lib=dylib=c++");
     } else if target.contains("linux") {
-        println!("cargo:rustc-link-lib=dylib=stdc++");
-        println!("cargo:rustc-link-lib=dylib=m");
+        if target.contains("musl") {
+            // musl targets produce fully static binaries — avoid dylib= prefix
+            println!("cargo:rustc-link-lib=stdc++");
+            println!("cargo:rustc-link-lib=m");
+        } else {
+            println!("cargo:rustc-link-lib=dylib=stdc++");
+            println!("cargo:rustc-link-lib=dylib=m");
+        }
     } else if target.contains("windows") {
         println!("cargo:rustc-link-lib=dylib=gdi32");
         println!("cargo:rustc-link-lib=dylib=user32");

--- a/scripts/publish/cli/install-build-deps.sh
+++ b/scripts/publish/cli/install-build-deps.sh
@@ -9,5 +9,15 @@ case "$target" in
 aarch64-unknown-linux-gnu)
   sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
   ;;
+x86_64-unknown-linux-musl)
+  # Download musl cross-compiler toolchain with C++ support (includes musl-native libstdc++)
+  curl -fsSL https://musl.cc/x86_64-linux-musl-cross.tgz | sudo tar xz -C /opt/
+  echo "/opt/x86_64-linux-musl-cross/bin" >> "$GITHUB_PATH"
+  # Set C/C++ compilers for cmake builds (kreuzberg-tesseract)
+  echo "CC=x86_64-linux-musl-gcc" >> "$GITHUB_ENV"
+  echo "CXX=x86_64-linux-musl-g++" >> "$GITHUB_ENV"
+  # Set Rust linker for musl target
+  echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=x86_64-linux-musl-gcc" >> "$GITHUB_ENV"
+  ;;
 *) ;;
 esac


### PR DESCRIPTION
Closes #184.

- Install [musl.cc](https://musl.cc) cross-compiler in CI (provides musl-native g++/libstdc++)
- Fix build.rs compiler detection: use clang only when explicitly set via CXX/CC env vars, default to g++ (works in Alpine and with musl.cc)
- Fix link flags: drop `dylib=` prefix for musl (static binaries), skip `stdc++fs` (merged into libstdc++ in GCC 9+)
- Re-enable `x86_64-unknown-linux-musl` in publish workflow

## Test plan
- [x] Verified build succeeds in Alpine Docker container (`rust:alpine`)
- [x] Produced binary is statically linked (`static-pie linked, stripped`)
- [ ] CI dry-run on fork (publish workflow needs matching version tag to pass validation)
- [ ] Runtime test on staging server