### PR TITLE
fix: expose missing ChunkingConfig fields in bindings

### DIFF
--- a/crates/kreuzberg-py/src/config/types.rs
+++ b/crates/kreuzberg-py/src/config/types.rs
@@ -865,6 +865,25 @@ impl ChunkingConfig {
         self.inner.prepend_heading_context
     }
 
+    #[getter]
+    fn chunker_type(&self) -> String {
+        match self.inner.chunker_type {
+            kreuzberg::ChunkerType::Text => "text".to_string(),
+            kreuzberg::ChunkerType::Markdown => "markdown".to_string(),
+            kreuzberg::ChunkerType::Yaml => "yaml".to_string(),
+        }
+    }
+
+    #[getter]
+    fn sizing_cache_dir(&self) -> Option<String> {
+        match &self.inner.sizing {
+            kreuzberg::ChunkSizing::Tokenizer { cache_dir, .. } => {
+                cache_dir.as_ref().map(|p| p.to_string_lossy().to_string())
+            }
+            _ => None,
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "ChunkingConfig(max_chars={}, max_overlap={}, embedding={}, preset={}, prepend_heading_context={})",

--- a/crates/kreuzberg-wasm/typescript/config/chunking-config.spec.ts
+++ b/crates/kreuzberg-wasm/typescript/config/chunking-config.spec.ts
@@ -137,6 +137,57 @@ describe("WASM: ChunkingConfig", () => {
 		});
 	});
 
+	describe("chunker type and heading context", () => {
+		it("should support chunkerType field", () => {
+			const config: ChunkingConfig = {
+				chunkerType: "markdown",
+				maxChars: 512,
+			};
+
+			expect(config.chunkerType).toBe("markdown");
+		});
+
+		it("should support prependHeadingContext field", () => {
+			const config: ChunkingConfig = {
+				chunkerType: "markdown",
+				prependHeadingContext: true,
+			};
+
+			expect(config.prependHeadingContext).toBe(true);
+		});
+
+		it("should support preset field", () => {
+			const config: ChunkingConfig = {
+				preset: "semantic",
+			};
+
+			expect(config.preset).toBe("semantic");
+		});
+
+		it("should serialize new fields for WASM boundary", () => {
+			const config: ChunkingConfig = {
+				chunkerType: "markdown",
+				prependHeadingContext: true,
+				preset: "semantic",
+			};
+
+			const json = JSON.stringify(config);
+			const parsed: ChunkingConfig = JSON.parse(json);
+
+			expect(parsed.chunkerType).toBe("markdown");
+			expect(parsed.prependHeadingContext).toBe(true);
+			expect(parsed.preset).toBe("semantic");
+		});
+
+		it("should leave new fields undefined by default", () => {
+			const config: ChunkingConfig = {};
+
+			expect(config.chunkerType).toBeUndefined();
+			expect(config.prependHeadingContext).toBeUndefined();
+			expect(config.preset).toBeUndefined();
+		});
+	});
+
 	describe("nesting in ExtractionConfig", () => {
 		it("should nest properly in ExtractionConfig", () => {
 			const config: ExtractionConfig = {

--- a/crates/kreuzberg-wasm/typescript/types.ts
+++ b/crates/kreuzberg-wasm/typescript/types.ts
@@ -276,12 +276,18 @@ export interface ChunkingConfig {
 	maxChars?: number;
 	/** Overlap between chunks */
 	maxOverlap?: number;
+	/** Named preset for chunking strategy (e.g., "balanced", "fast", "semantic") */
+	preset?: string;
+	/** Chunker type: "text" (default), "markdown", or "yaml" */
+	chunkerType?: string;
 	/** Sizing type: "characters" (default) or "tokenizer" */
 	sizingType?: "characters" | "tokenizer";
 	/** HuggingFace model ID for tokenizer sizing (e.g., "Xenova/gpt-4o") */
 	sizingModel?: string;
 	/** Optional cache directory for tokenizer files */
 	sizingCacheDir?: string;
+	/** Prepend heading context to each chunk when using markdown chunker. Default: false */
+	prependHeadingContext?: boolean;
 }
 
 /**

--- a/docs/reference/api-go.md
+++ b/docs/reference/api-go.md
@@ -671,7 +671,9 @@ type ChunkingConfig struct {
 	MaxChars     *int             // Maximum characters per chunk
 	MaxOverlap   *int             // Overlap between chunks in characters
 	Preset       *string          // Chunking preset name
+	ChunkerType  *string          // "text" (default), "markdown", or "yaml"
 	Sizing       *ChunkSizingConfig // Chunk size measurement configuration
+	PrependHeadingContext *bool   // Prepend heading hierarchy to chunks
 }
 
 type ChunkSizingConfig struct {

--- a/docs/reference/api-php.md
+++ b/docs/reference/api-php.md
@@ -888,6 +888,8 @@ readonly class ChunkingConfig
         public ?string $sizingType = null,
         public ?string $sizingModel = null,
         public ?string $sizingCacheDir = null,
+        public string $chunkerType = 'text',
+        public bool $prependHeadingContext = false,
     );
 }
 ```
@@ -901,6 +903,8 @@ readonly class ChunkingConfig
 - `$sizingType` (string|null): How chunk size is measured. Options: `"characters"` (default) or `"tokenizer"` (use a HuggingFace tokenizer). Default: null (characters)
 - `$sizingModel` (string|null): HuggingFace model ID for tokenizer-based sizing (e.g. `"bert-base-uncased"`). Required when `$sizingType` is `"tokenizer"`. Default: null
 - `$sizingCacheDir` (string|null): Optional directory to cache downloaded tokenizer files. Default: null
+- `$chunkerType` (string): Type of chunker to use. Options: `"text"` (default), `"markdown"`, `"yaml"`. Default: `"text"`
+- `$prependHeadingContext` (bool): When true, prepends heading hierarchy path to each chunk's content. Most useful with `chunkerType: "markdown"`. Default: false
 
 **Examples:**
 

--- a/docs/reference/api-python.md
+++ b/docs/reference/api-python.md
@@ -619,6 +619,8 @@ Text chunking configuration for splitting long documents.
 - `sizing_type` (str | None): How chunk size is measured. Options: `"characters"` (default) or `"tokenizer"` (use a HuggingFace tokenizer). Default: None (characters)
 - `sizing_model` (str | None): HuggingFace model ID for tokenizer-based sizing (e.g. `"bert-base-uncased"`). Required when `sizing_type="tokenizer"`. Default: None
 - `sizing_cache_dir` (str | None): Optional directory to cache downloaded tokenizer files. Default: None
+- `chunker_type` (str | None): Type of chunker to use. Options: `"text"` (default), `"markdown"`, `"yaml"`. Default: None (text)
+- `prepend_heading_context` (bool | None): When True, prepends heading hierarchy path to each chunk's content. Most useful with `chunker_type="markdown"`. Default: None (False)
 
 **Example:**
 

--- a/docs/reference/api-typescript.md
+++ b/docs/reference/api-typescript.md
@@ -779,9 +779,11 @@ interface ChunkingConfig {
   maxOverlap?: number;
   embedding?: EmbeddingConfig | null;
   preset?: string | null;
+  chunkerType?: string | null;
   sizingType?: "characters" | "tokenizer" | null;
   sizingModel?: string | null;
   sizingCacheDir?: string | null;
+  prependHeadingContext?: boolean | null;
 }
 ```
 
@@ -794,6 +796,8 @@ interface ChunkingConfig {
 - `sizingType` ("characters" | "tokenizer" | null): How chunk size is measured. Use `"tokenizer"` to measure by token count using a HuggingFace tokenizer. Default: null (characters)
 - `sizingModel` (string | null): HuggingFace model ID for tokenizer-based sizing (e.g. `"bert-base-uncased"`). Required when `sizingType` is `"tokenizer"`. Default: null
 - `sizingCacheDir` (string | null): Optional directory to cache downloaded tokenizer files. Default: null
+- `chunkerType` (string | null): Type of chunker to use. Options: `"text"` (default), `"markdown"`, `"yaml"`. Default: null (text)
+- `prependHeadingContext` (boolean | null): When true, prepends heading hierarchy path to each chunk's content. Most useful with `chunkerType: "markdown"`. Default: null (false)
 
 ---
 

--- a/docs/reference/api-wasm.md
+++ b/docs/reference/api-wasm.md
@@ -1443,6 +1443,8 @@ Configuration for text chunking.
 - `sizingType` ("characters" | "tokenizer" | undefined): How chunk size is measured. Use `"tokenizer"` to measure by token count using a HuggingFace tokenizer. Default: undefined (characters)
 - `sizingModel` (string | undefined): HuggingFace model ID for tokenizer-based sizing (e.g. `"bert-base-uncased"`). Required when `sizingType` is `"tokenizer"`. Default: undefined
 - `sizingCacheDir` (string | undefined): Optional directory to cache downloaded tokenizer files. Default: undefined
+- `chunkerType` (string | undefined): Type of chunker to use. Options: `"text"` (default), `"markdown"`, `"yaml"`. Default: undefined (text)
+- `prependHeadingContext` (boolean | undefined): When true, prepends heading hierarchy path to each chunk's content. Most useful with `chunkerType: "markdown"`. Default: undefined (false)
 
 ---
 

--- a/packages/csharp/Kreuzberg.Tests/Config/ChunkingConfigTests.cs
+++ b/packages/csharp/Kreuzberg.Tests/Config/ChunkingConfigTests.cs
@@ -219,4 +219,36 @@ public class ChunkingConfigTests
         Assert.Equal(100, config1.MaxOverlap);
         Assert.Equal(100, config2.ChunkOverlap);
     }
+
+    [Theory]
+    [InlineData("text")]
+    [InlineData("markdown")]
+    [InlineData("yaml")]
+    public void ChunkerType_ShouldAcceptValidValues(string chunkerType)
+    {
+        var config = new ChunkingConfig { ChunkerType = chunkerType };
+
+        Assert.Equal(chunkerType, config.ChunkerType);
+    }
+
+    [Fact]
+    public void ChunkerType_ShouldBeNullByDefault()
+    {
+        var config = new ChunkingConfig();
+
+        Assert.Null(config.ChunkerType);
+    }
+
+    [Fact]
+    public void ChunkerType_ShouldRoundTripThroughJson()
+    {
+        var original = new ChunkingConfig { ChunkerType = "markdown" };
+
+        var json = JsonSerializer.Serialize(original);
+        var restored = JsonSerializer.Deserialize<ChunkingConfig>(json);
+
+        Assert.NotNull(restored);
+        Assert.Equal("markdown", restored.ChunkerType);
+        Assert.Contains("chunker_type", json);
+    }
 }

--- a/packages/csharp/Kreuzberg/Models.cs
+++ b/packages/csharp/Kreuzberg/Models.cs
@@ -2510,6 +2510,13 @@ public sealed class ChunkingConfig
     public string? Preset { get; init; }
 
     /// <summary>
+    /// Type of chunker to use: "text" (default), "markdown", or "yaml".
+    /// The markdown chunker preserves document structure during splitting.
+    /// </summary>
+    [JsonPropertyName("chunker_type")]
+    public string? ChunkerType { get; init; }
+
+    /// <summary>
     /// Embedding configuration for vector generation.
     /// </summary>
     [JsonPropertyName("embedding")]

--- a/packages/go/v4/config_options.go
+++ b/packages/go/v4/config_options.go
@@ -486,6 +486,13 @@ func WithChunkingPreset(preset string) ChunkingOption {
 	}
 }
 
+// WithChunkerType sets the chunker type: "text" (default), "markdown", or "yaml".
+func WithChunkerType(t string) ChunkingOption {
+	return func(c *ChunkingConfig) {
+		c.ChunkerType = &t
+	}
+}
+
 // WithChunkingEnabled sets whether chunking is enabled.
 func WithChunkingEnabled(enabled bool) ChunkingOption {
 	return func(c *ChunkingConfig) {

--- a/packages/go/v4/config_test.go
+++ b/packages/go/v4/config_test.go
@@ -3,6 +3,7 @@ package kreuzberg_test
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	kreuzberg "github.com/kreuzberg-dev/kreuzberg/packages/go/v4"
@@ -500,6 +501,50 @@ func TestChunkingConfig_WithEmbedding(t *testing.T) {
 func TestChunkingConfig_NilPointerHandling(t *testing.T) {
 	var config *kreuzberg.ChunkingConfig
 	_ = config
+}
+
+func TestChunkingConfig_WithChunkerType(t *testing.T) {
+	config := kreuzberg.NewChunkingConfig(
+		kreuzberg.WithChunkerType("markdown"),
+	)
+
+	if config.ChunkerType == nil || *config.ChunkerType != "markdown" {
+		t.Error("expected ChunkerType to be markdown")
+	}
+}
+
+func TestChunkingConfig_ChunkerType_JSON_Roundtrip(t *testing.T) {
+	ct := "markdown"
+	original := &kreuzberg.ChunkingConfig{
+		ChunkerType: &ct,
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("failed to marshal ChunkingConfig: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"chunker_type":"markdown"`) {
+		t.Errorf("expected JSON to contain chunker_type, got: %s", string(data))
+	}
+
+	var restored kreuzberg.ChunkingConfig
+	err = json.Unmarshal(data, &restored)
+	if err != nil {
+		t.Fatalf("failed to unmarshal ChunkingConfig: %v", err)
+	}
+
+	if restored.ChunkerType == nil || *restored.ChunkerType != "markdown" {
+		t.Error("ChunkerType not preserved after roundtrip")
+	}
+}
+
+func TestChunkingConfig_ChunkerType_DefaultNil(t *testing.T) {
+	config := &kreuzberg.ChunkingConfig{}
+
+	if config.ChunkerType != nil {
+		t.Errorf("expected ChunkerType to be nil by default")
+	}
 }
 
 // ============================================================================

--- a/packages/go/v4/config_types.go
+++ b/packages/go/v4/config_types.go
@@ -206,6 +206,7 @@ type ChunkingConfig struct {
 	ChunkSize             *int               `json:"chunk_size,omitempty"`
 	ChunkOverlap          *int               `json:"chunk_overlap,omitempty"`
 	Preset                *string            `json:"preset,omitempty"`
+	ChunkerType           *string            `json:"chunker_type,omitempty"`
 	Enabled               *bool              `json:"enabled,omitempty"`
 	Embedding             *EmbeddingConfig   `json:"embedding,omitempty"`
 	Sizing                *ChunkSizingConfig `json:"sizing,omitempty"`

--- a/packages/php/src/Config/ChunkingConfig.php
+++ b/packages/php/src/Config/ChunkingConfig.php
@@ -112,6 +112,18 @@ readonly class ChunkingConfig
         public ?string $sizingCacheDir = null,
 
         /**
+         * Type of chunker to use.
+         *
+         * Supported values: "text" (default), "markdown", "yaml".
+         * The markdown chunker preserves document structure during splitting.
+         * The yaml chunker creates one chunk per top-level key.
+         *
+         * @var string
+         * @default "text"
+         */
+        public string $chunkerType = 'text',
+
+        /**
          * Prepend heading context to each chunk for improved retrieval.
          *
          * When enabled, each chunk will be prefixed with the heading hierarchy
@@ -187,6 +199,13 @@ readonly class ChunkingConfig
             }
         }
 
+        /** @var string $chunkerType */
+        $chunkerType = $data['chunker_type'] ?? 'text';
+        if (!is_string($chunkerType)) {
+            /** @var string $chunkerType */
+            $chunkerType = (string) $chunkerType;
+        }
+
         /** @var bool $prependHeadingContext */
         $prependHeadingContext = $data['prepend_heading_context'] ?? false;
         if (!is_bool($prependHeadingContext)) {
@@ -203,6 +222,7 @@ readonly class ChunkingConfig
             sizingType: $sizingType,
             sizingModel: $sizingModel,
             sizingCacheDir: $sizingCacheDir,
+            chunkerType: $chunkerType,
             prependHeadingContext: $prependHeadingContext,
         );
     }
@@ -261,6 +281,7 @@ readonly class ChunkingConfig
             'respect_sentences' => $this->respectSentences,
             'respect_paragraphs' => $this->respectParagraphs,
             'embedding' => $embedding,
+            'chunker_type' => $this->chunkerType !== 'text' ? $this->chunkerType : null,
             'sizing' => $sizing,
             'prepend_heading_context' => $this->prependHeadingContext,
         ], static fn ($value): bool => $value !== null);

--- a/packages/php/tests/Unit/Config/ChunkingConfigTest.php
+++ b/packages/php/tests/Unit/Config/ChunkingConfigTest.php
@@ -73,4 +73,38 @@ final class ChunkingConfigTest extends TestCase
         $this->assertIsBool($config->respectParagraphs);
         $this->assertTrue($config->respectParagraphs);
     }
+
+    #[Test]
+    public function it_defaults_chunker_type_to_text(): void
+    {
+        $config = new ChunkingConfig();
+
+        $this->assertSame('text', $config->chunkerType);
+    }
+
+    #[Test]
+    public function it_accepts_markdown_chunker_type(): void
+    {
+        $config = new ChunkingConfig(chunkerType: 'markdown');
+
+        $this->assertSame('markdown', $config->chunkerType);
+    }
+
+    #[Test]
+    public function it_round_trips_chunker_type_through_array(): void
+    {
+        $config = ChunkingConfig::fromArray(['chunker_type' => 'markdown']);
+
+        $this->assertSame('markdown', $config->chunkerType);
+        $this->assertArrayHasKey('chunker_type', $config->toArray());
+        $this->assertSame('markdown', $config->toArray()['chunker_type']);
+    }
+
+    #[Test]
+    public function it_omits_default_chunker_type_from_array(): void
+    {
+        $config = new ChunkingConfig();
+
+        $this->assertArrayNotHasKey('chunker_type', $config->toArray());
+    }
 }

--- a/packages/python/kreuzberg/_internal_bindings.pyi
+++ b/packages/python/kreuzberg/_internal_bindings.pyi
@@ -861,6 +861,23 @@ class ChunkingConfig:
             settings if provided). Use list_embedding_presets() to see available presets.
             Default: None
 
+        chunker_type (str): Type of chunker to use. Supported values:
+            "text" (default), "markdown", "yaml". Default: "text"
+
+        sizing_type (str): How chunk size is measured. "characters" (default)
+            or "tokenizer" for token-based sizing. Default: "characters"
+
+        sizing_model (str | None): HuggingFace model ID for tokenizer-based sizing.
+            Only used when sizing_type is "tokenizer". Example: "Xenova/gpt-4o".
+            Default: None
+
+        sizing_cache_dir (str | None): Optional cache directory for tokenizer files.
+            Only used when sizing_type is "tokenizer". Default: None
+
+        prepend_heading_context (bool): When True and chunker_type is "markdown",
+            prepends the heading hierarchy path to each chunk's content for
+            improved retrieval context. Default: False
+
     Example:
         Basic chunking with defaults:
             >>> from kreuzberg import ExtractionConfig, ChunkingConfig
@@ -883,9 +900,11 @@ class ChunkingConfig:
     max_overlap: int
     embedding: EmbeddingConfig | None
     preset: str | None
-    chunker_type: str | None
+    chunker_type: str
     sizing_type: str
     sizing_model: str | None
+    sizing_cache_dir: str | None
+    prepend_heading_context: bool
 
     def __init__(
         self,
@@ -898,6 +917,7 @@ class ChunkingConfig:
         sizing_type: str | None = None,
         sizing_model: str | None = None,
         sizing_cache_dir: str | None = None,
+        prepend_heading_context: bool | None = None,
     ) -> None: ...
 
 class ImageExtractionConfig:

--- a/packages/python/tests/config/test_chunking_config.py
+++ b/packages/python/tests/config/test_chunking_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import tempfile
+
 from kreuzberg import ChunkingConfig, EmbeddingConfig, EmbeddingModelType, ExtractionConfig
 
 
@@ -149,6 +151,72 @@ def test_chunking_config_edge_case_single_char_chunk() -> None:
     """ChunkingConfig should accept single character chunks."""
     config = ChunkingConfig(max_chars=1)
     assert config.max_chars == 1
+
+
+def test_chunking_config_chunker_type_default() -> None:
+    """ChunkingConfig should default to text chunker type."""
+    config = ChunkingConfig()
+    assert config.chunker_type == "text"
+
+
+def test_chunking_config_chunker_type_markdown() -> None:
+    """ChunkingConfig should accept markdown chunker type."""
+    config = ChunkingConfig(chunker_type="markdown")
+    assert config.chunker_type == "markdown"
+
+
+def test_chunking_config_prepend_heading_context_default() -> None:
+    """ChunkingConfig should default prepend_heading_context to False."""
+    config = ChunkingConfig()
+    assert config.prepend_heading_context is False
+
+
+def test_chunking_config_prepend_heading_context_enabled() -> None:
+    """ChunkingConfig should accept prepend_heading_context=True."""
+    config = ChunkingConfig(prepend_heading_context=True)
+    assert config.prepend_heading_context is True
+
+
+def test_chunking_config_sizing_type_default() -> None:
+    """ChunkingConfig should default to characters sizing."""
+    config = ChunkingConfig()
+    assert config.sizing_type == "characters"
+
+
+def test_chunking_config_sizing_type_tokenizer() -> None:
+    """ChunkingConfig should accept tokenizer sizing with model."""
+    config = ChunkingConfig(sizing_type="tokenizer", sizing_model="Xenova/gpt-4o")
+    assert config.sizing_type == "tokenizer"
+    assert config.sizing_model == "Xenova/gpt-4o"
+
+
+def test_chunking_config_sizing_cache_dir() -> None:
+    """ChunkingConfig should accept and return sizing_cache_dir."""
+    cache_dir = tempfile.gettempdir()
+    config = ChunkingConfig(
+        sizing_type="tokenizer",
+        sizing_model="Xenova/gpt-4o",
+        sizing_cache_dir=cache_dir,
+    )
+    assert config.sizing_cache_dir == cache_dir
+
+
+def test_chunking_config_sizing_cache_dir_default() -> None:
+    """ChunkingConfig should default sizing_cache_dir to None."""
+    config = ChunkingConfig()
+    assert config.sizing_cache_dir is None
+
+
+def test_chunking_config_markdown_with_heading_context() -> None:
+    """ChunkingConfig should support markdown chunker with heading context."""
+    config = ChunkingConfig(
+        chunker_type="markdown",
+        prepend_heading_context=True,
+        max_chars=512,
+    )
+    assert config.chunker_type == "markdown"
+    assert config.prepend_heading_context is True
+    assert config.max_chars == 512
 
 
 def test_chunking_config_realistic_nlp_scenario() -> None:


### PR DESCRIPTION
## Summary

In one of my projects I'm using the new `prepend_heading_context` chunking flag and it works great, but I caught myself doing a` # type: ignore` and that's how this was surfaced. 

The Python type stub was missing `prepend_heading_context` and `sizing_cache_dir`, and the PyO3 layer had no getters for `chunker_type` and `sizing_cache_dir` — fields could be set in the constructor but not read back. Several other bindings (PHP, Go, C#, WASM) were also missing `chunker_type`.

```python
# Before
config = ChunkingConfig(prepend_heading_context=True)  # type: ignore[call-arg]

# After
config = ChunkingConfig(prepend_heading_context=True)
```

Fixed this across all impacted bindings and added tests demonstrating the fix and also updated the docs to reflect these new options