### PR TITLE
docs: rewrite contributing guide 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,538 +1,90 @@
 # Contributing to Kreuzberg
 
-Thank you for your interest in contributing to Kreuzberg! This guide will help you get started with development.
+Thank you for your interest in contributing to Kreuzberg! Whether you're fixing a typo, adding a feature, or improving documentation, every contribution makes a difference.
 
-## Table of Contents
+## First time contributing?
 
-- [Development Setup](#development-setup)
-  - [Task Installation](#task-installation)
-  - [Quick Start](#quick-start)
-- [Development Workflow](#development-workflow)
-  - [Common Commands](#common-commands)
-  - [Language-Specific Tasks](#language-specific-tasks)
-  - [Build Profiles](#build-profiles)
-- [Exploring Tasks](#exploring-tasks)
-- [CI/CD Integration](#cicd-integration)
-- [Code Quality](#code-quality)
+Welcome! We're glad you're here. Start by choosing an issue that matches your experience level:
 
-## Development Setup
+- [Good first issue](https://github.com/kreuzberg-dev/kreuzberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) — small, well-scoped tasks ideal for newcomers
+- [Help wanted](https://github.com/kreuzberg-dev/kreuzberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) — tasks where we'd especially appreciate community help
 
-### Task Installation
+> **Tip:** Pick an issue you feel confident about. If you're unsure about scope or approach, leave a comment on the issue and we'll help you get started.
 
-This project uses [Task](https://taskfile.dev/) for task automation and orchestration. Task is a task runner that simplifies development workflows across multiple languages and platforms.
+Want to work on something bigger or propose a new feature? [Open a discussion](https://github.com/kreuzberg-dev/kreuzberg/issues) with maintainers first.
 
-#### Install Task
+## Jump right in!
 
-Choose the installation method for your platform:
+**Quick fixes** (typos, small doc improvements):
 
-**macOS (Homebrew):**
-```bash
-brew install go-task
-```
+1. Edit the file directly on GitHub
+2. Submit a pull request — that's it!
 
-**Linux:**
-```bash
-# Using the installer script
-sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin
-# Or via package managers:
-apt install go-task  # Debian/Ubuntu
-pacman -S go-task    # Arch
-```
+**Larger contributions** (features, new bindings, bug fixes):
 
-**Windows:**
-```powershell
-# Using Scoop
-scoop install task
+1. Read the full [Contributing Guide](https://docs.kreuzberg.dev/contributing/) on our docs site
+2. Set up your development environment (see below)
+3. Follow our workflow: branch → code → test → PR
 
-# Or using Chocolatey
-choco install go-task
-```
+## What can I contribute to?
 
-**All Platforms:**
-Download the latest release from [https://github.com/go-task/task/releases](https://github.com/go-task/task/releases)
+Kreuzberg is a polyglot project with many areas where you can help:
 
-For complete installation instructions, visit the [official Task documentation](https://taskfile.dev/installation/).
+| Area | Description |
+|------|-------------|
+| **Rust core** | Parser implementations, extraction pipeline, performance |
+| **Language bindings** | Python, TypeScript, Ruby, Go, Java, C#, PHP, R, Elixir, WASM |
+| **Documentation** | Guides, API references, examples, tutorials |
+| **Testing** | Unit tests, E2E test fixtures, cross-language coverage |
+| **Plugins** | New extraction plugins, plugin system improvements |
+| **CI/CD** | Build pipeline, cross-architecture support, release automation |
 
-### Quick Start
+## Development setup
 
-After installing Task, set up your development environment with a single command:
+Get up and running in two steps:
+
+1. **Install [Task](https://taskfile.dev/installation/)** — our task runner for all build and test workflows
+2. **Run setup:**
 
 ```bash
-# One-time setup - installs all dependencies for all languages
 task setup
 ```
 
-This idempotent setup command will:
-- Install Rust, Python, Node.js, Ruby, Java, Go, C#, and PHP tools
-- Set up language-specific dependencies
-- Initialize development environments
+This installs all toolchains and dependencies across every language. Safe to re-run anytime.
 
-You can safely re-run `task setup` anytime without side effects.
+## Quick reference
 
-## Development Workflow
+| Command | What it does |
+|---------|-------------|
+| `task setup` | Install all dependencies (idempotent) |
+| `task build` | Build all language bindings |
+| `task test` | Run all test suites |
+| `task lint` | Run all linters (with auto-fix) |
+| `task format` | Format all code |
+| `task check` | Combined lint + format check (no modifications) |
 
-### Common Commands
+For language-specific commands, use the namespace pattern: `task rust:test`, `task python:build`, `task node:format`, etc.
 
-The following top-level commands are available for common development tasks:
+For the complete development workflow, build profiles, coding standards, and PR guidelines, see the full [Contributing Guide](https://docs.kreuzberg.dev/contributing/).
 
-**Build**
-```bash
-# Build all language bindings
-task build
+## Commit messages
 
-# Or build everything explicitly
-task build:all
-```
+We use [Conventional Commits](https://www.conventionalcommits.org/). Prefix your commit messages with a type:
 
-**Test**
-```bash
-# Run test suites for all languages
-task test
+- `feat:` — new feature
+- `fix:` — bug fix
+- `docs:` — documentation changes
+- `perf:` — performance improvement
+- `chore:` — maintenance, dependencies, CI
+- `test:` — adding or updating tests
+- `refactor:` — code restructuring without behavior change
 
-# Or be explicit
-task test:all
-```
+## Community
 
-**Code Quality**
-```bash
-# Format code for all languages
-task format
+- **Star the repo:** [Give us a star on GitHub](https://github.com/kreuzberg-dev/kreuzberg) — it helps others discover Kreuzberg!
+- **Documentation:** [docs.kreuzberg.dev](https://docs.kreuzberg.dev)
+- **Discord:** [Join our community](https://discord.gg/xt9WY3GnKR)
+- **Issues:** [GitHub Issues](https://github.com/kreuzberg-dev/kreuzberg/issues)
+- **License:** [MIT](LICENSE)
 
-# Check formatting without modifications
-task format:check
-
-# Run all linters (with auto-fix)
-task lint
-
-# Check linting without modifications
-task lint:check
-
-# Combined check (lint + format) without modifications
-task check
-```
-
-**Dependencies**
-```bash
-# Update all language dependencies
-task update
-
-# Clean all build artifacts
-task clean
-```
-
-### Language-Specific Tasks
-
-Each language binding has its own namespace. Common patterns work across all languages:
-
-**Rust:**
-```bash
-# Build development version
-task rust:build:dev
-
-# Build release version (optimized)
-task rust:build:release
-
-# Run tests
-task rust:test
-
-# Format code
-task rust:format
-
-# Check formatting
-task rust:format:check
-```
-
-**Python:**
-```bash
-# Build Python extension
-task python:build
-
-# Run Python tests
-task python:test
-
-# Format Python code
-task python:format
-
-# Install dependencies
-task python:install
-```
-
-**TypeScript/Node.js:**
-```bash
-# Build TypeScript bindings
-task node:build
-
-# Run tests
-task node:test
-
-# Format code
-task node:format
-
-# Install dependencies
-task node:install
-```
-
-**Ruby:**
-```bash
-# Build Ruby extension
-task ruby:build
-
-# Run tests
-task ruby:test
-
-# Format code
-task ruby:format
-```
-
-**Go:**
-```bash
-# Build Go bindings
-task go:build
-
-# Run tests
-task go:test
-
-# Format code
-task go:format
-```
-
-**Java:**
-```bash
-# Build Java bindings
-task java:build
-
-# Run tests
-task java:test
-
-# Format code
-task java:format
-```
-
-**C#:**
-```bash
-# Build C# bindings
-task csharp:build
-
-# Run tests
-task csharp:test
-
-# Format code
-task csharp:format
-```
-
-**PHP:**
-```bash
-# Build PHP extension
-task php:build
-
-# Run tests
-task php:test
-
-# Format code
-task php:format
-```
-
-**WebAssembly:**
-```bash
-# Build WASM bindings
-task wasm:build
-
-# Run tests
-task wasm:test
-
-# Clean WASM artifacts
-task wasm:clean
-```
-
-### Build Profiles
-
-Kreuzberg supports multiple build profiles optimized for different scenarios:
-
-| Profile | Purpose | Use Case |
-|---------|---------|----------|
-| `dev` | Development builds with debug symbols and minimal optimizations | Local development, fast iteration |
-| `release` | Optimized production builds | Performance-critical deployments, releases |
-| `ci` | CI-specific builds with extra diagnostics and checks | Continuous integration pipelines |
-
-**Using Build Profiles:**
-
-```bash
-# Development build (default, fastest to compile)
-task build
-
-# Or explicitly use dev profile
-BUILD_PROFILE=dev task build
-
-# Release build (slower to compile, faster to run)
-BUILD_PROFILE=release task build
-
-# CI build (with diagnostics)
-BUILD_PROFILE=ci task build
-
-# Language-specific with profile
-BUILD_PROFILE=dev task rust:build
-BUILD_PROFILE=release task python:build
-```
-
-### Workflow Commands
-
-For orchestrated multi-language operations:
-
-```bash
-# Build all bindings in debug mode
-task build:all:dev
-
-# Build all bindings in release mode
-task build:all:release
-
-# Build all bindings in CI mode
-task build:all:ci
-
-# Run all tests in parallel (faster)
-task test:all:parallel
-
-# Run all tests in CI mode (with diagnostics)
-task test:all:ci
-
-# Generate all E2E tests from fixtures
-task e2e:generate:all
-
-# Run all E2E tests
-task e2e:test:all
-```
-
-## Exploring Tasks
-
-### List All Available Tasks
-
-View all tasks available in the project:
-
-```bash
-# Show simple list of all public tasks
-task --list
-
-# Show all tasks including internal ones
-task --list-all
-
-# Show tasks for a specific namespace (e.g., rust)
-task --list rust
-```
-
-### Get Help for a Specific Task
-
-Display detailed information about a task:
-
-```bash
-# View task description and syntax
-task -h build
-task -h rust:build
-task -h test:all:parallel
-
-# View variables used by a task
-task -h setup
-```
-
-### Example Output
-
-```bash
-$ task --list
-task: Available tasks for this project:
-
-* setup              Install all dependencies and initialize project. Idempotent - safe to re-run anytime.
-* build             Build core libraries and language bindings
-* test              Run test suites for all languages
-* format            Format code for all languages (with modifications)
-* format:check      Check code formatting without modifications
-* check             Run all checks without modifications (lint + format checks)
-* update            Update all dependencies to latest versions
-* clean             Clean all build artifacts
-* rust:build        Build Rust crate
-* rust:test         Run Rust tests
-* python:build      Build Python extension
-* python:test       Run Python tests
-...and more
-```
-
-## CI/CD Integration
-
-The same Taskfile used locally is also used in continuous integration workflows. This ensures consistency between local development and CI pipelines.
-
-### Build Profile in CI
-
-CI pipelines use the `ci` build profile for enhanced diagnostics and consistency:
-
-```bash
-# In GitHub Actions and other CI systems:
-BUILD_PROFILE=ci task build:all:ci
-BUILD_PROFILE=ci task test:all:ci
-```
-
-### Running CI Checks Locally
-
-To test your changes before pushing, run the same commands CI uses:
-
-```bash
-# Verify code quality (no modifications)
-task check
-
-# Run all tests with CI-level diagnostics
-task test:all:ci
-
-# Build all bindings in CI mode
-BUILD_PROFILE=ci task build:all:ci
-```
-
-This helps catch issues before your PR reaches CI.
-
-### Cross-Architecture Testing
-
-Kreuzberg maintains continuous integration testing across multiple architectures:
-
-- **x86_64**: Standard Linux and Windows runners
-- **aarch64**: Linux ARM64 (`ubuntu-24.04-arm`) and macOS ARM64 (Apple Silicon) runners
-
-Each language binding is tested on aarch64 to ensure:
-- Native compilation works correctly
-- Precompiled binaries function as expected
-- No architecture-specific regressions
-- Performance characteristics match expectations
-
-**When Contributing**:
-- Changes affecting platform-specific code: Monitor CI results for aarch64 jobs
-- Binary packaging changes: Ensure CI matrix includes aarch64 testing
-- System dependencies: Verify availability on both x86_64 and aarch64
-
-The CI pipeline automatically tests your changes on all supported architectures.
-
-## Code Quality
-
-### Formatting
-
-The project enforces consistent code formatting across all languages:
-
-```bash
-# Auto-format all code
-task format
-
-# Check if code is formatted correctly (for CI)
-task format:check
-```
-
-Supported formatters:
-- **Rust**: `rustfmt`
-- **Python**: `black` and `isort`
-- **TypeScript**: `prettier` and `biome`
-- **Ruby**: `ruby-linter`
-- **Java**: `google-java-format`
-- **Go**: `gofmt`
-- **C#**: `dotnet format`
-- **PHP**: `php-cs-fixer`
-- **TOML**: `taplo`
-
-### Linting
-
-Lint checks ensure code quality and consistency:
-
-```bash
-# Run all linters with auto-fix
-task lint
-
-# Check only (no modifications)
-task lint:check
-```
-
-Supported linters vary by language. Check `task -h lint` for details.
-
-### Pre-commit Hooks
-
-The project includes pre-commit hooks configuration (`.pre-commit-config.yaml`). To use it:
-
-```bash
-# Install pre-commit hooks (requires pre-commit to be installed)
-pre-commit install
-
-# Run hooks on all files
-pre-commit run --all-files
-
-# Run specific hooks
-pre-commit run rust-fmt --all-files
-```
-
-## Testing
-
-### Running Tests
-
-```bash
-# Run all language tests
-task test
-
-# Run tests for a specific language
-task rust:test
-task python:test
-task node:test
-
-# Run all tests in parallel (faster)
-task test:all:parallel
-
-# Run tests with CI-level diagnostics
-task test:all:ci
-```
-
-### E2E Tests
-
-End-to-end tests validate functionality across languages:
-
-```bash
-# Generate E2E test code from fixtures
-task e2e:generate:all
-
-# Run all E2E tests
-task e2e:test:all
-
-# Lint generated E2E test code
-task e2e:lint:all
-```
-
-## Development Best Practices
-
-1. **Use `task setup` first**: Ensure all dependencies are installed before starting development
-
-2. **Run `task check` before committing**: Verify formatting and linting locally:
-   ```bash
-   task check
-   ```
-
-3. **Use language-specific tasks for focused work**:
-   ```bash
-   # Working on Rust? Focus on Rust tasks
-   task rust:build:dev
-   task rust:test
-   task rust:format:check
-   ```
-
-4. **Leverage build profiles**: Use `dev` for rapid iteration, `release` when optimizing
-   ```bash
-   BUILD_PROFILE=dev task rust:build  # Fast iteration
-   BUILD_PROFILE=release task rust:build  # Performance testing
-   ```
-
-5. **Test before pushing**: Run CI-level tests locally to catch issues early:
-   ```bash
-   BUILD_PROFILE=ci task test:all:ci
-   ```
-
-## Documentation and Help
-
-- **Task documentation**: [https://taskfile.dev/](https://taskfile.dev/)
-- **Kreuzberg documentation**: [https://kreuzberg.dev/](https://kreuzberg.dev/)
-- **Get help**: Use `task -h <taskname>` to see options and descriptions
-- **Contribute documentation**: Submit PRs to improve our docs
-
-## Questions?
-
-Have questions about contributing? Please:
-- Check the [Kreuzberg documentation](https://kreuzberg.dev/)
-- Open an issue on [GitHub](https://github.com/kreuzberg-dev/kreuzberg/issues)
-- Join our [Discord community](https://discord.gg/xt9WY3GnKR)
-
-Thank you for contributing to Kreuzberg!
+Thank you for helping make Kreuzberg better!

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,208 +1,198 @@
 # Contributing Guide
 
-Thanks for helping improve Kreuzberg! This guide summarizes the workflow, tooling, and expectations for contributions across all language bindings.
+Thank you for your interest in contributing to Kreuzberg! This guide covers everything you need — from picking an issue to getting your pull request merged.
+
+---
+
+## First time contributing?
+
+Welcome! Here's how to get started:
+
+1. **Pick an issue** that matches your experience level:
+      - [Good first issue](https://github.com/kreuzberg-dev/kreuzberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) — small, well-scoped tasks ideal for newcomers
+      - [Help wanted](https://github.com/kreuzberg-dev/kreuzberg/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) — tasks where we'd especially appreciate community help
+2. **Read through the issue** and any existing comments
+3. **Leave a comment** letting maintainers know you'd like to work on it
+4. **Ask questions** — we're here to help!
+
+Congratulations — that's really all it takes to start contributing! Fork, fix, and open a PR. We keep the process simple so you can focus on what matters: the code.
+
+!!! tip
+    Start small. A focused contribution you understand well is more valuable than an ambitious one that stalls.
+
+Want to propose a larger change or new feature? [Open an issue](https://github.com/kreuzberg-dev/kreuzberg/issues) to discuss it with maintainers first.
+
+---
 
 ## Prerequisites
 
-- Rust toolchain (`rustup`) with the stable channel.
-- Python 3.10+ (we use `uv` for virtualenv and dependency management).
-- Node.js 20+ with `pnpm`.
-- Ruby 3.2.0 or higher (including Ruby 4.x) via `rbenv` (preferred) or `rvm`.
-- go 1.26+ (install via `brew install go`, `asdf install golang`, or the official installer).
-- Java 25+ (required for FFM API bindings).
-- .NET 10+ (required for C# bindings).
-- Homebrew (macOS) or system equivalents for Tesseract/Pdfium dependencies.
+You only need the toolchains for the areas you plan to work on.
 
-Install all project dependencies in one shot:
+**Required for all contributions:**
+
+- [Git](https://git-scm.com/) - 
+- [Task](https://taskfile.dev/installation/) — our task runner for all build and test workflows
+- Rust stable (via `rustup`) — required for core and all bindings
+
+**Language-specific toolchains** (only install what you need):
+
+| Language | Version | Tool |
+|----------|---------|------|
+| Python | 3.10+ | `uv` |
+| Node.js | 20+ | `pnpm` |
+| Ruby | 3.2+ | `rbenv` or `rvm` |
+| Go | 1.26+ | Official installer |
+| Java | 25+ | JDK |
+| .NET | 10+ | `dotnet` |
+| PHP | 8.1+ | `composer` |
+
+For platform-specific build dependencies (compilers, OpenSSL, etc.), see the [Installation guide](getting-started/installation.md).
+
+---
+
+## Development setup
+
+Set up your entire environment with a single command:
 
 ```bash title="Terminal"
 task setup
 ```
 
-This runs language-specific installers (Python `uv sync`, `pnpm install`, `bundle install`) and builds the Rust workspace.
+This installs all toolchains and dependencies. Safe to re-run anytime.
 
-## Building from Source
-
-### Build-Time Dependencies
-
-Kreuzberg uses pure Rust dependencies and requires no system libraries beyond standard build tools (the embeddings feature requires ONNX Runtime, which is optional).
-
-### Platform-Specific Requirements
-
-**Linux**:
-```bash title="Terminal"
-# Ubuntu/Debian
-sudo apt-get install build-essential libssl-dev pkg-config
-
-# Fedora/RHEL
-sudo dnf groupinstall "Development Tools"
-sudo dnf install openssl-devel pkg-config
-```
-
-**macOS**:
-```bash title="Terminal"
-# Install OpenSSL 3.x
-brew install openssl@3
-
-# Install Xcode Command Line Tools (required for compilation)
-xcode-select --install
-```
-
-**Windows**:
-- Install [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022) with C++ support
-- Or use MSYS2 with MinGW-w64: `pacman -S mingw-w64-x86_64-toolchain`
-
-### Building the Rust Core
+For building individual language bindings, use the namespace pattern:
 
 ```bash title="Terminal"
-# Build all workspace crates
-cargo build --workspace
-
-# Build with specific features
-cargo build -p kreuzberg --features full
-
-# Build release binaries
-cargo build --release --workspace
+task rust:build
+task python:build
+task node:build
 ```
 
-### Building Language Bindings
+---
 
-**Python** (PyO3):
+## Development workflow
+
+### 1. Fork and clone
+
+Fork the repository on GitHub, then clone your fork:
+
 ```bash title="Terminal"
-cd packages/python
-
-# Build and install in development mode (editable install)
-maturin develop
-
-# Build wheel package for distribution
-maturin build
+git clone git@github.com:<your-username>/kreuzberg.git
+cd kreuzberg
+git remote add upstream https://github.com/kreuzberg-dev/kreuzberg.git
 ```
 
-**TypeScript** (NAPI-RS):
+### 2. Create a branch
+
 ```bash title="Terminal"
-cd packages/typescript
-
-# Build native module and generate TypeScript declarations
-pnpm build
+git checkout -b feat/your-feature-name main
 ```
 
-**Ruby** (Magnus):
+Use a prefix that matches your change type: `feat/`, `fix/`, `docs/`, `perf/`, `chore/`, `test/`.
+
+### 3. Make your changes
+
+Keep commits small and focused.
+
+### 4. Run checks
+
 ```bash title="Terminal"
-cd packages/ruby
-
-# Compile native extension
-bundle exec rake compile
-
-# Build platform-specific gem
-bundle exec rake native:gem
+task check
 ```
 
-**Go** (cgo):
+This runs both linting and formatting checks. For language-specific tests:
+
 ```bash title="Terminal"
-# Build FFI library with full features (Linux/macOS)
-cargo build -p kreuzberg-ffi --release
-
-# Build FFI library for Windows (MinGW cannot link ONNX Runtime, so use core features only)
-cargo build -p kreuzberg-ffi --release --target x86_64-pc-windows-gnu --no-default-features --features core
-
-# Set library paths for Go to find the FFI library
-export DYLD_FALLBACK_LIBRARY_PATH=$PWD/target/release  # macOS
-export LD_LIBRARY_PATH=$PWD/target/release             # Linux
-# Windows: Add target\release to PATH environment variable
-
-# Install Go development tools (golangci-lint) and download modules
-task go:install
-
-# Run code formatters and linters (gofmt + golangci-lint)
-task go:lint
-
-# Run Go tests (requires libkreuzberg_ffi in target/release)
-task go:test
-
-# Regenerate test fixtures and run end-to-end Go tests
-task e2e:go:verify
+task rust:test
+task python:test
+task node:test
 ```
 
-**Note:** Windows Go builds use MinGW (GNU toolchain) which cannot link MSVC-only ONNX Runtime. The `core` feature excludes embeddings but includes all other functionality.
+### 5. Commit with conventional messages
 
-**Java** (FFM API):
-```bash title="Terminal"
-cd packages/java
+We use [Conventional Commits](https://www.conventionalcommits.org/). The pre-commit hook validates this.
 
-# Clean, compile, and run tests
-mvn clean compile test
-
-# Run code quality checks (Checkstyle)
-mvn checkstyle:check
+```
+feat: add PDF table extraction support
+fix: handle empty MIME type in archive entries
+docs: update Python API reference for v4.4
+perf: parallelize layout inference
 ```
 
-**C#** (.NET):
-```bash title="Terminal"
-cd packages/csharp
+### 6. Update documentation
 
-# Build the C# project
-dotnet build
+When adding user-facing features, add or update pages under `docs/` and reference them in `mkdocs.yaml`.
 
-# Run all tests
-dotnet test
-```
+---
 
-### Common Build Issues
+## Issues
 
-**Cross-compilation**:
-```bash title="Terminal"
-# Install target
-rustup target add x86_64-unknown-linux-musl
+### Finding issues
 
-# Build with cross
-cargo install cross
-cross build --target x86_64-unknown-linux-musl
-```
+Browse the [issue tracker](https://github.com/kreuzberg-dev/kreuzberg/issues) and filter by labels: `good first issue`, `help wanted`, `bug`, or `enhancement`.
 
-**Linker errors on Linux**:
-Ensure you have `gcc` and `binutils` installed:
-```bash title="Terminal"
-sudo apt-get install build-essential
-```
+### Reporting a bug
 
-## Development Workflow
+Include: what you expected, what happened (with error output), steps to reproduce, your environment (OS, language version, Kreuzberg version), and a minimal sample file if applicable.
 
-1. **Create a branch** off `main` with a descriptive name (e.g., `feat/python-config-alias`).
-2. **Make changes** with small, focused commits. Code should compile on all supported platforms.
-3. **Run tests/lint** for the areas you touched:
-   - `task lint` – cross-language linters (cargo clippy, Ruff, Rubocop, Biome/Oxlint, Mypy).
-   - `task dev:test` – full test matrix (Rust + Python + Ruby + TypeScript + Go + Java + C#).
-   - Language-specific shortcuts: `task python:test`, `task typescript:test`, `task ruby:test`, `task rust:test`, `task go:test`, `task java:test`, `task csharp:test`.
-4. **Write/Update docs** when adding features. User-facing content lives under `docs/` and must be referenced in `mkdocs.yaml`.
-5. **Ensure conventional commits** (`feat: ...`, `fix: ...`, `docs: ...`). The pre-commit hook checks commit messages.
-6. **Create a pull request** with a clear summary, screenshots/logs if relevant, and a checklist of tests you ran.
+### Suggesting improvements
 
-## Coding Standards
+Search for existing issues first. Describe the use case and keep scope focused — break large ideas into smaller, actionable issues.
 
-- **Rust**: edition 2024, no `unwrap` in production paths, document all public items, add `SAFETY` comments for unsafe blocks.
-- **Python**: dataclasses use `frozen=True`, `slots=True`; function-based pytest tests; follow Ruff/Mypy rules.
-- **TypeScript**: maintain strict types, avoid `any`, keep bindings in `packages/typescript/src` and tests under `tests/binding|smoke|cli`.
-- **Ruby**: no global state outside `Kreuzberg` module, keep native bridge panic-free, follow Rubocop defaults.
-- **Java**: FFM API (Foreign Function & Memory), sealed classes, records, pattern matching; JUnit 5; follow Checkstyle rules.
-- **C#**: .NET 10+; follow Microsoft C# coding conventions; use records for data types, nullable reference types enabled.
-- **Testing strategy**: Only language-specific smoke/binding tests live in each package; shared behavior belongs to the `e2e/` fixtures (Python, Ruby, TypeScript, Rust, Go, Java, C# runners). When adding a new feature, update the relevant fixture and regenerate via `task e2e:<lang>:generate`.
+!!! tip "Filing great issues"
+    Be specific: "PDF tables lose column alignment" is better than "PDF parsing is broken." Explain impact and link related issues with `#123`.
 
-## Documentation
+---
 
-- User docs only belong under `docs/`. Each new page must be added to `mkdocs.yaml`.
-- Prefer linking to existing guides or references rather than duplicating explanations.
-- Run `mkdocs build` (or `task docs:build`) if you add/rename files to ensure nav entries resolve.
+## Submitting a pull request
 
-## Submitting a PR
+### PR checklist
 
-Before opening a PR, verify:
+Before opening a PR, verify locally:
 
-- [ ] `task lint` passes.
-- [ ] Targeted tests or `task dev:test` pass.
-- [ ] Docs and changelog entries are updated (if applicable).
-- [ ] New files include appropriate licenses/headers where required.
-- [ ] Commit messages follow Conventional Commits.
+- [ ] `task check` passes
+- [ ] Targeted tests pass
+- [ ] Docs updated (if applicable)
+- [ ] Commits follow Conventional Commits
 
-Once reviewed and merged, GitHub Actions will produce updated wheels, gems, N-API bundles, CLI binaries, and Docker images.
+### Writing a good PR description
 
-Thanks again for contributing!
+Include **what** changed, **why**, and **how** you tested it. Use `Fixes #123` to auto-close related issues.
+
+!!! tip
+    Set your PR to **Draft** while it's in progress. Maintainers may leave early comments but won't do a full review until you mark it ready.
+
+### Review and merge
+
+1. **CI runs** — automated builds and tests across platforms
+2. **Maintainers review** — code correctness, style, and design
+3. **Feedback rounds** — make requested changes and push
+4. **Merge** — once approved with all checks passing
+
+**Merge requirements:** all CI checks pass, at least one maintainer approval, no unresolved conversations, branch up to date with `main`.
+
+!!! info
+    Don't worry about failing CI on your first PR. Maintainers will help you resolve issues.
+
+---
+
+## Coding standards
+
+- **Rust:** Edition 2024, no `unwrap()` in production paths, document all public items, `SAFETY` comments for `unsafe` blocks
+- **Python:** `frozen=True` / `slots=True` dataclasses, function-based pytest, follow Ruff and Mypy rules
+- **TypeScript:** Strict types, no `any`, bindings in `packages/typescript/src`
+- **Ruby:** No global state outside `Kreuzberg` module, panic-free native bridge, follow RuboCop
+- **Go / Java / C#:** Follow standard language conventions and project linters
+
+**Testing:** language-specific tests live in each package; shared E2E behavior belongs in `e2e/` fixtures. When adding features, regenerate with `task e2e:<lang>:generate`.
+
+---
+
+## Community and support
+
+- **Star the repo:** [Give us a star on GitHub](https://github.com/kreuzberg-dev/kreuzberg) — it helps others discover Kreuzberg!
+- **Discord:** [Join our community](https://discord.gg/xt9WY3GnKR)
+- **Issues:** [GitHub Issues](https://github.com/kreuzberg-dev/kreuzberg/issues)
+- **License:** [MIT](https://github.com/kreuzberg-dev/kreuzberg/blob/main/LICENSE)
+
+Thank you for contributing to Kreuzberg!

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1018,9 +1018,7 @@ strong {
 	background: linear-gradient(90deg, rgba(218, 42, 224, 0.18) 0%, transparent 100%);
 	box-shadow: none;
 	border-radius: 4px;
-	padding: 8px 60px 8px 12px;
-	align-items: center;
-	margin-left: -12px;
+	padding: 8px 12px;
 	color: #da2ae0;
 	font-weight: 500;
 }
@@ -1034,7 +1032,7 @@ strong {
 }
 
 .md-nav--secondary .md-nav__list .md-nav__link {
-	margin-top: 20px;
+	margin-top: 8px;
 	margin-right: 0;
 }
 


### PR DESCRIPTION
Rewrote both CONTRIBUTING.md (concise GitHub on-ramp) and docs/contributing.md (comprehensive docs-site guide) following welcoming style and format.

closing #499 