### PR TITLE
feat: improve CSV and XML extraction for embedding quality

### DIFF
--- a/crates/kreuzberg/src/extraction/xml.rs
+++ b/crates/kreuzberg/src/extraction/xml.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Streaming parser**: Processes XML files in constant memory
 //! - **Element tracking**: Counts total elements and unique element names
-//! - **Contextual text extraction**: Extracts text with element names as context for better quality
+//! - **Hierarchical text extraction**: Preserves document structure through indentation
 //! - **Whitespace handling**: Optional whitespace preservation
 //!
 //! # Example
@@ -19,9 +19,9 @@
 //! let xml = b"<root><item>Hello</item><item>World</item></root>";
 //! let result = parse_xml(xml, false)?; // false = trim whitespace
 //!
-//! // Content includes element names as context
-//! assert!(result.content.contains("item: Hello"));
-//! assert!(result.content.contains("item: World"));
+//! // Content preserves element hierarchy through indentation
+//! assert!(result.content.contains("item\n  Hello"));
+//! assert!(result.content.contains("item\n  World"));
 //! assert_eq!(result.element_count, 3);
 //! # Ok(())
 //! # }
@@ -77,7 +77,7 @@ fn parse_xml_inner(xml_bytes: &[u8], preserve_whitespace: bool, svg_mode: bool) 
     let mut unique_elements_set = HashSet::new();
     let mut buf = Vec::new();
     let mut element_stack: Vec<String> = Vec::new();
-    let mut last_was_element_tag = false;
+    let mut had_depth1_element = false;
 
     loop {
         match reader.read_event_into(&mut buf) {
@@ -90,27 +90,12 @@ fn parse_xml_inner(xml_bytes: &[u8], preserve_whitespace: bool, svg_mode: bool) 
 
                 // In SVG mode, skip attribute extraction entirely
                 if !svg_mode {
-                    // Extract attribute values as text content
-                    for attr in e.attributes().flatten() {
-                        let attr_value: Cow<str> = String::from_utf8_lossy(&attr.value);
-                        let trimmed_value = attr_value.trim();
-                        if !trimmed_value.is_empty() {
-                            let attr_key: Cow<str> = String::from_utf8_lossy(attr.key.as_ref());
-                            if !content.is_empty() && !content.ends_with('\n') {
-                                content.push('\n');
-                            }
-                            content.push_str(&name_owned);
-                            content.push('[');
-                            content.push_str(&attr_key);
-                            content.push_str("]: ");
-                            content.push_str(trimmed_value);
-                            content.push('\n');
-                        }
-                    }
+                    let depth = element_stack.len();
+                    let label = format_element_label(&name_owned, e.attributes());
+                    write_element_line(&mut content, &label, depth, &mut had_depth1_element);
                 }
 
                 element_stack.push(name_owned);
-                last_was_element_tag = true;
             }
             Ok(Event::Empty(e)) => {
                 let name_bytes = (e.name().as_ref() as &[u8]).to_vec();
@@ -121,39 +106,14 @@ fn parse_xml_inner(xml_bytes: &[u8], preserve_whitespace: bool, svg_mode: bool) 
 
                 // In SVG mode, skip self-closing tag output entirely
                 if !svg_mode {
-                    // For self-closing tags, add element name and attributes
-                    if !content.is_empty() && !content.ends_with('\n') {
-                        content.push('\n');
-                    }
-
-                    // Extract attribute values
-                    let mut has_attrs = false;
-                    for attr in e.attributes().flatten() {
-                        let attr_value: Cow<str> = String::from_utf8_lossy(&attr.value);
-                        let trimmed_value = attr_value.trim();
-                        if !trimmed_value.is_empty() {
-                            let attr_key: Cow<str> = String::from_utf8_lossy(attr.key.as_ref());
-                            content.push_str(&name_owned);
-                            content.push('[');
-                            content.push_str(&attr_key);
-                            content.push_str("]: ");
-                            content.push_str(trimmed_value);
-                            content.push('\n');
-                            has_attrs = true;
-                        }
-                    }
-
-                    if !has_attrs {
-                        content.push_str(&name_owned);
-                        content.push('\n');
-                    }
+                    let depth = element_stack.len();
+                    let label = format_element_label(&name_owned, e.attributes());
+                    write_element_line(&mut content, &label, depth, &mut had_depth1_element);
                 }
-                last_was_element_tag = true;
             }
             Ok(Event::End(_e)) => {
                 // Pop matching element from stack
                 element_stack.pop();
-                last_was_element_tag = true;
             }
             Ok(Event::Text(e)) => {
                 let text_cow: Cow<str> = String::from_utf8_lossy(e.as_ref());
@@ -176,20 +136,8 @@ fn parse_xml_inner(xml_bytes: &[u8], preserve_whitespace: bool, svg_mode: bool) 
                             content.push_str(&trimmed);
                         }
                     } else {
-                        // Add element context if we just opened a new element
-                        if last_was_element_tag && !element_stack.is_empty() {
-                            if !content.is_empty() && !content.ends_with('\n') {
-                                content.push('\n');
-                            }
-                            let elem_name = &element_stack[element_stack.len() - 1];
-                            content.push_str(elem_name);
-                            content.push_str(": ");
-                        }
-
-                        content.push_str(&trimmed);
-                        content.push('\n');
+                        write_text_line(&mut content, &trimmed, element_stack.len());
                     }
-                    last_was_element_tag = false;
                 }
             }
             Ok(Event::CData(e)) => {
@@ -204,20 +152,7 @@ fn parse_xml_inner(xml_bytes: &[u8], preserve_whitespace: bool, svg_mode: bool) 
                 }
 
                 let text_cow: Cow<str> = String::from_utf8_lossy(&e);
-
-                // Add element context if we just opened a new element
-                if last_was_element_tag && !element_stack.is_empty() {
-                    if !content.is_empty() && !content.ends_with('\n') {
-                        content.push('\n');
-                    }
-                    let elem_name = &element_stack[element_stack.len() - 1];
-                    content.push_str(elem_name);
-                    content.push_str(": ");
-                }
-
-                content.push_str(&text_cow);
-                content.push('\n');
-                last_was_element_tag = false;
+                write_text_line(&mut content, &text_cow, element_stack.len());
             }
             Ok(Event::Eof) => break,
             Err(e) => {
@@ -265,6 +200,70 @@ fn decode_utf16_to_utf8(data: &[u8], big_endian: bool) -> Result<Vec<u8>> {
     Ok(text.into_bytes())
 }
 
+/// Build an element label with non-namespace attributes inline.
+fn format_element_label(name: &str, attrs: quick_xml::events::attributes::Attributes) -> String {
+    let attr_parts: Vec<String> = attrs
+        .flatten()
+        .filter_map(|attr| {
+            let key: Cow<str> = String::from_utf8_lossy(attr.key.as_ref());
+            if key.starts_with("xmlns") {
+                return None;
+            }
+            let val: Cow<str> = String::from_utf8_lossy(&attr.value);
+            let trimmed = val.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(format!("{}: {}", key, trimmed))
+            }
+        })
+        .collect();
+    if attr_parts.is_empty() {
+        name.to_string()
+    } else {
+        format!("{} ({})", name, attr_parts.join(", "))
+    }
+}
+
+/// Write an indented element label, with blank lines between depth-1 siblings.
+fn write_element_line(content: &mut String, label: &str, depth: usize, had_depth1: &mut bool) {
+    match depth {
+        0 => {
+            content.push_str(label);
+            content.push('\n');
+        }
+        1 => {
+            if *had_depth1 {
+                content.push('\n');
+            }
+            content.push_str(label);
+            content.push('\n');
+            *had_depth1 = true;
+        }
+        _ => {
+            for _ in 0..depth - 1 {
+                content.push_str("  ");
+            }
+            content.push_str(label);
+            content.push('\n');
+        }
+    }
+}
+
+/// Write indented text content under the current element.
+fn write_text_line(content: &mut String, text: &str, stack_len: usize) {
+    let indent = if stack_len == 0 {
+        0
+    } else {
+        stack_len.saturating_sub(1).max(1)
+    };
+    for _ in 0..indent {
+        content.push_str("  ");
+    }
+    content.push_str(text);
+    content.push('\n');
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -273,9 +272,9 @@ mod tests {
     fn test_simple_xml() {
         let xml = b"<root><item>Hello</item><item>World</item></root>";
         let result = parse_xml(xml, false).unwrap();
-        // Now includes element names as context
-        assert!(result.content.contains("item: Hello"));
-        assert!(result.content.contains("item: World"));
+        // Element names with text indented beneath
+        assert!(result.content.contains("item\n  Hello"));
+        assert!(result.content.contains("item\n  World"));
         assert_eq!(result.element_count, 3);
         assert!(result.unique_elements.contains(&"root".to_string()));
         assert!(result.unique_elements.contains(&"item".to_string()));
@@ -311,7 +310,7 @@ mod tests {
     fn test_whitespace_handling() {
         let xml = b"<root>  <item>  Text  </item>  </root>";
         let result = parse_xml(xml, false).unwrap();
-        assert!(result.content.contains("item: Text"));
+        assert!(result.content.contains("item\n  Text"));
     }
 
     #[test]
@@ -336,7 +335,7 @@ mod tests {
     fn test_xml_with_attributes() {
         let xml = br#"<root id="1"><item type="test">Content</item></root>"#;
         let result = parse_xml(xml, false).unwrap();
-        assert!(result.content.contains("item: Content"));
+        assert!(result.content.contains("item (type: test)\n  Content"));
         assert_eq!(result.element_count, 2);
     }
 
@@ -352,7 +351,7 @@ mod tests {
     fn test_xml_with_comments() {
         let xml = b"<root><!-- Comment --><item>Text</item></root>";
         let result = parse_xml(xml, false).unwrap();
-        assert!(result.content.contains("item: Text"));
+        assert!(result.content.contains("item\n  Text"));
         assert_eq!(result.element_count, 2);
     }
 
@@ -360,7 +359,7 @@ mod tests {
     fn test_xml_with_processing_instructions() {
         let xml = b"<?xml version=\"1.0\"?><root><item>Text</item></root>";
         let result = parse_xml(xml, false).unwrap();
-        assert!(result.content.contains("item: Text"));
+        assert!(result.content.contains("item\n  Text"));
         assert_eq!(result.element_count, 2);
     }
 
@@ -369,7 +368,7 @@ mod tests {
         let xml = b"<root>Text before<item>nested</item>Text after</root>";
         let result = parse_xml(xml, false).unwrap();
         assert!(result.content.contains("Text before"));
-        assert!(result.content.contains("item: nested"));
+        assert!(result.content.contains("item\n  nested"));
         assert!(result.content.contains("Text after"));
     }
 
@@ -394,8 +393,7 @@ mod tests {
     fn test_xml_with_nested_elements() {
         let xml = b"<root><parent><child><grandchild>Deep</grandchild></child></parent></root>";
         let result = parse_xml(xml, false).unwrap();
-        assert!(result.content.contains("Deep"));
-        assert!(result.content.contains("grandchild: Deep"));
+        assert!(result.content.contains("    grandchild\n      Deep"));
         assert_eq!(result.element_count, 4);
         assert_eq!(result.unique_elements.len(), 4);
     }
@@ -428,7 +426,7 @@ mod tests {
     fn test_xml_with_newlines() {
         let xml = b"<root>\n  <item>\n    Text\n  </item>\n</root>";
         let result = parse_xml(xml, false).unwrap();
-        assert!(result.content.contains("item: Text"));
+        assert!(result.content.contains("item\n  Text"));
     }
 
     #[test]

--- a/crates/kreuzberg/src/extractors/csv.rs
+++ b/crates/kreuzberg/src/extractors/csv.rs
@@ -72,24 +72,10 @@ impl DocumentExtractor for CsvExtractor {
 
         let rows = parse_csv(&text, delimiter);
 
-        // Build space-separated text (each row on its own line, cells separated by spaces)
-        let content_text = rows
-            .iter()
-            .map(|row| {
-                row.iter()
-                    .map(|cell| cell.trim())
-                    .filter(|cell| !cell.is_empty())
-                    .collect::<Vec<_>>()
-                    .join(" ")
-            })
-            .filter(|line| !line.is_empty())
-            .collect::<Vec<_>>()
-            .join("\n");
-
         let row_count = rows.len();
         let col_count = rows.iter().map(|r| r.len()).max().unwrap_or(0);
-
         let has_header = detect_header(&rows);
+        let content_text = build_content_text(&rows, has_header);
         let column_types = infer_column_types(&rows, has_header);
 
         // Build markdown table before moving rows into Table::cells
@@ -433,6 +419,52 @@ fn infer_column_types(rows: &[Vec<String>], has_header: bool) -> Vec<String> {
         .collect()
 }
 
+/// Build text content with header-value pairs for embedding quality.
+///
+/// When a header row is detected, produces `Row N:\n  Header: Value` pairs
+/// that preserve the semantic association between column names and cell values.
+/// Empty cells are skipped. Falls back to space-separated values when no
+/// header is detected.
+fn build_content_text(rows: &[Vec<String>], has_header: bool) -> String {
+    if rows.is_empty() {
+        return String::new();
+    }
+
+    if !has_header || rows.len() < 2 {
+        return rows
+            .iter()
+            .map(|row| {
+                row.iter()
+                    .map(|cell| cell.trim())
+                    .filter(|cell| !cell.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            })
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n");
+    }
+
+    let headers = &rows[0];
+    let mut sections = Vec::with_capacity(rows.len() - 1);
+
+    for (i, row) in rows[1..].iter().enumerate() {
+        let mut lines = vec![format!("Row {}:", i + 1)];
+        for (header, value) in headers.iter().zip(row.iter()) {
+            let h = header.trim();
+            let v = value.trim();
+            if !h.is_empty() && !v.is_empty() {
+                lines.push(format!("  {}: {}", h, v));
+            }
+        }
+        if lines.len() > 1 {
+            sections.push(lines.join("\n"));
+        }
+    }
+
+    sections.join("\n\n")
+}
+
 /// Build a Markdown table from parsed rows.
 fn build_markdown_table(rows: &[Vec<String>]) -> String {
     if rows.is_empty() {
@@ -544,11 +576,13 @@ mod tests {
             .await
             .expect("CSV extraction should succeed");
 
-        // Content should be space-separated (not comma-separated)
-        assert!(result.content.contains("Name Age City"));
-        assert!(result.content.contains("Alice 30 NYC"));
-        assert!(result.content.contains("Bob 25 LA"));
-        assert!(!result.content.contains(','));
+        // Header-value pairs preserve semantic associations
+        assert!(result.content.contains("Name: Alice"));
+        assert!(result.content.contains("Age: 30"));
+        assert!(result.content.contains("City: NYC"));
+        assert!(result.content.contains("Name: Bob"));
+        assert!(result.content.contains("Row 1:"));
+        assert!(result.content.contains("Row 2:"));
 
         // Tables should be populated
         assert_eq!(result.tables.len(), 1);
@@ -708,10 +742,8 @@ mod tests {
         let result = extractor.extract_bytes(&content, "text/csv", &config).await.unwrap();
 
         assert!(!result.content.is_empty());
-        assert!(result.content.contains("Alice Johnson"));
-        assert!(result.content.contains("Engineering"));
-        // Should not have comma delimiters in the content
-        assert!(!result.content.lines().any(|line| line.contains(',')));
+        assert!(result.content.contains("Name: Alice Johnson"));
+        assert!(result.content.contains("Department: Engineering"));
         // Tables should be populated
         assert_eq!(result.tables.len(), 1);
         assert_eq!(result.tables[0].cells.len(), 11); // header + 10 data rows

--- a/crates/kreuzberg/tests/csv_embedding_quality.rs
+++ b/crates/kreuzberg/tests/csv_embedding_quality.rs
@@ -1,0 +1,142 @@
+//! Tests verifying CSV extraction produces embedding-friendly output.
+//!
+//! Header-value pairs preserve semantic associations between column names
+//! and cell values, improving vector search quality over flat space-separated output.
+
+use kreuzberg::core::config::ExtractionConfig;
+use kreuzberg::core::extractor::extract_bytes;
+
+/// Header-value pairs should be explicit in the content.
+#[tokio::test]
+async fn test_csv_preserves_header_value_association() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Age,City\nAlice,30,NYC\nBob,25,LA\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert!(result.content.contains("Name: Alice"));
+    assert!(result.content.contains("Age: 30"));
+    assert!(result.content.contains("City: NYC"));
+    assert!(result.content.contains("Name: Bob"));
+    assert!(result.content.contains("Age: 25"));
+    assert!(result.content.contains("City: LA"));
+}
+
+/// Rows should be labeled and separated by blank lines for chunker-friendly splitting.
+#[tokio::test]
+async fn test_csv_row_grouping() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Score\nAlice,95\nBob,88\nCarol,72\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert!(result.content.contains("Row 1:"));
+    assert!(result.content.contains("Row 2:"));
+    assert!(result.content.contains("Row 3:"));
+    assert!(
+        result.content.contains("\n\nRow 2:"),
+        "Rows should be separated by blank lines"
+    );
+}
+
+/// Empty cells should be omitted to avoid noisy `Header:` lines.
+#[tokio::test]
+async fn test_csv_skips_empty_values() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Age,City\nAlice,,NYC\nBob,25,LA\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert!(result.content.contains("Name: Alice"));
+    assert!(result.content.contains("City: NYC"));
+    // Row 1 (Alice) should not have an Age line since it's empty
+    let row1 = result.content.split("\n\n").next().unwrap_or("");
+    assert!(!row1.contains("Age:"), "Empty cells should be skipped");
+}
+
+/// The tables field should still contain the full parsed structure.
+#[tokio::test]
+async fn test_csv_tables_field_unchanged() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Age\nAlice,30\nBob,25\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert_eq!(result.tables.len(), 1);
+    assert_eq!(result.tables[0].cells.len(), 3);
+    assert_eq!(result.tables[0].cells[0], vec!["Name", "Age"]);
+    assert!(!result.tables[0].markdown.is_empty());
+}
+
+/// Rows shorter than the header should not panic; extra headers are skipped.
+#[tokio::test]
+async fn test_csv_short_row_no_panic() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Age,City\nAlice,30\nBob,25,LA\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert!(result.content.contains("Name: Alice"));
+    assert!(result.content.contains("Age: 30"));
+    // Alice's row has no City — should not appear
+    let row1 = result.content.split("\n\n").next().unwrap_or("");
+    assert!(!row1.contains("City:"));
+}
+
+/// Rows where all cells are empty should be omitted entirely.
+#[tokio::test]
+async fn test_csv_all_empty_data_rows() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Age\n,,\nAlice,30\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    // First row is all empty — should be skipped, Alice should be Row 1
+    assert!(result.content.contains("Name: Alice"));
+}
+
+/// When no header is detected, should fall back to space-separated output.
+#[tokio::test]
+async fn test_csv_no_header_fallback() {
+    let config = ExtractionConfig::default();
+    // All text, no numbers — detect_header returns false
+    let csv = b"Alice,NYC,Engineer\nBob,LA,Designer\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert!(
+        !result.content.contains("Row 1:"),
+        "No header detected — should not label rows"
+    );
+    assert!(result.content.contains("Alice"));
+    assert!(result.content.contains("Bob"));
+}
+
+/// Header-only CSV (no data rows) should still produce output.
+#[tokio::test]
+async fn test_csv_header_only() {
+    let config = ExtractionConfig::default();
+    let csv = b"Name,Age,City\n";
+
+    let result = extract_bytes(csv, "text/csv", &config).await.unwrap();
+
+    assert!(!result.content.is_empty());
+    assert!(result.content.contains("Name"));
+}
+
+/// Real CSV file with header-value pairing.
+#[tokio::test]
+async fn test_csv_real_file_header_value() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_documents/csv/data_table.csv");
+    if !path.exists() {
+        return;
+    }
+    let content = std::fs::read(&path).unwrap();
+    let config = ExtractionConfig::default();
+
+    let result = extract_bytes(&content, "text/csv", &config).await.unwrap();
+
+    assert!(result.content.contains("Name: Alice Johnson"));
+    assert!(result.content.contains("Department: Engineering"));
+    assert!(result.content.contains("Row 1:"));
+}

--- a/crates/kreuzberg/tests/xml_embedding_quality.rs
+++ b/crates/kreuzberg/tests/xml_embedding_quality.rs
@@ -1,0 +1,137 @@
+//! Tests verifying XML extraction produces embedding-friendly hierarchical output.
+//!
+//! Indented output preserves document structure so that related elements
+//! (e.g. a plant's name and zone) stay grouped together for vector search.
+
+use kreuzberg::core::config::ExtractionConfig;
+use kreuzberg::core::extractor::extract_bytes;
+
+/// Sibling elements should be grouped under their parent with indentation.
+#[tokio::test]
+async fn test_xml_preserves_hierarchy() {
+    let config = ExtractionConfig::default();
+    let xml = br#"<?xml version="1.0"?><CATALOG><PLANT><COMMON>Bloodroot</COMMON><ZONE>4</ZONE></PLANT></CATALOG>"#;
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    // PLANT children should be indented under PLANT
+    assert!(result.content.contains("PLANT"));
+    assert!(result.content.contains("  COMMON\n    Bloodroot"));
+    assert!(result.content.contains("  ZONE\n    4"));
+}
+
+/// Deeper nesting should produce deeper indentation.
+#[tokio::test]
+async fn test_xml_indentation_shows_nesting() {
+    let config = ExtractionConfig::default();
+    let xml = b"<root><parent><child><grandchild>Deep</grandchild></child></parent></root>";
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(result.content.contains("    grandchild\n      Deep"));
+}
+
+/// Attributes should appear inline with the element label.
+#[tokio::test]
+async fn test_xml_attributes_inline() {
+    let config = ExtractionConfig::default();
+    let xml = br#"<root><item type="book" id="42">Title</item></root>"#;
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(result.content.contains("item (type: book, id: 42)"));
+    assert!(result.content.contains("Title"));
+}
+
+/// Top-level sibling groups should be separated by blank lines.
+#[tokio::test]
+async fn test_xml_sibling_separation() {
+    let config = ExtractionConfig::default();
+    let xml = b"<CATALOG><PLANT><COMMON>A</COMMON></PLANT><PLANT><COMMON>B</COMMON></PLANT></CATALOG>";
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    // Blank line between PLANT siblings
+    assert!(result.content.contains("\n\nPLANT"));
+}
+
+/// Namespace attributes (xmlns:*) should be filtered from output.
+#[tokio::test]
+async fn test_xml_namespace_filtering() {
+    let config = ExtractionConfig::default();
+    let xml = br#"<root xmlns:ns="http://example.com" id="1"><item>Text</item></root>"#;
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(!result.content.contains("xmlns"), "Namespace attrs should be filtered");
+    assert!(
+        result.content.contains("root (id: 1)"),
+        "Non-namespace attrs should be preserved"
+    );
+    assert!(result.content.contains("Text"));
+}
+
+/// Mixed content (text between elements) should be preserved with indentation.
+#[tokio::test]
+async fn test_xml_mixed_content() {
+    let config = ExtractionConfig::default();
+    let xml = b"<root>Text before<item>nested</item>Text after</root>";
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(result.content.contains("Text before"));
+    assert!(result.content.contains("nested"));
+    assert!(result.content.contains("Text after"));
+}
+
+/// Self-closing tags should appear in the output.
+#[tokio::test]
+async fn test_xml_self_closing_tags() {
+    let config = ExtractionConfig::default();
+    let xml = br#"<root><item type="empty"/></root>"#;
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(result.content.contains("item (type: empty)"));
+}
+
+/// Empty attribute values should be filtered from the label.
+#[tokio::test]
+async fn test_xml_empty_attribute_filtered() {
+    let config = ExtractionConfig::default();
+    let xml = br#"<root><item id="" type="book">Text</item></root>"#;
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(result.content.contains("item (type: book)"));
+    assert!(!result.content.contains("id:"), "Empty attribute should be filtered");
+}
+
+/// Text directly inside the root element should still be indented.
+#[tokio::test]
+async fn test_xml_root_level_text() {
+    let config = ExtractionConfig::default();
+    let xml = b"<root>Some text</root>";
+
+    let result = extract_bytes(xml, "application/xml", &config).await.unwrap();
+
+    assert!(result.content.contains("root"));
+    assert!(result.content.contains("Some text"));
+}
+
+/// Real XML file should produce grouped plant entries.
+#[tokio::test]
+async fn test_xml_real_file_plant_catalog() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_documents/xml/plant_catalog.xml");
+    if !path.exists() {
+        return;
+    }
+    let content = std::fs::read(&path).unwrap();
+    let config = ExtractionConfig::default();
+
+    let result = extract_bytes(&content, "application/xml", &config).await.unwrap();
+
+    // Each plant's fields should be grouped together
+    assert!(result.content.contains("PLANT\n  COMMON\n    Bloodroot"));
+    assert!(result.content.contains("PLANT\n  COMMON\n    Columbine"));
+}


### PR DESCRIPTION
## Motivation

I ran into this in my RAG pipeline that indexes structured data files into a vector store. I specifically noticed the issue when indexing XML documentation. 

Additionally, I also tried doing some indexing of CSV data and saw poor results there as well. I wasn't able to get  headers or row level information while chatting with some CSVs. 

For example, a CSV like:
```csv
Name,Age,City
Alice,30,NYC
Bob,25,LA
```

currently extracts to `Name Age City / Alice 30 NYC / Bob 25 LA` — just tokens mashed together. There is no way to know that `30` is an age vs a zip code. The header row is a completely separate line from the values.

And XML like:
```xml
<CATALOG>
  <PLANT>
    <COMMON>Bloodroot</COMMON>
    <ZONE>4</ZONE>
  </PLANT>
  <PLANT>
    <COMMON>Columbine</COMMON>
    <ZONE>3</ZONE>
  </PLANT>
</CATALOG>
```

currently extracts to flat lines like `COMMON: Bloodroot / ZONE: 4 / COMMON: Columbine / ZONE: 3` with no grouping. You can't tell which plant a zone belongs to.

Once I switched to an indented hierarchical format like done here, retrieval improved drastically because related elements actually stay together in the same chunks.

The current content output for these formats does not offer much utility. Consumers already have tables and document, and for search/embedding the flat output loses too much structure. This gives the content field a clearer purpose.

## What changed

**CSV** (`extractors/csv.rs`): Zips data rows with the header row to produce labeled pairs. Falls back to space-separated if no header detected.

Before: `Name Age City / Alice 30 NYC / Bob 25 LA`
After:
```
Row 1:
  Name: Alice
  Age: 30
  City: NYC

Row 2:
  Name: Bob
  Age: 25
  City: LA
```

**XML** (`extraction/xml.rs`): Uses the existing element stack depth for indentation, with blank lines between top-level siblings. Attributes are inline, namespace attrs filtered.

Before: `COMMON: Bloodroot / ZONE: 4 / COMMON: Columbine / ZONE: 3`
After:
```
PLANT
  COMMON
    Bloodroot
  ZONE
    4

PLANT
  COMMON
    Columbine
  ZONE
    3
```

## Why this matters for RAG

- **CSV**: Values are now labeled with their column name and grouped per row. A query like "Alice age" actually hits `Age: 30` in the same chunk as `Name: Alice`. Before, these were just unlabeled tokens on different lines.
- **XML**: Blank lines between siblings give chunkers natural split points. A plant name and its zone end up in the same embedding window instead of getting interleaved with other plants. This is what made the Godot XML docs actually searchable for me.
- `tables` (CSV) and `document` (XML) are untouched — programmatic consumers are unaffected.

## Tests

- 19 new tests: header-value pairing, row grouping, empty cell skipping, no-header fallback, header-only CSV, hierarchy, attributes, namespace filtering, empty attribute filtering, root-level text, sibling separation, mixed content, self-closing tags, short rows, real file extraction
- All 14 existing CSV integration tests pass unchanged

---

Happy to gate this behind a config flag if changing the default is too disruptive. The current output may not be very useful to preserve though so I opted to replace it.