### PR TITLE
doc: Fix features page example for KeywordConfig

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -253,7 +253,7 @@ Extract keywords and key phrases from documents.
 ```python title="keyword_extraction_config.py"
 # Configure keyword extraction using YAKE algorithm
 KeywordConfig(
-    algorithm="yake",
+    algorithm=KeywordAlgorithm.Yake,
     max_keywords=10,
     ngram_range=(1,3)
 )


### PR DESCRIPTION
Updates incorrect API example for `KeywordConfig` to use correct class name and ngram_range argument