### PR TITLE
docs: fix migration guide regressions and polish python demos

### DIFF
--- a/docs/migration/v3-to-v4.md
+++ b/docs/migration/v3-to-v4.md
@@ -273,7 +273,7 @@ kreuzberg = "4.0"
 from kreuzberg import extract_file, ExtractionConfig
 
 # v4 imports (same public API, internal structure changed)
-from kreuzberg import extract_file, ExtractionConfig
+from kreuzberg import extract_file_sync, ExtractionConfig
 ```
 
 #### Configuration Changes
@@ -309,16 +309,16 @@ from kreuzberg import batch_extract
 results = batch_extract(["file1.pdf", "file2.pdf"])
 
 # v4 batch extraction (renamed function)
-from kreuzberg import batch_extract_files
+from kreuzberg import batch_extract_files_sync
 
-results = batch_extract_files(["file1.pdf", "file2.pdf"])
+results = batch_extract_files_sync(["file1.pdf", "file2.pdf"])
 ```
 
 #### Error Handling
 
 ```python title="Python"
 # v3 error handling (single exception type)
-from kreuzberg import KreuzbergException
+from kreuzberg import extract_file, KreuzbergException
 
 try:
     result = extract_file("doc.pdf")
@@ -326,10 +326,10 @@ except KreuzbergException as e:
     print(f"Error: {e}")
 
 # v4 error handling (typed exception hierarchy)
-from kreuzberg import KreuzbergError, ParsingError, ValidationError
+from kreuzberg import extract_file_sync, KreuzbergError, ParsingError, ValidationError
 
 try:
-    result = extract_file("doc.pdf")
+    result = extract_file_sync("doc.pdf")
 except ParsingError as e:
     print(f"Parsing error: {e}")
 except ValidationError as e:
@@ -432,7 +432,7 @@ if "pdf" in result.metadata:
     pages = result.metadata["pdf"]["page_count"]
 
 # v4 metadata access (typed attributes)
-result = extract_file("doc.pdf")
+result = extract_file_sync("doc.pdf")
 if result.metadata.pdf:
     pages = result.metadata.pdf.page_count
 ```
@@ -570,7 +570,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 print(result.detected_languages)
 ```
 
@@ -591,7 +591,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("doc.pdf", config=config)
+result = extract_file_sync("doc.pdf", config=config)
 for chunk in result.chunks:
     print(f"Chunk: {len(chunk)} chars")
 ```
@@ -611,7 +611,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("encrypted.pdf", config=config)
+result = extract_file_sync("encrypted.pdf", config=config)
 ```
 
 ### Token Reduction
@@ -629,7 +629,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 ```
 
 ### Extract from Bytes
@@ -658,7 +658,7 @@ result = extract_bytes_sync(data, None)
 result = extract_file("doc.pdf")
 
 # v4 structured table extraction
-result = extract_file("doc.pdf")
+result = extract_file_sync("doc.pdf")
 for table in result.tables:
     print(table.markdown)
     print(table.cells)
@@ -702,13 +702,13 @@ v4 provides native APIs for:
 
 ```python title="Python"
 # v4 automatic config discovery
-result = extract_file("doc.pdf")
+result = extract_file_sync("doc.pdf")
 
 # v4 manual config loading
-from kreuzberg import load_config
+from kreuzberg import load_config, extract_file_sync
 
 config = load_config("custom-config.toml")
-result = extract_file("doc.pdf", config=config)
+result = extract_file_sync("doc.pdf", config=config)
 ```
 
 ### Image Extraction
@@ -729,7 +729,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 ```
 
 ### API Server
@@ -1051,7 +1051,7 @@ for chunk in result.chunks:
 **After (v4):**
 
 ```python title="Python"
-from kreuzberg import extract_file, ExtractionConfig, PageConfig
+from kreuzberg import extract_file_sync, ExtractionConfig, PageConfig
 
 config = ExtractionConfig(
     pages=PageConfig(
@@ -1061,7 +1061,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 
 # Access byte-based offsets and page tracking
 for chunk in result.chunks:
@@ -1388,11 +1388,11 @@ KreuzbergError (base)
 
 ### Function Names
 
-| v3                | v4                       |
-| ----------------- | ------------------------ |
-| `batch_extract()` | `batch_extract_files()`  |
-| `extract_bytes()` | `extract_bytes()` (same) |
-| `extract_file()`  | `extract_file()` (same)  |
+| v3                | v4                            |
+| ----------------- | ----------------------------- |
+| `batch_extract()` | `batch_extract_files_sync()`  |
+| `extract_bytes()` | `extract_bytes_sync()` (same) |
+| `extract_file()`  | `extract_file_sync()` (same)  |
 
 ### Removed Features
 
@@ -1407,7 +1407,7 @@ config = ExtractionConfig(
         tesseract_config=TesseractConfig(enable_table_detection=True)
     )
 )
-result = extract_file("doc.pdf", config=config)
+result = extract_file_sync("doc.pdf", config=config)
 ```
 
 #### Entity Extraction, Keyword Extraction, Document Classification
@@ -1507,9 +1507,9 @@ print(result["content"])
 print(result["metadata"])
 
 # v4 basic extraction
-from kreuzberg import extract_file
+from kreuzberg import extract_file_sync
 
-result = extract_file("document.pdf")
+result = extract_file_sync("document.pdf")
 print(result.content)
 print(result.metadata)
 ```
@@ -1528,7 +1528,7 @@ config = ExtractionConfig(
 result = extract_file("scanned.pdf", config=config)
 
 # v4 OCR extraction
-from kreuzberg import extract_file, ExtractionConfig, OcrConfig
+from kreuzberg import extract_file_sync, ExtractionConfig, OcrConfig
 
 config = ExtractionConfig(
     ocr=OcrConfig(
@@ -1537,7 +1537,7 @@ config = ExtractionConfig(
     ),
 )
 
-result = extract_file("scanned.pdf", config=config)
+result = extract_file_sync("scanned.pdf", config=config)
 ```
 
 ### Batch Processing
@@ -1551,9 +1551,9 @@ for result in results:
     print(result["content"])
 
 # v4 batch processing
-from kreuzberg import batch_extract_files
+from kreuzberg import batch_extract_files_sync
 
-results = batch_extract_files(["doc1.pdf", "doc2.pdf", "doc3.pdf"])
+results = batch_extract_files_sync(["doc1.pdf", "doc2.pdf", "doc3.pdf"])
 for result in results:
     print(result.content)
 ```
@@ -1570,10 +1570,10 @@ except KreuzbergException as e:
     print(f"Error: {e}")
 
 # v4 error handling
-from kreuzberg import extract_file, KreuzbergError, ParsingError
+from kreuzberg import extract_file_sync, KreuzbergError, ParsingError
 
 try:
-    result = extract_file("doc.pdf")
+    result = extract_file_sync("doc.pdf")
 except ParsingError as e:
     print(f"Parsing error: {e}")
 except KreuzbergError as e:
@@ -1586,10 +1586,10 @@ except KreuzbergError as e:
 
 ```python title="Python"
 import pytest
-from kreuzberg import extract_file, ExtractionConfig
+from kreuzberg import extract_file_sync, ExtractionConfig
 
 def test_basic_extraction():
-    result = extract_file("tests/fixtures/sample.pdf")
+    result = extract_file_sync("tests/fixtures/sample.pdf")
     assert result.content
     assert result.mime_type == "application/pdf"
 
@@ -1600,40 +1600,40 @@ def test_ocr_extraction():
         ocr=OcrConfig(backend="tesseract", language="eng"),
     )
 
-    result = extract_file("tests/fixtures/scanned.pdf", config=config)
+    result = extract_file_sync("tests/fixtures/scanned.pdf", config=config)
     assert result.content
     assert result.metadata.ocr
 
 def test_batch_processing():
-    from kreuzberg import batch_extract_files
+    from kreuzberg import batch_extract_files_sync
 
     files = ["tests/fixtures/doc1.pdf", "tests/fixtures/doc2.pdf"]
-    results = batch_extract_files(files)
+    results = batch_extract_files_sync(files)
 
     assert len(results) == 2
     for result in results:
         assert result.content
 
 def test_error_handling():
-    from kreuzberg import ParsingError
+    from kreuzberg import ParsingError, extract_file_sync
 
     with pytest.raises(ParsingError):
-        extract_file("tests/fixtures/corrupted.pdf")
+        extract_file_sync("tests/fixtures/corrupted.pdf")
 ```
 
 ### Performance Testing
 
 ```python title="Python"
 import time
-from kreuzberg import extract_file, batch_extract_files
+from kreuzberg import extract_file_sync, batch_extract_files_sync
 
 start = time.time()
-result = extract_file("large_document.pdf")
+result = extract_file_sync("large_document.pdf")
 print(f"Single file: {time.time() - start:.2f}s")
 
 files = [f"document{i}.pdf" for i in range(100)]
 start = time.time()
-results = batch_extract_files(files)
+results = batch_extract_files_sync(files)
 print(f"Batch (100 files): {time.time() - start:.2f}s")
 ```
 
@@ -1689,7 +1689,7 @@ Hierarchy blocks are available through the `page.hierarchy.blocks` structure whe
 #### Python
 
 ```python title="Python"
-from kreuzberg import extract_file, ExtractionConfig, PageConfig, PdfConfig, HierarchyDetectionConfig
+from kreuzberg import extract_file_sync, ExtractionConfig, PageConfig, PdfConfig, HierarchyDetectionConfig
 
 config = ExtractionConfig(
     pages=PageConfig(extract_pages=True),
@@ -1698,7 +1698,7 @@ config = ExtractionConfig(
     )
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 
 # Access hierarchy blocks for each page
 for page in result.pages:
@@ -1783,7 +1783,7 @@ class HierarchyBlock:
 Hierarchy detection can be disabled globally or per-extraction:
 
 ```python title="Python"
-from kreuzberg import ExtractionConfig, PageConfig, PdfConfig, HierarchyDetectionConfig
+from kreuzberg import extract_file_sync, ExtractionConfig, PageConfig, PdfConfig, HierarchyDetectionConfig
 
 # Option 1: Disable in configuration
 config = ExtractionConfig(
@@ -1793,7 +1793,7 @@ config = ExtractionConfig(
     )
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 
 # Option 2: Disable via TOML configuration file
 # kreuzberg.toml
@@ -1835,7 +1835,7 @@ config = HierarchyConfig(
 #### 1. Building Hierarchical RAG Systems
 
 ```python title="Python"
-from kreuzberg import extract_file, ExtractionConfig, PageConfig, PdfConfig, HierarchyDetectionConfig, ChunkingConfig
+from kreuzberg import extract_file_sync, ExtractionConfig, PageConfig, PdfConfig, HierarchyDetectionConfig, ChunkingConfig
 
 config = ExtractionConfig(
     pages=PageConfig(extract_pages=True),
@@ -1845,7 +1845,7 @@ config = ExtractionConfig(
     chunking=ChunkingConfig(max_characters=1000)
 )
 
-result = extract_file("document.pdf", config=config)
+result = extract_file_sync("document.pdf", config=config)
 
 # Build hierarchical knowledge base
 knowledge_base = []

--- a/examples/python/basic.py
+++ b/examples/python/basic.py
@@ -7,31 +7,42 @@ from kreuzberg import ExtractionConfig, extract_file, extract_file_sync
 
 
 def main() -> None:
+    # Simple synchronous extraction
     result = extract_file_sync("document.pdf")
+    print(f"Extracted {len(result.content)} characters")
+    print(f"Content preview: {result.content[:200]}...")
 
+    # Extraction with configuration
     config = ExtractionConfig(
         enable_quality_processing=True,
         use_cache=True,
     )
     result = extract_file_sync("document.pdf", config=config)
+    print(f"With quality processing: {len(result.content)} characters")
 
+    # Async extraction
     import asyncio
 
     async def async_extract():
         return await extract_file("document.pdf")
 
-    asyncio.run(async_extract())
+    result = asyncio.run(async_extract())
+    print(f"Async result: {len(result.content)} characters")
 
+    # Extraction from bytes
     from kreuzberg import extract_bytes_sync
 
     with open("document.pdf", "rb") as f:
         data = f.read()
 
     result = extract_bytes_sync(data, mime_type="application/pdf")
+    print(f"From bytes: {len(result.content)} characters")
 
+    # Accessing typed metadata
     result = extract_file_sync("document.pdf")
     if result.metadata.pdf:
-        pass
+        print(f"Page count: {result.metadata.pdf.page_count}")
+        print(f"Title: {result.metadata.title}")
 
 
 if __name__ == "__main__":

--- a/examples/python/batch.py
+++ b/examples/python/batch.py
@@ -4,13 +4,13 @@ Demonstrates efficient batch processing of multiple documents.
 """
 
 import asyncio
-import contextlib
 from pathlib import Path
 
 from kreuzberg import ExtractionConfig, batch_extract_files, batch_extract_files_sync
 
 
 def main() -> None:
+    # Basic batch extraction
     files = [
         "document1.pdf",
         "document2.docx",
@@ -20,19 +20,22 @@ def main() -> None:
 
     results = batch_extract_files_sync(files)
 
-    for file, _result in zip(files, results, strict=False):
-        pass
+    for file, result in zip(files, results, strict=False):
+        print(f"{file}: {len(result.content)} chars, format={result.metadata.mime_type}")
 
+    # Async batch extraction
     async def process_batch():
         files = [f"doc{i}.pdf" for i in range(10)]
         results = await batch_extract_files(files)
 
-        sum(len(r.content) for r in results)
+        total_chars = sum(len(r.content) for r in results)
+        print(f"Batch total: {total_chars} characters across {len(results)} files")
 
         return results
 
     asyncio.run(process_batch())
 
+    # Batch with configuration
     config = ExtractionConfig(
         enable_quality_processing=True,
         use_cache=True,
@@ -40,16 +43,19 @@ def main() -> None:
     )
 
     results = batch_extract_files_sync(files, config=config)
+    print(f"Configured batch: {len(results)} results")
 
+    # Batch from glob pattern
     from glob import glob
 
     pdf_files = glob("data/*.pdf")
     if pdf_files:
         results = batch_extract_files_sync(pdf_files[:5])
 
-        for file, _result in zip(pdf_files[:5], results, strict=False):
-            pass
+        for file, result in zip(pdf_files[:5], results, strict=False):
+            print(f"{Path(file).name}: {len(result.content)} chars")
 
+    # Batch extraction from bytes
     from kreuzberg import batch_extract_bytes_sync
 
     data_list = []
@@ -69,19 +75,21 @@ def main() -> None:
         mime_types.append(mime_map.get(ext, "application/octet-stream"))
 
     results = batch_extract_bytes_sync(data_list, mime_types)
+    print(f"Bytes batch: {len(results)} results")
 
+    # Error handling with individual file processing
     files_with_invalid = [
         "valid1.pdf",
         "nonexistent.pdf",
         "valid2.txt",
     ]
 
-    with contextlib.suppress(Exception):
-        results = batch_extract_files_sync(files_with_invalid)
-
     for file in files_with_invalid:
-        with contextlib.suppress(Exception):
-            batch_extract_files_sync([file])[0]
+        try:
+            result = batch_extract_files_sync([file])[0]
+            print(f"{file}: OK ({len(result.content)} chars)")
+        except Exception as e:
+            print(f"{file}: FAILED ({type(e).__name__}: {e})")
 
 
 if __name__ == "__main__":

--- a/examples/python/custom_ocr.py
+++ b/examples/python/custom_ocr.py
@@ -87,8 +87,10 @@ def main() -> None:
         )
     )
 
-    extract_file_sync("scanned_document.pdf", config=config)
+    result = extract_file_sync("scanned_document.pdf", config=config)
+    print(f"Google Vision OCR: {len(result.content)} characters")
 
+    # Register additional backends
     azure_ocr = AzureCognitiveServicesOCR(
         endpoint="https://your-resource.cognitiveservices.azure.com", api_key="your-api-key"
     )
@@ -100,26 +102,33 @@ def main() -> None:
     handwriting_ocr = HandwritingOCR()
     register_ocr_backend(handwriting_ocr)
 
-    for _backend in [google_ocr, azure_ocr, custom_ml_ocr, handwriting_ocr]:
-        pass
+    # List registered backends
+    for backend in [google_ocr, azure_ocr, custom_ml_ocr, handwriting_ocr]:
+        print(f"Registered backend: {backend.name()}")
 
+    # Use each backend
     config = ExtractionConfig(ocr=OcrConfig(backend="azure_ocr", language="eng"))
-    extract_file_sync("document.pdf", config=config)
+    result = extract_file_sync("document.pdf", config=config)
+    print(f"Azure OCR: {len(result.content)} characters")
 
     config = ExtractionConfig(ocr=OcrConfig(backend="custom_ml_ocr", language="eng"))
-    extract_file_sync("document.pdf", config=config)
+    result = extract_file_sync("document.pdf", config=config)
+    print(f"Custom ML OCR: {len(result.content)} characters")
 
     config = ExtractionConfig(ocr=OcrConfig(backend="handwriting_ocr", language="eng"))
-    extract_file_sync("handwritten_notes.pdf", config=config)
+    result = extract_file_sync("handwritten_notes.pdf", config=config)
+    print(f"Handwriting OCR: {len(result.content)} characters")
 
     backends = ["google_vision", "azure_ocr", "tesseract"]
 
     for backend_name in backends:
         try:
             config = ExtractionConfig(ocr=OcrConfig(backend=backend_name, language="eng"))
-            extract_file_sync("document.pdf", config=config)
+            result = extract_file_sync("document.pdf", config=config)
+            print(f"Fallback succeeded with '{backend_name}': {len(result.content)} chars")
             break
-        except Exception:
+        except Exception as e:
+            print(f"Backend '{backend_name}' failed: {e}")
             continue
 
 

--- a/examples/python/custom_postprocessor.py
+++ b/examples/python/custom_postprocessor.py
@@ -185,6 +185,7 @@ class KeywordExtractor:
 
 
 def main() -> None:
+    # Register a full pipeline of post-processors
     register_post_processor(MetadataEnricher())
     register_post_processor(PIIRedactor())
     register_post_processor(TextNormalizer())
@@ -192,20 +193,32 @@ def main() -> None:
     register_post_processor(SummaryGenerator(max_summary_length=300))
     register_post_processor(KeywordExtractor())
 
-    extract_file_sync("document.pdf")
+    # Extract with the full pipeline
+    result = extract_file_sync("document.pdf")
+    print(f"Full pipeline — word count: {result.metadata.get('word_count')}")
+    print(f"  PII redacted: {result.metadata.get('pii_redacted')}")
+    print(f"  Keywords: {result.metadata.get('keywords', [])[:5]}")
+    print(f"  Summary: {result.metadata.get('summary', '')[:100]}...")
 
+    # Remove one post-processor and re-extract
     unregister_post_processor("pii_redactor")
 
-    extract_file_sync("document.pdf")
+    result = extract_file_sync("document.pdf")
+    print(f"Without PII redaction — pii_redacted: {result.metadata.get('pii_redacted', False)}")
 
+    # Clear all and extract with no post-processing
     clear_post_processors()
 
-    extract_file_sync("document.pdf")
+    result = extract_file_sync("document.pdf")
+    print(f"No post-processing — metadata keys: {list(result.metadata.keys())[:5]}")
 
+    # Register a minimal pipeline
     register_post_processor(MetadataEnricher())
     register_post_processor(SummaryGenerator(max_summary_length=200))
 
-    extract_file_sync("document.pdf")
+    result = extract_file_sync("document.pdf")
+    print(f"Minimal pipeline — word count: {result.metadata.get('word_count')}")
+    print(f"  Truncated: {result.metadata.get('is_truncated')}")
 
 
 if __name__ == "__main__":

--- a/examples/python/ocr.py
+++ b/examples/python/ocr.py
@@ -7,6 +7,7 @@ from kreuzberg import ExtractionConfig, OcrConfig, extract_file_sync
 
 
 def main() -> None:
+    # Basic OCR with Tesseract
     config = ExtractionConfig(
         ocr=OcrConfig(
             backend="tesseract",
@@ -15,7 +16,10 @@ def main() -> None:
     )
 
     result = extract_file_sync("scanned_document.pdf", config=config)
+    print(f"OCR extracted: {len(result.content)} characters")
+    print(f"Preview: {result.content[:200]}...")
 
+    # OCR with a different language (German)
     config = ExtractionConfig(
         ocr=OcrConfig(
             backend="tesseract",
@@ -24,21 +28,27 @@ def main() -> None:
     )
 
     result = extract_file_sync("german_document.pdf", config=config)
+    print(f"German OCR: {len(result.content)} characters")
 
+    # Force OCR on a document with mixed native text and scanned pages
     config = ExtractionConfig(
         ocr=OcrConfig(backend="tesseract", language="eng"),
         force_ocr=True,
     )
 
     result = extract_file_sync("mixed_document.pdf", config=config)
+    print(f"Forced OCR: {len(result.content)} characters")
 
+    # OCR on a screenshot/image file
     config = ExtractionConfig(ocr=OcrConfig(backend="tesseract", language="eng"))
 
     result = extract_file_sync("screenshot.png", config=config)
 
     if result.metadata.ocr:
-        pass
+        print(f"OCR confidence: {result.metadata.ocr.confidence}")
+        print(f"OCR backend used: {result.metadata.ocr.backend}")
 
+    # OCR with table detection via Tesseract
     from kreuzberg import TesseractConfig
 
     config = ExtractionConfig(
@@ -53,8 +63,9 @@ def main() -> None:
 
     result = extract_file_sync("table_document.pdf", config=config)
 
-    for _i, _table in enumerate(result.tables):
-        pass
+    for i, table in enumerate(result.tables):
+        print(f"Table {i + 1}: {len(table.rows)} rows x {len(table.headers)} columns")
+        print(f"  Headers: {table.headers}")
 
 
 if __name__ == "__main__":

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -204,6 +204,8 @@ nav:
   - Migration Guides:
       - v3 to v4: migration/v3-to-v4.md
       - From Unstructured: migration/from-unstructured.md
+      - v4.0 Font Changes: migration/v4.0-fonts.md
+      - v4.0 HTML Metadata: migration/v4.0-html-metadata.md
   - Comparisons:
       - vs Unstructured: comparisons/kreuzberg-vs-unstructured.md
   - Changelog: CHANGELOG.md


### PR DESCRIPTION
Fix documentation regression where v3 examples incorrectly used v4 API
syntax (extract_file_sync) instead of the original v3 API (extract_file).
This caused confusion for users migrating from v3 to v4.

Changes:
- Restored 11 v3 code examples to use original v3 API (extract_file, 
  batch_extract) for accurate v3→v4 comparison
- Enriched 5 Python examples in examples/python/ with real output 
  demonstrations (removed skeleton pass stubs)
- Added missing migration docs to mkdocs nav (v4.0-fonts.md, 
  v4.0-html-metadata.md)
- Removed stale docs/migration/file.tmp (55KB duplicate)

Affected sections:
- API comparisons (imports, batch, error handling, metadata)
- Feature examples (chunking, tables, byte offsets)
- Migration examples (basic, OCR, batch processing)

