### PR TITLE
feat(epub): preserve headings in markdown/djot output

### DIFF
--- a/crates/kreuzberg/src/extractors/epub/content.rs
+++ b/crates/kreuzberg/src/extractors/epub/content.rs
@@ -1,47 +1,98 @@
 //! EPUB content extraction and text processing.
 //!
 //! Handles extraction of text content from XHTML files in spine order.
-//! Uses direct XML tree traversal to avoid double-lossy conversion through markdown.
+//!
+//! For `OutputFormat::Plain`, this uses direct XML tree traversal to avoid lossy conversions.
+//! For `OutputFormat::Markdown` / `OutputFormat::Djot`, this converts XHTML through the HTML
+//! conversion pipeline so structural elements (like headings) are preserved.
 
 use crate::Result;
+use crate::core::config::{ExtractionConfig, OutputFormat};
+use crate::types::ProcessingWarning;
 use std::io::Cursor;
 use zip::ZipArchive;
 
 use super::metadata::parse_opf;
 use super::parsing::{read_file_from_zip, resolve_path};
 
+fn trim_trailing_newlines(s: &str) -> &str {
+    s.trim_end_matches(['\n', '\r'])
+}
+
 /// Extract text content from an EPUB document by reading in spine order
 pub(super) fn extract_content(
     archive: &mut ZipArchive<Cursor<Vec<u8>>>,
     opf_path: &str,
     manifest_dir: &str,
-) -> Result<String> {
+    config: &ExtractionConfig,
+) -> Result<(String, bool, Vec<ProcessingWarning>)> {
     let opf_xml = read_file_from_zip(archive, opf_path)?;
     let (_, spine_hrefs) = parse_opf(&opf_xml)?;
 
     let mut content = String::new();
+    let wants_markup = matches!(config.output_format, OutputFormat::Markdown | OutputFormat::Djot);
+    let mut warnings: Vec<ProcessingWarning> = Vec::new();
+    let mut had_markup_fallback = false;
 
     for (index, href) in spine_hrefs.iter().enumerate() {
         let file_path = resolve_path(manifest_dir, href);
 
         match read_file_from_zip(archive, &file_path) {
             Ok(xhtml_content) => {
-                let text = extract_text_from_xhtml(&xhtml_content);
-                if !text.is_empty() {
+                // Preserve structural elements like headings by converting XHTML → Markdown/Djot
+                // using the same conversion pipeline as the HTML extractor. Use the API variant
+                // that disables YAML/frontmatter injection.
+                let extracted = if wants_markup {
+                    match crate::extraction::html::convert_html_to_markdown_with_metadata(
+                        &xhtml_content,
+                        config.html_options.clone(),
+                        Some(config.output_format),
+                    ) {
+                        Ok((converted, _)) => converted,
+                        Err(err) => {
+                            had_markup_fallback = true;
+                            warnings.push(ProcessingWarning {
+                                source: "epub".to_string(),
+                                message: format!(
+                                    "XHTML conversion failed for spine item '{}'; falling back to plain text: {}",
+                                    file_path, err
+                                ),
+                            });
+                            extract_text_from_xhtml(&xhtml_content)
+                        }
+                    }
+                } else {
+                    // Default: plain text extraction (no markup syntax).
+                    extract_text_from_xhtml(&xhtml_content)
+                };
+
+                let extracted = if wants_markup {
+                    trim_trailing_newlines(&extracted)
+                } else {
+                    extracted.trim_end()
+                };
+
+                if !extracted.is_empty() {
                     if index > 0 && !content.ends_with('\n') {
                         content.push('\n');
                     }
-                    content.push_str(&text);
+                    content.push_str(extracted);
                     content.push('\n');
                 }
             }
-            Err(_) => {
+            Err(err) => {
+                warnings.push(ProcessingWarning {
+                    source: "epub".to_string(),
+                    message: format!("Failed to read spine item '{}' from EPUB archive: {}", file_path, err),
+                });
                 continue;
             }
         }
     }
 
-    Ok(content.trim().to_string())
+    let content = trim_trailing_newlines(&content).to_string();
+    let fully_converted = wants_markup && !had_markup_fallback;
+    Ok((content, fully_converted, warnings))
 }
 
 /// Block-level HTML/XHTML elements that should produce newlines before/after their content.

--- a/crates/kreuzberg/src/extractors/epub/mod.rs
+++ b/crates/kreuzberg/src/extractors/epub/mod.rs
@@ -9,7 +9,7 @@
 //! Uses only permissive-licensed crates:
 //! - `zip` (MIT/Apache) - for reading EPUB container
 //! - `roxmltree` (MIT) - for parsing XML
-//! - `html-to-markdown-rs` (MIT) - for converting XHTML to plain text
+//! - `html-to-markdown-rs` (MIT) - for converting XHTML to Markdown/Djot when requested
 
 mod content;
 mod metadata;
@@ -81,7 +81,7 @@ impl DocumentExtractor for EpubExtractor {
     #[cfg_attr(
         feature = "otel",
         tracing::instrument(
-            skip(self, content, _config),
+            skip(self, content, config),
             fields(
                 extractor.name = self.name(),
                 content.size_bytes = content.len(),
@@ -92,7 +92,7 @@ impl DocumentExtractor for EpubExtractor {
         &self,
         content: &[u8],
         mime_type: &str,
-        _config: &ExtractionConfig,
+        config: &ExtractionConfig,
     ) -> Result<ExtractionResult> {
         let cursor = Cursor::new(content.to_vec());
 
@@ -112,13 +112,26 @@ impl DocumentExtractor for EpubExtractor {
 
         let opf_xml = read_file_from_zip(&mut archive, &opf_path)?;
 
-        let extracted_content = extract_content(&mut archive, &opf_path, &manifest_dir)?;
+        let (extracted_content, fully_converted, processing_warnings) =
+            extract_content(&mut archive, &opf_path, &manifest_dir, config)?;
 
         let (epub_metadata, additional_metadata) = extract_metadata(&opf_xml)?;
         let metadata_map: AHashMap<Cow<'static, str>, serde_json::Value> = additional_metadata
             .into_iter()
             .map(|(k, v)| (Cow::Owned(k), v))
             .collect();
+
+        // Signal that the extractor already formatted the output so the pipeline
+        // does not double-convert (mirrors HtmlExtractor behavior).
+        let pre_formatted = if fully_converted {
+            match config.output_format {
+                crate::core::config::OutputFormat::Markdown => Some("markdown".to_string()),
+                crate::core::config::OutputFormat::Djot => Some("djot".to_string()),
+                _ => None,
+            }
+        } else {
+            None
+        };
 
         Ok(ExtractionResult {
             content: extracted_content,
@@ -129,6 +142,7 @@ impl DocumentExtractor for EpubExtractor {
                 language: epub_metadata.language,
                 created_at: epub_metadata.date,
                 additional: metadata_map,
+                output_format: pre_formatted,
                 ..Default::default()
             },
             pages: None,
@@ -143,7 +157,7 @@ impl DocumentExtractor for EpubExtractor {
             #[cfg(any(feature = "keywords-yake", feature = "keywords-rake"))]
             extracted_keywords: None,
             quality_score: None,
-            processing_warnings: Vec::new(),
+            processing_warnings,
             annotations: None,
         })
     }

--- a/crates/kreuzberg/tests/epub_markdown_headings_tests.rs
+++ b/crates/kreuzberg/tests/epub_markdown_headings_tests.rs
@@ -1,0 +1,173 @@
+//! Regression tests: EPUB headings should be preserved for Markdown/Djot output.
+//!
+//! The native EPUB extractor historically returned plain text only, flattening
+//! `<h1>`–`<h6>` into regular lines. When `ExtractionConfig.output_format` is set
+//! to Markdown (or Djot), we should run the XHTML through the HTML→Markdown
+//! converter so headings become `#` / `##` etc.
+
+#![cfg(feature = "office")]
+
+use kreuzberg::core::config::{ExtractionConfig, OutputFormat};
+use kreuzberg::extractors::EpubExtractor;
+use kreuzberg::plugins::DocumentExtractor;
+use std::io::{Cursor, Write};
+use zip::write::FileOptions;
+
+fn build_minimal_epub_bytes() -> Vec<u8> {
+    let container_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    let opf_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Test Book</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="c1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="c1"/>
+  </spine>
+</package>"#;
+
+    let chapter_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter One</title></head>
+  <body>
+    <h1>Chapter One</h1>
+    <p>Some text.</p>
+  </body>
+</html>"#;
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut writer = zip::ZipWriter::new(&mut cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+
+    writer.start_file("mimetype", options).expect("zip start_file failed");
+    writer
+        .write_all(b"application/epub+zip")
+        .expect("zip write mimetype failed");
+
+    writer
+        .add_directory("META-INF/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/", options)
+        .expect("zip add_directory failed");
+
+    writer
+        .start_file("META-INF/container.xml", options)
+        .expect("zip start_file failed");
+    writer
+        .write_all(container_xml.as_bytes())
+        .expect("zip write container.xml failed");
+
+    writer
+        .start_file("OEBPS/content.opf", options)
+        .expect("zip start_file failed");
+    writer
+        .write_all(opf_xml.as_bytes())
+        .expect("zip write content.opf failed");
+
+    writer
+        .start_file("OEBPS/chapter1.xhtml", options)
+        .expect("zip start_file failed");
+    writer
+        .write_all(chapter_xhtml.as_bytes())
+        .expect("zip write chapter1.xhtml failed");
+
+    writer.finish().expect("zip finish failed");
+    cursor.into_inner()
+}
+
+#[tokio::test]
+async fn test_epub_markdown_output_keeps_headings() {
+    let bytes = build_minimal_epub_bytes();
+    let extractor = EpubExtractor::new();
+
+    let mut config = ExtractionConfig::default();
+    config.output_format = OutputFormat::Markdown;
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &config)
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.processing_warnings.is_empty(),
+        "Expected no warnings, got: {:?}",
+        result.processing_warnings
+    );
+    assert!(
+        result.content.contains("# Chapter One"),
+        "Expected Markdown heading, got:\n{}",
+        result.content
+    );
+    assert!(
+        !result.content.starts_with("---"),
+        "Expected no YAML frontmatter injection, got:\n{}",
+        result.content
+    );
+    assert!(result.content.contains("Some text."), "Expected body text");
+}
+
+#[tokio::test]
+async fn test_epub_djot_output_keeps_headings() {
+    let bytes = build_minimal_epub_bytes();
+    let extractor = EpubExtractor::new();
+
+    let mut config = ExtractionConfig::default();
+    config.output_format = OutputFormat::Djot;
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &config)
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.processing_warnings.is_empty(),
+        "Expected no warnings, got: {:?}",
+        result.processing_warnings
+    );
+    assert!(
+        result.content.contains("# Chapter One"),
+        "Expected Djot heading, got:\n{}",
+        result.content
+    );
+    assert!(
+        !result.content.starts_with("---"),
+        "Expected no YAML frontmatter injection, got:\n{}",
+        result.content
+    );
+    assert!(result.content.contains("Some text."), "Expected body text");
+}
+
+#[tokio::test]
+async fn test_epub_plain_output_does_not_inject_markdown_headings() {
+    let bytes = build_minimal_epub_bytes();
+    let extractor = EpubExtractor::new();
+
+    let config = ExtractionConfig::default();
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &config)
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.processing_warnings.is_empty(),
+        "Expected no warnings, got: {:?}",
+        result.processing_warnings
+    );
+    assert!(
+        !result.content.contains("# Chapter One"),
+        "Plain output should not contain Markdown heading markers, got:\n{}",
+        result.content
+    );
+    assert!(result.content.contains("Chapter One"), "Expected heading text");
+}


### PR DESCRIPTION
This PR implements support for basic markup preservation in EPUB files. This is require as in many e-books sections and chapter titles are marked using headers. 

# Summary of the changes
- Preserves structural elements (headings) when extracting EPUBs to Markdown/Djot format - Previously, EPUB extraction always produced plain text, flattening \<h1>–\<h6> elements. Now when OutputFormat::Markdown or OutputFormat::Djot is configured, XHTML content is converted through the HTML→Markdown pipeline so headings become proper #/## markers.
- Adds graceful fallback - If XHTML-to-Markdown conversion fails for a spine item, the extractor falls back to plain text extraction and emits a ProcessingWarning.
- Sets output_format metadata - Signals to the extraction pipeline that the output is already formatted, preventing double-conversion (mirrors HtmlExtractor behavior).
- Adds comprehensive tests - New test file validates heading preservation for both Markdown and Djot outputs, confirms plain text output doesn't inject markdown markers, and verifies no YAML frontmatter is injected.