### PR TITLE
fix: pass mime_type to extract_file_in_worker binding

### DIFF
--- a/crates/kreuzberg-node/src/worker_pool_api.rs
+++ b/crates/kreuzberg-node/src/worker_pool_api.rs
@@ -136,7 +136,7 @@ pub fn get_worker_pool_stats(pool: &JsWorkerPool) -> Result<WorkerPoolStats> {
 pub async fn extract_file_in_worker(
     pool: &JsWorkerPool,
     file_path: String,
-    password: Option<String>,
+    mime_type: Option<String>,
     config: Option<JsExtractionConfig>,
 ) -> Result<JsExtractionResult> {
     let pool_id = pool.pool_id;
@@ -162,17 +162,8 @@ pub async fn extract_file_in_worker(
 
     let mut rust_config = resolve_config(config)?;
 
-    // Inject password into PDF config if provided
-    if let Some(ref pwd) = password {
-        let pdf_opts = rust_config.pdf_options.get_or_insert_with(Default::default);
-        let passwords = pdf_opts.passwords.get_or_insert_with(Vec::new);
-        if !passwords.contains(pwd) {
-            passwords.push(pwd.clone());
-        }
-    }
-
     // Spawn the extraction in a blocking thread
-    let result = tokio::task::spawn_blocking(move || kreuzberg::extract_file_sync(&file_path, None, &rust_config))
+    let result = tokio::task::spawn_blocking(move || kreuzberg::extract_file_sync(&file_path, mime_type.as_deref(), &rust_config))
         .await
         .map_err(|e| Error::from_reason(format!("Worker thread error: {}", e)))?
         .map_err(convert_error)?;


### PR DESCRIPTION
When using the `extractFileInWorker` function in the node bindings, I noticed that the explicit `mime_type` option was not being properly passed through to the Rust binding. This could cause unexpected errors if the files to be extracted did not have an extension present.

This change makes the binding code consistent with the way the Typescript wrapper is expecting it to be used.
https://github.com/kreuzberg-dev/kreuzberg/blob/e7c8e4b7a018e0e339bd73746f88adbb7ab792ef/crates/kreuzberg-node/typescript/extraction/worker-pool.ts#L133-L138

I went ahead and removed a chunk of code that added the old password parameter to the pdf config, as it didn't appear to be used for anything anymore. My assumption was that users could simply pass in the complete list of passwords in their pdf config, but let me know if my assumption is incorrect.