### PR TITLE
enable token_reduction feature

### DIFF
--- a/crates/kreuzberg/src/core/pipeline/features.rs
+++ b/crates/kreuzberg/src/core/pipeline/features.rs
@@ -105,6 +105,64 @@ pub(super) fn execute_chunking(result: &mut ExtractionResult, config: &Extractio
     Ok(())
 }
 
+/// Execute token reduction if configured.
+pub(super) fn execute_token_reduction(result: &mut ExtractionResult, config: &ExtractionConfig) -> Result<()> {
+    #[cfg(feature = "quality")]
+    if let Some(ref tr_config) = config.token_reduction {
+        use crate::text::token_reduction::{ReductionLevel, TokenReductionConfig as DetailedConfig, reduce_tokens};
+
+        let level = ReductionLevel::from(tr_config.mode.as_str());
+
+        if level != ReductionLevel::Off {
+            let detailed_config = DetailedConfig {
+                level,
+                ..DetailedConfig::default()
+            };
+
+            // Use detected language as hint if available, otherwise use OCR language if set
+            let lang_hint = result
+                .detected_languages
+                .as_ref()
+                .and_then(|langs| langs.first().map(|s| s.as_str()))
+                .or(config.ocr.as_ref().map(|ocr| ocr.language.as_str()));
+
+            match reduce_tokens(&result.content, &detailed_config, lang_hint) {
+                Ok(reduced) => {
+                    result.content = reduced;
+                }
+                Err(e) => {
+                    let error_msg = e.to_string();
+                    result.processing_warnings.push(ProcessingWarning {
+                        source: "token_reduction".to_string(),
+                        message: error_msg.clone(),
+                    });
+                    // DEPRECATED: kept for backward compatibility; will be removed in next major version.
+                    result.metadata.additional.insert(
+                        Cow::Borrowed("token_reduction_error"),
+                        serde_json::Value::String(error_msg),
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "quality"))]
+    if config.token_reduction.is_some() {
+        let error_msg = "Token reduction requires the quality feature to be enabled".to_string();
+        result.processing_warnings.push(ProcessingWarning {
+            source: "token_reduction".to_string(),
+            message: error_msg.clone(),
+        });
+        // DEPRECATED: kept for backward compatibility; will be removed in next major version.
+        result.metadata.additional.insert(
+            Cow::Borrowed("token_reduction_error"),
+            serde_json::Value::String(error_msg),
+        );
+    }
+
+    Ok(())
+}
+
 /// Execute language detection if configured.
 pub(super) fn execute_language_detection(result: &mut ExtractionResult, config: &ExtractionConfig) -> Result<()> {
     #[cfg(feature = "language-detection")]

--- a/crates/kreuzberg/src/core/pipeline/mod.rs
+++ b/crates/kreuzberg/src/core/pipeline/mod.rs
@@ -20,7 +20,7 @@ use crate::core::config::ExtractionConfig;
 use crate::types::ExtractionResult;
 
 use execution::{execute_processors, execute_validators};
-use features::{execute_chunking, execute_language_detection};
+use features::{execute_chunking, execute_language_detection, execute_token_reduction};
 use initialization::{get_processors_from_cache, initialize_features, initialize_processor_cache};
 
 /// Run the post-processing pipeline on an extraction result.
@@ -73,8 +73,9 @@ pub async fn run_pipeline(mut result: ExtractionResult, config: &ExtractionConfi
         .await?;
     }
 
-    execute_chunking(&mut result, config)?;
     execute_language_detection(&mut result, config)?;
+    execute_token_reduction(&mut result, config)?;
+    execute_chunking(&mut result, config)?;
     execute_validators(&result, config).await?;
 
     // Transform to element-based output if requested
@@ -137,8 +138,9 @@ pub async fn run_pipeline(mut result: ExtractionResult, config: &ExtractionConfi
 /// - Async validators
 #[cfg(not(feature = "tokio-runtime"))]
 pub fn run_pipeline_sync(mut result: ExtractionResult, config: &ExtractionConfig) -> Result<ExtractionResult> {
-    execute_chunking(&mut result, config)?;
     execute_language_detection(&mut result, config)?;
+    execute_token_reduction(&mut result, config)?;
+    execute_chunking(&mut result, config)?;
 
     // Transform to element-based output if requested
     if config.result_format == crate::types::OutputFormat::ElementBased {

--- a/crates/kreuzberg/tests/config_features.rs
+++ b/crates/kreuzberg/tests/config_features.rs
@@ -361,7 +361,9 @@ async fn test_token_reduction_aggressive() {
         ..Default::default()
     };
 
-    let text = "This is a very long sentence with many unnecessary words that could be reduced. ".repeat(5);
+    let text =
+        "This is a very long sentence with many unnecessary words like 'the' and 'is' and 'a' that could be reduced. "
+            .repeat(5);
     let text_bytes = text.as_bytes();
 
     let result = extract_bytes(text_bytes, "text/plain", &config)
@@ -369,6 +371,12 @@ async fn test_token_reduction_aggressive() {
         .expect("Should extract successfully");
 
     assert!(!result.content.is_empty());
+    assert!(
+        result.content.len() < text.len(),
+        "Content should be reduced in size. Original: {}, Reduced: {}",
+        text.len(),
+        result.content.len()
+    );
 }
 
 /// Test token reduction in conservative mode.


### PR DESCRIPTION
# Enable TokenReduction into Extraction Pipeline


## Summary
  This PR attempts to fix a  bug where the TokenReduction feature was ignored during
  document extraction, despite being present in ExtractionConfig. ([Issue](https://github.com/kreuzberg-dev/kreuzberg/issues/436#issue-4023736864))
:warning: This is vibe coded I'm not very familiar with rust. 

## Changes
   - Added execute_token_reduction to the feature
     processing logic in crates/kreuzberg/src/core/pipeline/features.rs.
   - Modified run_pipeline and run_pipeline_sync in
     crates/kreuzberg/src/core/pipeline/mod.rs to include the reduction stage.
   - Updated the execution order to: Language Detection
     -> Token Reduction -> Chunking. Not sure if the original ordering was intentional.
   - Updated test_token_reduction_aggressive in
     crates/kreuzberg/tests/config_features.rs to verify actual character count
     reduction.


Verified using the Python SDK in a uv environment with a test document. `light` saw a ~2% reduction, `moderate` ~29% and both `aggressive` and `maximum` saw 97% reductions. 
  
  I ran out of time trying to install all dependencies for `task setup`



