### PR TITLE
feat: better separate dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,16 +39,15 @@ homepage = "https://kreuzberg.dev"
 collapsible_if = "allow"
 
 [workspace.dependencies]
+kreuzberg = { path = "./crates/kreuzberg", default-features = false }
+kreuzberg-ffi = { path = "./crates/kreuzberg-ffi" }
+
 # Pinned: fastembed 5.12 requires exact =2.0.0-rc.11, kreuzberg-paddle-ocr must match
 ort = { version = "=2.0.0-rc.11", default-features = false }
 tokio = { version = "1.50.0", features = [
-    "rt",
-    "rt-multi-thread",
-    "macros",
     "sync",
     "process",
     "fs",
-    "time",
     "io-util",
 ] }
 

--- a/crates/kreuzberg-cli/Cargo.toml
+++ b/crates/kreuzberg-cli/Cargo.toml
@@ -13,25 +13,31 @@ keywords = ["document", "extraction", "cli", "tool", "parser"]
 categories = ["command-line-utilities", "text-processing"]
 
 [dependencies]
-kreuzberg = { path = "../kreuzberg", version = "4.4.5", features = ["full"] }
+kreuzberg = { workspace = true, features = ["formats", "tokio-runtime", "simd-utf8"] }
+
 clap = { workspace = true }
-tokio = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 base64 = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [features]
-default = ["bundled-pdfium"]
+default = ["bundled-pdfium", "embeddings", "ocr", "paddle-ocr"]
+
 bundled-pdfium = ["kreuzberg/bundled-pdfium"]
 static-pdfium = ["kreuzberg/static-pdfium"]
+
+ocr = ["kreuzberg/ocr"]
+
 api = ["kreuzberg/api"]
 mcp = ["kreuzberg/mcp"]
 mcp-http = ["kreuzberg/mcp-http"]
 embeddings = ["kreuzberg/embeddings"]
 paddle-ocr = ["kreuzberg/paddle-ocr"]
-all = ["api", "mcp", "mcp-http", "embeddings", "paddle-ocr"]
+
+all = ["default", "api", "mcp", "mcp-http"]
 
 [[bin]]
 name = "kreuzberg"

--- a/crates/kreuzberg-cli/src/commands/mod.rs
+++ b/crates/kreuzberg-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@
 pub mod cache;
 pub mod config;
 pub mod extract;
+#[cfg(any(feature = "api", feature = "mcp"))]
 pub mod server;
 
 // Re-export command functions for convenience

--- a/crates/kreuzberg-cli/src/commands/server.rs
+++ b/crates/kreuzberg-cli/src/commands/server.rs
@@ -3,7 +3,6 @@
 //! This module provides commands for starting the Kreuzberg API server
 //! and the MCP (Model Context Protocol) server.
 
-#[cfg(feature = "api")]
 use anyhow::Result;
 
 /// Execute API server command

--- a/crates/kreuzberg-ffi/Cargo.toml
+++ b/crates/kreuzberg-ffi/Cargo.toml
@@ -36,7 +36,7 @@ ahash = { workspace = true }
 ctor = { workspace = true }
 
 [target.'cfg(all(windows, target_env = "gnu"))'.dependencies]
-kreuzberg = { path = "../kreuzberg", features = [
+kreuzberg = { workspace = true, features = [
     "pdf",
     "excel",
     "office",
@@ -57,7 +57,7 @@ kreuzberg = { path = "../kreuzberg", features = [
 ] }
 
 [target.'cfg(not(all(windows, target_env = "gnu")))'.dependencies]
-kreuzberg = { path = "../kreuzberg", features = ["full", "bundled-pdfium"] }
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/crates/kreuzberg-node/Cargo.toml
+++ b/crates/kreuzberg-node/Cargo.toml
@@ -15,12 +15,13 @@ categories = ["api-bindings", "text-processing"]
 crate-type = ["cdylib"]
 
 [dependencies]
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+kreuzberg-ffi = { workspace = true }
+
 bytes = { workspace = true }
-kreuzberg = { path = "../kreuzberg", features = ["full", "bundled-pdfium"] }
-kreuzberg-ffi = { path = "../kreuzberg-ffi" }
 napi = { version = "3", default-features = false, features = ["napi8", "async", "serde-json"] }
 napi-derive = "3"
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["time"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/kreuzberg-php/Cargo.toml
+++ b/crates/kreuzberg-php/Cargo.toml
@@ -17,9 +17,10 @@ crate-type = ["cdylib"]
 test = false
 
 [dependencies]
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+
 ctor = { workspace = true }
 ext-php-rs = "0.15"
-kreuzberg = { path = "../kreuzberg", features = ["full", "bundled-pdfium"] }
 num_cpus = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }

--- a/crates/kreuzberg-py/Cargo.toml
+++ b/crates/kreuzberg-py/Cargo.toml
@@ -17,9 +17,10 @@ crate-type = ["cdylib", "rlib"]
 test = false
 
 [dependencies]
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+kreuzberg-ffi = { workspace = true }
+
 async-trait = { workspace = true }
-kreuzberg = { path = "../kreuzberg", features = ["full", "bundled-pdfium"] }
-kreuzberg-ffi = { path = "../kreuzberg-ffi" }
 once_cell = "1.21"
 # NOTE: pyo3 pinned to 0.27.x until pyo3-async-runtimes supports 0.28.x
 pyo3 = { version = "=0.27.2", features = ["abi3-py310"] }

--- a/crates/kreuzberg-wasm/Cargo.toml
+++ b/crates/kreuzberg-wasm/Cargo.toml
@@ -15,7 +15,8 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-kreuzberg = { path = "../kreuzberg", default-features = false, features = ["wasm-target"] }
+kreuzberg = { workspace = true, default-features = false, features = ["wasm-target"] }
+
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 wasm-bindgen-rayon = { version = "1.3", optional = true }

--- a/crates/kreuzberg/Cargo.toml
+++ b/crates/kreuzberg/Cargo.toml
@@ -25,13 +25,13 @@ pool-metrics = []
 
 simd-utf8 = ["dep:simdutf8"]
 
-tokio-runtime = ["dep:tokio"]
+tokio-runtime = ["dep:tokio", "tokio/rt", "tokio/rt-multi-thread"]
 
 pdf = ["dep:pdfium-render", "dep:lopdf", "dep:image"]
 static-pdfium = ["pdf"]
 bundled-pdfium = ["pdf"]
 system-pdfium = ["pdf"]
-excel = ["dep:calamine", "tokio-runtime"]
+excel = ["dep:calamine"]
 excel-wasm = ["dep:calamine"]
 office = [
     "dep:cfb",
@@ -70,6 +70,7 @@ paddle-ocr = [
     "dep:sha2",
     "dep:image",
     "dep:hf-hub",
+    "dep:ureq",
     "html",
     "tokio-runtime",
     "ocr",
@@ -105,7 +106,7 @@ wasm-target = [
 ]
 wasm-threads = ["dep:wasm-bindgen-rayon"]
 
-full = [
+formats = [
     "pdf",
     "excel",
     "office",
@@ -113,14 +114,17 @@ full = [
     "html",
     "xml",
     "archives",
-    "ocr",
-    "paddle-ocr",
     "language-detection",
     "chunking",
-    "embeddings",
     "quality",
     "keywords",
     "mdx",
+]
+full = [
+    "formats",
+    "ocr",
+    "paddle-ocr",
+    "embeddings",
     "api",
     "mcp",
     "otel",
@@ -241,6 +245,7 @@ tar = "0.4.44"
 zip = { version = "8.2.0", default-features = false, features = ["deflate-flate2"] }
 serial_test = "3.4.0"
 anyhow = { workspace = true }
+tokio = { workspace = true, features = ["macros", "time"] }
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 criterion = { workspace = true }
@@ -264,7 +269,7 @@ fastembed = { version = "5.12", default-features = false, features = [
 ], optional = true }
 hf-hub = { version = "0.5", default-features = false, features = ["ureq"], optional = true }
 # Force ureq (transitive dep via hf-hub) to use rustls on non-Windows
-ureq = { version = "3.2", default-features = false, features = ["rustls", "json"] }
+ureq = { version = "3.2", default-features = false, features = ["rustls", "json"], optional = true }
 
 # Use native-tls on Windows to avoid aws-lc-sys CMake build issues with MinGW
 [target.'cfg(all(target_os = "windows", not(target_arch = "wasm32")))'.dependencies]
@@ -283,7 +288,7 @@ fastembed = { version = "5.12", default-features = false, features = [
 ], optional = true }
 hf-hub = { version = "0.5", default-features = false, features = ["ureq"], optional = true }
 # Force ureq (transitive dep via hf-hub) to use native-tls on Windows
-ureq = { version = "3.2", default-features = false, features = ["native-tls", "json"] }
+ureq = { version = "3.2", default-features = false, features = ["native-tls", "json"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen-rayon = { version = "1.3", optional = true }

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -8,11 +8,12 @@ license.workspace = true
 publish = false
 
 [dependencies]
-kreuzberg = { path = "../../crates/kreuzberg", features = ["full", "bundled-pdfium"] }
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+
 serde_json = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
 async-trait = { workspace = true }
 tempfile = { workspace = true }
 hex = { workspace = true }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772822230,
+        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1773025773,
+        "narHash": "sha256-Wik8+xApNfldpUFjPmJkPdg0RrvUPSWGIZis+A/0N1w=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3c06fdbbd36ff60386a1e590ee0cd52dcd1892bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "Kreuzberg, document extraction library";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+
+        coreShell = with pkgs; mkShell {
+          nativeBuildInputs = [
+            rust
+            pkg-config
+            git
+            cmake
+            gnumake
+            curl
+            go-task
+
+            # Linting tools
+            taplo
+            shfmt
+            shellcheck
+            actionlint
+            cppcheck
+          ];
+
+          buildInputs = [
+            tesseract
+            file
+          ] ++ lib.optionals stdenv.isDarwin [
+            apple-sdk_15
+          ];
+
+          env = {
+            TESSDATA_PREFIX = "${tesseract}/share/tessdata";
+          };
+
+          shellHook = ''
+            echo "kreuzberg dev shell ready ($(rustc --version))"
+          '';
+        };
+
+        extendCore = extra: pkgs.mkShell {
+          inputsFrom = [ coreShell ];
+          nativeBuildInputs = extra;
+        };
+      in
+      {
+        devShells = {
+          default = coreShell;
+
+          python = extendCore (with pkgs; [ python3 uv ]);
+          node = extendCore (with pkgs; [ nodejs corepack ]);
+          go = extendCore (with pkgs; [ go ]);
+          ruby = extendCore (with pkgs; [ ruby ]);
+          elixir = extendCore (with pkgs; [ elixir erlang ]);
+          dotnet = extendCore (with pkgs; [ dotnet-sdk ]);
+          r = extendCore (with pkgs; [ R ]);
+          php = extendCore (with pkgs; [ php ]);
+          wasm = extendCore (with pkgs; [ deno wasm-pack ]);
+
+          full = extendCore (with pkgs; [
+            python3
+            uv
+            nodejs
+            corepack
+            go
+            ruby
+            elixir
+            erlang
+            dotnet-sdk
+            R
+            php
+            deno
+            wasm-pack
+          ]);
+        };
+      }
+    );
+}

--- a/packages/elixir/native/kreuzberg_rustler/Cargo.toml
+++ b/packages/elixir/native/kreuzberg_rustler/Cargo.toml
@@ -11,7 +11,8 @@ name = "kreuzberg_rustler"
 crate-type = ["cdylib"]
 
 [dependencies]
-kreuzberg = { path = "../../../../crates/kreuzberg", features = ["full", "bundled-pdfium"] }
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+
 rustler = { version = "0.37" }
 serde_json = "1.0"
 

--- a/tools/benchmark-harness/Cargo.toml
+++ b/tools/benchmark-harness/Cargo.toml
@@ -22,7 +22,8 @@ name = "benchmark_harness"
 path = "src/lib.rs"
 
 [dependencies]
-kreuzberg = { path = "../../crates/kreuzberg", features = ["full", "bundled-pdfium"] }
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+
 tokio = { workspace = true, features = ["full"] }
 serde = { workspace = true }
 serde_json = { workspace = true }


### PR DESCRIPTION
Hey, it's me again.

This is a bit more intrusive PR compared to my last one (#447). 

While building the CLI, I began noticing many dependencies being built related to features I'm not using, and I couldn't figure out why they were there, even when related features in the CLI were disabled.

The CLI enabled `full` from the core package, which in turn brought axum, ureq, rustls, multiple duplicates... This is a attempt at making this experience better.

1. Now, instead of relying directly on `full`, there's a new core feature flag called `formats` with all essential formats, leaving out bigger features like embeddings, ocr, mcp, api, etc.
2. Ureq is made optional, and is enabled when hf-hub is.
3. CLI by default compiles with all features it did before, but by desabling default features, you can now disable unused deps.
4. `excel` doesn't enable tokio-runtime by default anymore (was this needed before? I couldn't find a reason).
5. The shared core and FFI crates are now workspace dependencies (not strictly needed, but it's better to reason about, IMO).
6. Calamine was just now updated, dropping the need for a previous different quick-xml version (there were 3 different versions at one point).

I've added a Nix Flake file for consideration, though it's of course not needed if you decide against. But it makes it easier to contribute:
```
$ nix develop # loads only the rust essentials
$ nix develop .#python, .#node, .#go, .#ruby, .#elixir, .#dotnet, .#r, .#php, .#wasm # each loads their respective dependencies
$ nix develop .#full # loads all dependencies needed for all platforms supported
```

Feel free to ask me to remove anything, or close it if you disagree with the direction. This is more of a suggestion.