### PR TITLE
fix(epub): preserve spine semantics and reduce TOC navigation noise

### DIFF
--- a/crates/kreuzberg/src/extractors/epub/content.rs
+++ b/crates/kreuzberg/src/extractors/epub/content.rs
@@ -6,100 +6,245 @@
 //! For `OutputFormat::Markdown` / `OutputFormat::Djot`, this converts XHTML through the HTML
 //! conversion pipeline so structural elements (like headings) are preserved.
 
-use crate::Result;
-use crate::core::config::{ExtractionConfig, OutputFormat};
 use crate::types::ProcessingWarning;
+use ahash::AHashSet;
+use std::cmp::Ordering;
 use std::io::Cursor;
 use zip::ZipArchive;
 
-use super::metadata::parse_opf;
-use super::parsing::{read_file_from_zip, resolve_path};
+use super::metadata::{EpubPackageDocument, ManifestItem};
+use super::parsing::read_file_from_zip;
 
-fn trim_trailing_newlines(s: &str) -> &str {
-    s.trim_end_matches(['\n', '\r'])
+#[derive(Debug, Clone)]
+/// A resolved XHTML spine document prepared for EPUB extraction.
+///
+/// The stored XHTML is sanitized so all downstream extraction paths see the
+/// same body content: packaging prelude is removed, and specialized navigation
+/// sections are stripped when they should not surface in extracted text.
+pub(super) struct EpubSpineDocument {
+    pub(super) file_path: String,
+    pub(super) xhtml: String,
 }
 
-/// Extract text content from an EPUB document by reading in spine order.
-///
-/// Returns `(content, fully_converted, warnings, spine_hrefs)` where `spine_hrefs`
-/// are the already-parsed spine item paths, available for reuse by callers (e.g.
-/// `build_document_structure`) without re-reading/re-parsing the OPF file.
-pub(super) fn extract_content(
+/// Read all body documents from the EPUB archive and downgrade per-item I/O
+/// failures into processing warnings.
+pub(super) fn read_body_documents(
     archive: &mut ZipArchive<Cursor<Vec<u8>>>,
-    opf_path: &str,
-    manifest_dir: &str,
-    config: &ExtractionConfig,
-) -> Result<(String, bool, Vec<ProcessingWarning>, Vec<String>)> {
-    let opf_xml = read_file_from_zip(archive, opf_path)?;
-    let (_, spine_hrefs) = parse_opf(&opf_xml)?;
+    package: &EpubPackageDocument,
+) -> crate::Result<(Vec<EpubSpineDocument>, Vec<ProcessingWarning>)> {
+    let mut documents = Vec::new();
+    let mut warnings = Vec::new();
 
-    let mut content = String::new();
-    let wants_markup = matches!(config.output_format, OutputFormat::Markdown | OutputFormat::Djot);
-    let mut warnings: Vec<ProcessingWarning> = Vec::new();
-    let mut had_markup_fallback = false;
+    for spine_item in &package.spine_items {
+        let Some(source_item) = package.manifest.get(&spine_item.idref) else {
+            warnings.push(ProcessingWarning {
+                source: std::borrow::Cow::Borrowed("epub"),
+                message: std::borrow::Cow::Owned(format!(
+                    "Spine item '{}' references a missing manifest entry",
+                    spine_item.idref
+                )),
+            });
+            continue;
+        };
 
-    for (index, href) in spine_hrefs.iter().enumerate() {
-        let file_path = resolve_path(manifest_dir, href);
+        let render_item = match resolve_renderable_manifest_item(package, &spine_item.idref) {
+            Ok(render_item) => render_item,
+            Err(err) => {
+                warnings.push(ProcessingWarning {
+                    source: std::borrow::Cow::Borrowed("epub"),
+                    message: std::borrow::Cow::Owned(format!(
+                        "Skipping spine item '{}' (href '{}'): {}",
+                        spine_item.idref, source_item.raw_href, err
+                    )),
+                });
+                continue;
+            }
+        };
+
+        let file_path =
+            render_item
+                .resolved_path()
+                .map(str::to_owned)
+                .map_err(|message| crate::KreuzbergError::Parsing {
+                    message: format!(
+                        "Unsafe manifest href for spine item '{}' (href '{}'): {}",
+                        spine_item.idref, render_item.raw_href, message
+                    ),
+                    source: None,
+                })?;
+        let guide_toc_candidate = source_item
+            .path
+            .as_deref()
+            .is_some_and(|path| package.is_guide_toc_candidate_path(path))
+            || render_item
+                .path
+                .as_deref()
+                .is_some_and(|path| package.is_guide_toc_candidate_path(path));
 
         match read_file_from_zip(archive, &file_path) {
-            Ok(xhtml_content) => {
-                // Preserve structural elements like headings by converting XHTML → Markdown/Djot
-                // using the same conversion pipeline as the HTML extractor. Use the API variant
-                // that disables YAML/frontmatter injection.
-                let extracted = if wants_markup {
-                    match crate::extraction::html::convert_html_to_markdown_with_metadata(
-                        &xhtml_content,
-                        config.html_options.clone(),
-                        Some(config.output_format),
-                    ) {
-                        Ok((converted, _)) => converted,
-                        Err(err) => {
-                            had_markup_fallback = true;
-                            warnings.push(ProcessingWarning {
-                                source: std::borrow::Cow::Borrowed("epub"),
-                                message: std::borrow::Cow::Owned(format!(
-                                    "XHTML conversion failed for spine item '{}'; falling back to plain text: {}",
-                                    file_path, err
-                                )),
-                            });
-                            extract_text_from_xhtml(&xhtml_content)
-                        }
-                    }
-                } else {
-                    // Default: plain text extraction (no markup syntax).
-                    extract_text_from_xhtml(&xhtml_content)
-                };
+            Ok(raw_xhtml) => {
+                let normalized_xhtml = normalize_xhtml(&raw_xhtml);
+                let render_xhtml = strip_specialized_navigation_sections(&strip_document_head(&normalized_xhtml));
 
-                let extracted = if wants_markup {
-                    trim_trailing_newlines(&extracted)
-                } else {
-                    extracted.trim_end()
-                };
-
-                if !extracted.is_empty() {
-                    if index > 0 && !content.ends_with('\n') {
-                        content.push('\n');
-                    }
-                    content.push_str(extracted);
-                    content.push('\n');
+                if guide_toc_candidate && looks_like_navigation_document(&render_xhtml) {
+                    continue;
                 }
+
+                if extract_text_from_xhtml(&render_xhtml).is_empty() {
+                    continue;
+                }
+
+                documents.push(EpubSpineDocument {
+                    file_path,
+                    xhtml: render_xhtml,
+                });
             }
             Err(err) => {
                 warnings.push(ProcessingWarning {
                     source: std::borrow::Cow::Borrowed("epub"),
                     message: std::borrow::Cow::Owned(format!(
-                        "Failed to read spine item '{}' from EPUB archive: {}",
-                        file_path, err
+                        "Failed to read body spine item '{}' (idref '{}') from EPUB archive: {}",
+                        file_path, spine_item.idref, err
                     )),
                 });
-                continue;
             }
         }
     }
 
-    let content = trim_trailing_newlines(&content).to_string();
-    let fully_converted = wants_markup && !had_markup_fallback;
-    Ok((content, fully_converted, warnings, spine_hrefs))
+    Ok((documents, warnings))
+}
+
+fn resolve_renderable_manifest_item<'a>(
+    package: &'a EpubPackageDocument,
+    start_idref: &str,
+) -> Result<&'a ManifestItem, String> {
+    let mut current_id = start_idref;
+    let mut visited = AHashSet::new();
+
+    loop {
+        if !visited.insert(current_id.to_string()) {
+            return Err(format!("manifest fallback cycle detected at '{}'", current_id));
+        }
+
+        let Some(item) = package.manifest.get(current_id) else {
+            return Err(format!("missing manifest entry '{}'", current_id));
+        };
+
+        if item.is_renderable_body_document() {
+            return Ok(item);
+        }
+
+        let Some(next_id) = item.fallback.as_deref() else {
+            let media_type = item.media_type.as_deref().unwrap_or("unknown");
+            return Err(format!(
+                "no renderable XHTML/DTBook fallback found for media type '{}'",
+                media_type
+            ));
+        };
+
+        current_id = next_id;
+    }
+}
+
+fn strip_xml_elements<F>(xhtml: &str, mut predicate: F) -> String
+where
+    F: FnMut(roxmltree::Node<'_, '_>) -> bool,
+{
+    let Ok(doc) = roxmltree::Document::parse(xhtml) else {
+        return xhtml.to_string();
+    };
+
+    let mut ranges = doc
+        .descendants()
+        .filter(|node| node.is_element())
+        .filter(|node| predicate(*node))
+        .map(|node| node.range())
+        .collect::<Vec<_>>();
+
+    if ranges.is_empty() {
+        return xhtml.to_string();
+    }
+
+    ranges.sort_by(|left, right| match left.start.cmp(&right.start) {
+        Ordering::Equal => right.end.cmp(&left.end),
+        order => order,
+    });
+
+    let mut stripped = String::with_capacity(xhtml.len());
+    let mut cursor = 0usize;
+    for range in ranges {
+        if range.start < cursor {
+            continue;
+        }
+        stripped.push_str(&xhtml[cursor..range.start]);
+        cursor = range.end;
+    }
+    stripped.push_str(&xhtml[cursor..]);
+    stripped
+}
+
+fn strip_document_head(xhtml: &str) -> String {
+    strip_xml_elements(xhtml, |node| node.tag_name().name().eq_ignore_ascii_case("head"))
+}
+
+fn strip_specialized_navigation_sections(xhtml: &str) -> String {
+    strip_xml_elements(xhtml, |node| {
+        node.tag_name().name().eq_ignore_ascii_case("nav") && is_specialized_navigation_node(node)
+    })
+}
+
+fn is_specialized_navigation_node(node: roxmltree::Node<'_, '_>) -> bool {
+    node.attributes().any(|attr| {
+        attr.name().eq_ignore_ascii_case("type")
+            && attr
+                .value()
+                .split_ascii_whitespace()
+                .any(|value| matches!(value.to_ascii_lowercase().as_str(), "toc" | "landmarks" | "page-list"))
+    })
+}
+
+fn looks_like_navigation_document(xhtml: &str) -> bool {
+    let Ok(doc) = roxmltree::Document::parse(xhtml) else {
+        return false;
+    };
+
+    let mut link_count = 0usize;
+    let mut list_item_count = 0usize;
+    let mut paragraph_count = 0usize;
+    let mut heading_or_title_mentions_contents = false;
+
+    for node in doc.descendants().filter(|node| node.is_element()) {
+        match node.tag_name().name().to_ascii_lowercase().as_str() {
+            "nav"
+                if node.attributes().any(|attr| {
+                    attr.name().eq_ignore_ascii_case("type")
+                        && attr
+                            .value()
+                            .split_ascii_whitespace()
+                            .any(|value| value.eq_ignore_ascii_case("toc"))
+                }) =>
+            {
+                return true;
+            }
+            "a" => link_count += 1,
+            "li" => list_item_count += 1,
+            "p" => paragraph_count += 1,
+            "title" | "h1" | "h2"
+                if node.text().is_some_and(|text| {
+                    matches!(
+                        text.trim().to_ascii_lowercase().as_str(),
+                        "contents" | "table of contents"
+                    )
+                }) =>
+            {
+                heading_or_title_mentions_contents = true;
+            }
+            _ => {}
+        }
+    }
+
+    (link_count >= 2 && list_item_count >= 2 && paragraph_count <= 1)
+        || (heading_or_title_mentions_contents && link_count >= 2)
 }
 
 /// Block-level HTML/XHTML elements that should produce newlines before/after their content.
@@ -162,21 +307,20 @@ const SKIP_ELEMENTS: &[&str] = &[
 /// at block-level element boundaries.
 pub(super) fn extract_text_from_xhtml(xhtml: &str) -> String {
     // Try direct XML tree traversal first (lossless path).
-    if let Some((text, _)) = try_extract_via_roxmltree(xhtml) {
+    if let Some(text) = try_extract_via_roxmltree(xhtml) {
         return text;
     }
 
     // Fallback: strip HTML tags character-by-character.
-    strip_html_tags(xhtml)
+    let normalized = normalize_xhtml(xhtml);
+    strip_html_tags(&normalized)
 }
 
 /// Attempt to extract plain text via `roxmltree` XML parsing.
 ///
 /// Returns `None` if the document cannot be parsed as XML/XHTML.
-fn try_extract_via_roxmltree(xhtml: &str) -> Option<(String, bool)> {
-    // Remove DOCTYPE declaration to avoid XXE/DTD parsing issues with roxmltree.
-    // roxmltree rejects DTDs for security, so we strip them before parsing.
-    let sanitized = strip_doctype(xhtml);
+fn try_extract_via_roxmltree(xhtml: &str) -> Option<String> {
+    let sanitized = normalize_xhtml(xhtml);
 
     match roxmltree::Document::parse(&sanitized) {
         Ok(doc) => {
@@ -189,75 +333,62 @@ fn try_extract_via_roxmltree(xhtml: &str) -> Option<(String, bool)> {
             let result = collapse_blank_lines(&output);
             let result = result.trim().to_string();
 
-            if result.is_empty() { None } else { Some((result, true)) }
+            if result.is_empty() { None } else { Some(result) }
         }
         Err(_) => None,
     }
 }
 
-/// Re-export of `strip_doctype` for use in `mod.rs` title extraction.
-pub(super) fn strip_doctype_for_title(xml: &str) -> String {
-    strip_doctype(xml)
+/// Normalize XHTML so downstream HTML/XHTML processing sees chapter markup
+/// without EPUB packaging prelude.
+///
+/// This strips XML declarations and doctypes, which are valid in EPUB chapter
+/// files but should not surface in extracted Markdown or interfere with safe parsing.
+pub(super) fn normalize_xhtml(xml: &str) -> String {
+    strip_xml_prelude(xml)
 }
 
-/// Remove DOCTYPE declaration from XML/XHTML to allow safe parsing with roxmltree.
+/// Remove XML declarations and DOCTYPE declarations from XML/XHTML.
 ///
-/// DTD declarations can cause security issues (XXE attacks), and roxmltree rejects them.
-/// This function safely removes the DOCTYPE declaration while preserving the rest of the document.
-fn strip_doctype(xml: &str) -> String {
-    // Find and remove <!DOCTYPE ...> declarations. We need to handle nested brackets
-    // in the DOCTYPE (e.g., <!DOCTYPE html [internal subset]>)
-    let mut result = String::new();
-    let mut in_doctype = false;
-    let mut bracket_depth = 0;
+/// EPUB chapter files often begin with an XML declaration followed by a DOCTYPE.
+/// Those are packaging details, not body content, and `roxmltree` rejects DTDs.
+fn strip_xml_prelude(xml: &str) -> String {
+    let mut rest = xml.trim_start();
 
-    let mut chars = xml.chars().peekable();
+    loop {
+        if let Some(tail) = rest.strip_prefix("<?xml")
+            && let Some(end) = tail.find("?>")
+        {
+            rest = tail[end + 2..].trim_start();
+            continue;
+        }
 
-    while let Some(ch) = chars.next() {
-        if !in_doctype && ch == '<' {
-            // Check if this starts a DOCTYPE
-            let start_pos = result.len();
-            result.push(ch);
+        if let Some(tail) = rest.strip_prefix("<!DOCTYPE")
+            && let Some(end) = find_doctype_end(tail)
+        {
+            rest = tail[end + 1..].trim_start();
+            continue;
+        }
 
-            if chars.peek() == Some(&'!') {
-                result.push(chars.next().unwrap());
-                let next_chars: String = chars.clone().take(7).collect();
-                if next_chars.starts_with("DOCTYPE") {
-                    // This is a DOCTYPE declaration, skip it
-                    in_doctype = true;
-                    bracket_depth = 0;
-                    // Consume the DOCTYPE keyword and everything up to the closing >
-                    for c in chars.by_ref() {
-                        if c == '[' {
-                            bracket_depth += 1;
-                        } else if c == ']' {
-                            bracket_depth -= 1;
-                        } else if c == '>' && bracket_depth == 0 {
-                            in_doctype = false;
-                            break;
-                        }
-                    }
-                    // Remove what we added to result (the '<!')
-                    result.truncate(start_pos);
-                } else {
-                    // Not a DOCTYPE, keep what we added
-                }
-            }
-        } else if in_doctype {
-            // Already in a DOCTYPE, continue consuming
-            if ch == '[' {
-                bracket_depth += 1;
-            } else if ch == ']' {
-                bracket_depth -= 1;
-            } else if ch == '>' && bracket_depth == 0 {
-                in_doctype = false;
-            }
-        } else {
-            result.push(ch);
+        break;
+    }
+
+    rest.to_string()
+}
+
+fn find_doctype_end(tail: &str) -> Option<usize> {
+    let mut bracket_depth: usize = 0;
+
+    for (idx, ch) in tail.char_indices() {
+        match ch {
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '>' if bracket_depth == 0 => return Some(idx),
+            _ => {}
         }
     }
 
-    result
+    None
 }
 
 /// Recursively visit an XML node and append its text to `output`.

--- a/crates/kreuzberg/src/extractors/epub/metadata.rs
+++ b/crates/kreuzberg/src/extractors/epub/metadata.rs
@@ -5,7 +5,9 @@
 
 use crate::Result;
 use roxmltree;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::parsing::resolve_path;
 
 /// Metadata extracted from OPF (Open Packaging Format) file
 #[derive(Debug, Default, Clone)]
@@ -27,11 +29,234 @@ pub(super) struct OepbMetadata {
     pub(super) cover_image_href: Option<String>,
 }
 
-/// Extract metadata from EPUB OPF file
-pub(super) fn extract_metadata(opf_xml: &str) -> Result<(OepbMetadata, BTreeMap<String, serde_json::Value>)> {
-    let mut additional_metadata = BTreeMap::new();
+#[derive(Debug, Clone)]
+pub(super) struct EpubPackageDocument {
+    pub(super) metadata: OepbMetadata,
+    pub(super) manifest: BTreeMap<String, ManifestItem>,
+    pub(super) spine_items: Vec<EpubSpineItem>,
+    guide_toc_paths: BTreeSet<String>,
+}
 
-    let (epub_metadata, _) = parse_opf(opf_xml)?;
+impl EpubPackageDocument {
+    pub(super) fn is_guide_toc_candidate_path(&self, path: &str) -> bool {
+        self.guide_toc_paths.contains(path)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+/// A spine entry extracted from the OPF package document.
+pub(super) struct EpubSpineItem {
+    pub(super) idref: String,
+}
+
+#[derive(Debug, Clone)]
+/// Manifest metadata used to enrich spine entries after OPF parsing.
+pub(super) struct ManifestItem {
+    pub(super) raw_href: String,
+    pub(super) path: Option<String>,
+    path_resolution_error: Option<String>,
+    pub(super) media_type: Option<String>,
+    pub(super) fallback: Option<String>,
+}
+
+impl ManifestItem {
+    pub(super) fn is_renderable_body_document(&self) -> bool {
+        matches!(
+            self.media_type.as_deref(),
+            Some("application/xhtml+xml") | Some("application/x-dtbook+xml")
+        ) || self.media_type.is_none() && has_renderable_extension(&self.raw_href)
+    }
+
+    pub(super) fn resolved_path(&self) -> std::result::Result<&str, String> {
+        self.path.as_deref().ok_or_else(|| {
+            self.path_resolution_error
+                .clone()
+                .unwrap_or_else(|| format!("unable to resolve manifest href '{}'", self.raw_href))
+        })
+    }
+}
+
+fn has_renderable_extension(href: &str) -> bool {
+    let href = href
+        .split_once('#')
+        .map(|(path, _)| path)
+        .unwrap_or(href)
+        .rsplit('/')
+        .next()
+        .unwrap_or(href);
+
+    href.rsplit_once('.')
+        .map(|(_, ext)| {
+            matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "xhtml" | "html" | "htm" | "xml" | "dtbook"
+            )
+        })
+        .unwrap_or(false)
+}
+
+/// Parse OPF file and extract metadata and spine order
+pub(super) fn parse_opf(xml: &str, opf_dir: &str) -> Result<EpubPackageDocument> {
+    match roxmltree::Document::parse(xml) {
+        Ok(doc) => {
+            let root = doc.root();
+
+            let mut package = EpubPackageDocument {
+                metadata: OepbMetadata::default(),
+                manifest: BTreeMap::new(),
+                spine_items: Vec::new(),
+                guide_toc_paths: BTreeSet::new(),
+            };
+            let mut manifest: BTreeMap<String, ManifestItem> = BTreeMap::new();
+
+            for node in root.descendants() {
+                match node.tag_name().name() {
+                    "title" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.title = Some(text.trim().to_string());
+                        }
+                    }
+                    "creator" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.creator = Some(text.trim().to_string());
+                        }
+                    }
+                    "date" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.date = Some(text.trim().to_string());
+                        }
+                    }
+                    "language" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.language = Some(text.trim().to_string());
+                        }
+                    }
+                    "identifier" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.identifier = Some(text.trim().to_string());
+                        }
+                    }
+                    "publisher" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.publisher = Some(text.trim().to_string());
+                        }
+                    }
+                    "subject" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.subject = Some(text.trim().to_string());
+                        }
+                    }
+                    "description" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.description = Some(text.trim().to_string());
+                        }
+                    }
+                    "rights" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.rights = Some(text.trim().to_string());
+                        }
+                    }
+                    "coverage" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.coverage = Some(text.trim().to_string());
+                        }
+                    }
+                    "format" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.format = Some(text.trim().to_string());
+                        }
+                    }
+                    "relation" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.relation = Some(text.trim().to_string());
+                        }
+                    }
+                    "source" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.source = Some(text.trim().to_string());
+                        }
+                    }
+                    "type" => {
+                        if let Some(text) = node.text() {
+                            package.metadata.dc_type = Some(text.trim().to_string());
+                        }
+                    }
+                    "item" => {
+                        if let Some(id) = node.attribute("id")
+                            && let Some(href) = node.attribute("href")
+                        {
+                            let (path, path_resolution_error) = match resolve_path(opf_dir, href) {
+                                Ok(resolved_href) => (Some(resolved_href.path), None),
+                                Err(err) => (None, Some(err.to_string())),
+                            };
+                            manifest.insert(
+                                id.to_string(),
+                                ManifestItem {
+                                    raw_href: href.to_string(),
+                                    path,
+                                    path_resolution_error,
+                                    media_type: node.attribute("media-type").map(ToString::to_string),
+                                    fallback: node.attribute("fallback").map(ToString::to_string),
+                                },
+                            );
+                        }
+                    }
+                    "reference" => {
+                        if node
+                            .attribute("type")
+                            .is_some_and(|kind| kind.eq_ignore_ascii_case("toc"))
+                            && let Some(href) = node.attribute("href")
+                        {
+                            let resolved_href = resolve_path(opf_dir, href)?;
+                            package.guide_toc_paths.insert(resolved_href.path);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Find cover image via <meta name="cover" content="item-id"/>
+            let mut cover_item_id = None;
+            for node in root.descendants() {
+                if node.tag_name().name() == "meta"
+                    && node.attribute("name") == Some("cover")
+                    && let Some(content) = node.attribute("content")
+                {
+                    cover_item_id = Some(content.to_string());
+                    break;
+                }
+            }
+
+            if let Some(cover_id) = cover_item_id
+                && let Some(href) = manifest.get(&cover_id)
+                && let Ok(path) = href.resolved_path()
+            {
+                package.metadata.cover_image_href = Some(path.to_string());
+            }
+
+            for node in root.descendants() {
+                if node.tag_name().name() == "itemref"
+                    && let Some(idref) = node.attribute("idref")
+                {
+                    package.spine_items.push(EpubSpineItem {
+                        idref: idref.to_string(),
+                    });
+                }
+            }
+
+            package.manifest = manifest;
+            Ok(package)
+        }
+        Err(e) => Err(crate::KreuzbergError::Parsing {
+            message: format!("Failed to parse OPF file: {}", e),
+            source: None,
+        }),
+    }
+}
+
+/// Convert parsed EPUB metadata into the extractor's generic metadata map.
+pub(super) fn build_additional_metadata(epub_metadata: &OepbMetadata) -> BTreeMap<String, serde_json::Value> {
+    let mut additional_metadata = BTreeMap::new();
 
     if let Some(ref identifier) = epub_metadata.identifier {
         additional_metadata.insert("identifier".to_string(), serde_json::json!(identifier.clone()));
@@ -77,134 +302,5 @@ pub(super) fn extract_metadata(opf_xml: &str) -> Result<(OepbMetadata, BTreeMap<
         additional_metadata.insert("cover_image".to_string(), serde_json::json!(cover_href.clone()));
     }
 
-    Ok((epub_metadata, additional_metadata))
-}
-
-/// Parse OPF file and extract metadata and spine order
-pub(super) fn parse_opf(xml: &str) -> Result<(OepbMetadata, Vec<String>)> {
-    match roxmltree::Document::parse(xml) {
-        Ok(doc) => {
-            let root = doc.root();
-
-            let mut metadata = OepbMetadata::default();
-            let mut manifest: BTreeMap<String, String> = BTreeMap::new();
-            let mut spine_order: Vec<String> = Vec::new();
-
-            for node in root.descendants() {
-                match node.tag_name().name() {
-                    "title" => {
-                        if let Some(text) = node.text() {
-                            metadata.title = Some(text.trim().to_string());
-                        }
-                    }
-                    "creator" => {
-                        if let Some(text) = node.text() {
-                            metadata.creator = Some(text.trim().to_string());
-                        }
-                    }
-                    "date" => {
-                        if let Some(text) = node.text() {
-                            metadata.date = Some(text.trim().to_string());
-                        }
-                    }
-                    "language" => {
-                        if let Some(text) = node.text() {
-                            metadata.language = Some(text.trim().to_string());
-                        }
-                    }
-                    "identifier" => {
-                        if let Some(text) = node.text() {
-                            metadata.identifier = Some(text.trim().to_string());
-                        }
-                    }
-                    "publisher" => {
-                        if let Some(text) = node.text() {
-                            metadata.publisher = Some(text.trim().to_string());
-                        }
-                    }
-                    "subject" => {
-                        if let Some(text) = node.text() {
-                            metadata.subject = Some(text.trim().to_string());
-                        }
-                    }
-                    "description" => {
-                        if let Some(text) = node.text() {
-                            metadata.description = Some(text.trim().to_string());
-                        }
-                    }
-                    "rights" => {
-                        if let Some(text) = node.text() {
-                            metadata.rights = Some(text.trim().to_string());
-                        }
-                    }
-                    "coverage" => {
-                        if let Some(text) = node.text() {
-                            metadata.coverage = Some(text.trim().to_string());
-                        }
-                    }
-                    "format" => {
-                        if let Some(text) = node.text() {
-                            metadata.format = Some(text.trim().to_string());
-                        }
-                    }
-                    "relation" => {
-                        if let Some(text) = node.text() {
-                            metadata.relation = Some(text.trim().to_string());
-                        }
-                    }
-                    "source" => {
-                        if let Some(text) = node.text() {
-                            metadata.source = Some(text.trim().to_string());
-                        }
-                    }
-                    "type" => {
-                        if let Some(text) = node.text() {
-                            metadata.dc_type = Some(text.trim().to_string());
-                        }
-                    }
-                    "item" => {
-                        if let Some(id) = node.attribute("id")
-                            && let Some(href) = node.attribute("href")
-                        {
-                            manifest.insert(id.to_string(), href.to_string());
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            // Find cover image via <meta name="cover" content="item-id"/>
-            let mut cover_item_id = None;
-            for node in root.descendants() {
-                if node.tag_name().name() == "meta"
-                    && node.attribute("name") == Some("cover")
-                    && let Some(content) = node.attribute("content")
-                {
-                    cover_item_id = Some(content.to_string());
-                    break;
-                }
-            }
-
-            if let Some(cover_id) = cover_item_id
-                && let Some(href) = manifest.get(&cover_id)
-            {
-                metadata.cover_image_href = Some(href.clone());
-            }
-
-            for node in root.descendants() {
-                if node.tag_name().name() == "itemref"
-                    && let Some(idref) = node.attribute("idref")
-                    && let Some(href) = manifest.get(idref)
-                {
-                    spine_order.push(href.clone());
-                }
-            }
-
-            Ok((metadata, spine_order))
-        }
-        Err(e) => Err(crate::KreuzbergError::Parsing {
-            message: format!("Failed to parse OPF file: {}", e),
-            source: None,
-        }),
-    }
+    additional_metadata
 }

--- a/crates/kreuzberg/src/extractors/epub/mod.rs
+++ b/crates/kreuzberg/src/extractors/epub/mod.rs
@@ -16,20 +16,21 @@ mod metadata;
 mod parsing;
 
 use crate::Result;
-use crate::core::config::ExtractionConfig;
+use crate::core::config::{ExtractionConfig, OutputFormat};
 use crate::plugins::{DocumentExtractor, Plugin};
 use crate::types::ExtractionResult;
 use crate::types::Metadata;
+use crate::types::ProcessingWarning;
 use ahash::AHashMap;
 use async_trait::async_trait;
 use std::borrow::Cow;
 use std::io::Cursor;
 use zip::ZipArchive;
 
-use content::extract_content;
 use content::extract_text_from_xhtml;
-use metadata::extract_metadata;
-use parsing::{parse_container_xml, read_file_from_zip, resolve_path};
+use content::read_body_documents;
+use metadata::{build_additional_metadata, parse_opf};
+use parsing::{parse_container_xml, read_file_from_zip};
 
 /// EPUB format extractor using permissive-licensed dependencies.
 ///
@@ -51,73 +52,133 @@ impl Default for EpubExtractor {
 }
 
 #[cfg(feature = "office")]
+struct RenderedSpineDocument {
+    content_fragment: String,
+    content_fully_converted: bool,
+    document: Option<crate::types::document_structure::DocumentStructure>,
+    warnings: Vec<ProcessingWarning>,
+}
+
+#[cfg(feature = "office")]
+fn trim_trailing_newlines(s: &str) -> &str {
+    s.trim_end_matches(['\n', '\r'])
+}
+
+#[cfg(feature = "office")]
 impl EpubExtractor {
-    /// Build a `DocumentStructure` from the EPUB spine.
-    ///
-    /// Uses the full HTML structure walker for each chapter's XHTML, preserving
-    /// inline formatting annotations (bold, italic, links, etc.) and proper
-    /// element types (lists, tables, code blocks).
-    ///
-    /// Accepts the already-parsed `spine_hrefs` from content extraction to avoid
-    /// redundantly re-reading and re-parsing the OPF file from the ZIP archive.
+    fn build_fallback_document_structure(
+        document: &content::EpubSpineDocument,
+        index: usize,
+    ) -> crate::types::document_structure::DocumentStructure {
+        use crate::types::builder::DocumentStructureBuilder;
+
+        let mut builder = DocumentStructureBuilder::new().source_format("epub");
+        let chapter_title =
+            extract_title_from_xhtml(&document.xhtml).unwrap_or_else(|| format!("Chapter {}", index + 1));
+        builder.push_heading(1, &chapter_title, None, None);
+
+        let text = extract_text_from_xhtml(&document.xhtml);
+        for paragraph in text.split("\n\n") {
+            let trimmed = paragraph.trim();
+            if !trimmed.is_empty() {
+                builder.push_paragraph(trimmed, vec![], None, None);
+            }
+        }
+
+        builder.build()
+    }
+
+    /// Render a spine document once.
+    fn render_spine_document(
+        document: &content::EpubSpineDocument,
+        index: usize,
+        config: &ExtractionConfig,
+    ) -> RenderedSpineDocument {
+        let wants_markup = matches!(config.output_format, OutputFormat::Markdown | OutputFormat::Djot);
+        let mut warnings = Vec::new();
+
+        let (content_fragment, content_fully_converted) = if wants_markup {
+            match crate::extraction::html::convert_html_to_markdown_with_metadata(
+                &document.xhtml,
+                config.html_options.clone(),
+                Some(config.output_format),
+            ) {
+                Ok((converted, _)) => (trim_trailing_newlines(&converted).to_string(), true),
+                Err(err) => {
+                    warnings.push(ProcessingWarning {
+                        source: std::borrow::Cow::Borrowed("epub"),
+                        message: std::borrow::Cow::Owned(format!(
+                            "XHTML conversion failed for spine item '{}'; falling back to plain text: {}",
+                            document.file_path, err
+                        )),
+                    });
+                    (extract_text_from_xhtml(&document.xhtml).trim_end().to_string(), false)
+                }
+            }
+        } else {
+            (extract_text_from_xhtml(&document.xhtml).trim_end().to_string(), true)
+        };
+
+        let document = if config.include_document_structure {
+            let chapter_structure = crate::extraction::html::structure::build_document_structure(&document.xhtml);
+
+            if chapter_structure.nodes.is_empty() {
+                warnings.push(ProcessingWarning {
+                    source: std::borrow::Cow::Borrowed("epub"),
+                    message: std::borrow::Cow::Owned(format!(
+                        "Document structure extraction produced no nodes for spine item '{}'; falling back to plain-text structure",
+                        document.file_path
+                    )),
+                });
+                Some(Self::build_fallback_document_structure(document, index))
+            } else {
+                Some(chapter_structure)
+            }
+        } else {
+            None
+        };
+
+        RenderedSpineDocument {
+            content_fragment,
+            content_fully_converted,
+            document,
+            warnings,
+        }
+    }
+
     fn build_document_structure(
-        archive: &mut ZipArchive<Cursor<Vec<u8>>>,
-        spine_hrefs: &[String],
-        manifest_dir: &str,
+        rendered_documents: &[RenderedSpineDocument],
     ) -> Option<crate::types::document_structure::DocumentStructure> {
         use crate::types::builder::DocumentStructureBuilder;
 
         let mut builder = DocumentStructureBuilder::new().source_format("epub");
+        let mut has_nodes = false;
 
-        for (index, href) in spine_hrefs.iter().enumerate() {
-            let file_path = resolve_path(manifest_dir, href);
-            let xhtml_content = match read_file_from_zip(archive, &file_path) {
-                Ok(content) => content,
-                Err(_) => continue,
+        for rendered in rendered_documents {
+            let Some(chapter_structure) = &rendered.document else {
+                continue;
             };
 
-            // Use the HTML structure walker for rich extraction (inline formatting,
-            // links, lists, etc.) from each chapter's XHTML content.
-            let sanitized = content::strip_doctype_for_title(&xhtml_content);
-            let chapter_structure = crate::extraction::html::structure::build_document_structure(&sanitized);
-
-            if chapter_structure.nodes.is_empty() {
-                // Fallback: extract plain text if structure walker produces nothing
-                let chapter_title =
-                    extract_title_from_xhtml(&xhtml_content).unwrap_or_else(|| format!("Chapter {}", index + 1));
-                builder.push_heading(1, &chapter_title, None, None);
-
-                let text = extract_text_from_xhtml(&xhtml_content);
-                for paragraph in text.split("\n\n") {
-                    let trimmed = paragraph.trim();
-                    if !trimmed.is_empty() {
-                        builder.push_paragraph(trimmed, vec![], None, None);
-                    }
-                }
-            } else {
-                // Merge the chapter's nodes into our combined structure.
-                // Use push_raw with the node's content layer to preserve structure.
-                for node in &chapter_structure.nodes {
-                    builder.push_raw(
-                        node.content.clone(),
-                        None,
-                        None,
-                        node.content_layer,
-                        node.annotations.clone(),
-                    );
-                }
+            for node in &chapter_structure.nodes {
+                has_nodes = true;
+                builder.push_raw(
+                    node.content.clone(),
+                    None,
+                    None,
+                    node.content_layer,
+                    node.annotations.clone(),
+                );
             }
         }
 
-        Some(builder.build())
+        if has_nodes { Some(builder.build()) } else { None }
     }
 }
 
 /// Extract the first heading text from XHTML content.
 #[cfg(feature = "office")]
 fn extract_title_from_xhtml(xhtml: &str) -> Option<String> {
-    // Strip DOCTYPE for roxmltree
-    let sanitized = content::strip_doctype_for_title(xhtml);
+    let sanitized = content::normalize_xhtml(xhtml);
     let doc = roxmltree::Document::parse(&sanitized).ok()?;
 
     for node in doc.root().descendants() {
@@ -203,11 +264,30 @@ impl DocumentExtractor for EpubExtractor {
         };
 
         let opf_xml = read_file_from_zip(&mut archive, &opf_path)?;
-
-        let (extracted_content, fully_converted, processing_warnings, spine_hrefs) =
-            extract_content(&mut archive, &opf_path, &manifest_dir, config)?;
-
-        let (epub_metadata, additional_metadata) = extract_metadata(&opf_xml)?;
+        let package = parse_opf(&opf_xml, &manifest_dir)?;
+        let additional_metadata = build_additional_metadata(&package.metadata);
+        let (documents, mut processing_warnings) = read_body_documents(&mut archive, &package)?;
+        let mut rendered_documents = Vec::with_capacity(documents.len());
+        for (index, document) in documents.iter().enumerate() {
+            let mut rendered = Self::render_spine_document(document, index, config);
+            processing_warnings.append(&mut rendered.warnings);
+            rendered_documents.push(rendered);
+        }
+        let mut extracted_content = String::new();
+        for rendered in &rendered_documents {
+            if !rendered.content_fragment.is_empty() {
+                if !extracted_content.is_empty() && !extracted_content.ends_with('\n') {
+                    extracted_content.push('\n');
+                }
+                extracted_content.push_str(&rendered.content_fragment);
+                extracted_content.push('\n');
+            }
+        }
+        let extracted_content = trim_trailing_newlines(&extracted_content).to_string();
+        let fully_converted = matches!(config.output_format, OutputFormat::Markdown | OutputFormat::Djot)
+            && rendered_documents
+                .iter()
+                .all(|rendered| rendered.content_fully_converted);
         let metadata_map: AHashMap<Cow<'static, str>, serde_json::Value> = additional_metadata
             .into_iter()
             .map(|(k, v)| (Cow::Owned(k), v))
@@ -227,7 +307,7 @@ impl DocumentExtractor for EpubExtractor {
 
         // Build document structure from spine chapters (only when requested)
         let document = if config.include_document_structure {
-            Self::build_document_structure(&mut archive, &spine_hrefs, &manifest_dir)
+            Self::build_document_structure(&rendered_documents)
         } else {
             None
         };
@@ -236,10 +316,10 @@ impl DocumentExtractor for EpubExtractor {
             content: extracted_content,
             mime_type: mime_type.to_string().into(),
             metadata: Metadata {
-                title: epub_metadata.title,
-                authors: epub_metadata.creator.map(|c| vec![c]),
-                language: epub_metadata.language,
-                created_at: epub_metadata.date,
+                title: package.metadata.title,
+                authors: package.metadata.creator.map(|c| vec![c]),
+                language: package.metadata.language,
+                created_at: package.metadata.date,
                 additional: metadata_map,
                 output_format: pre_formatted,
                 ..Default::default()
@@ -337,7 +417,9 @@ mod tests {
   </spine>
 </package>"#;
 
-        let (epub_meta, additional) = metadata::extract_metadata(opf).expect("Metadata parse failed");
+        let package = metadata::parse_opf(opf, "").expect("Metadata parse failed");
+        let epub_meta = package.metadata;
+        let additional = metadata::build_additional_metadata(&epub_meta);
         assert_eq!(epub_meta.title, Some("Test Book".to_string()));
         assert_eq!(epub_meta.coverage, Some("Worldwide".to_string()));
         assert_eq!(epub_meta.format, Some("application/epub+zip".to_string()));

--- a/crates/kreuzberg/src/extractors/epub/parsing.rs
+++ b/crates/kreuzberg/src/extractors/epub/parsing.rs
@@ -8,6 +8,12 @@ use roxmltree;
 use std::io::Cursor;
 use zip::ZipArchive;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct CanonicalHref {
+    pub(super) path: String,
+    pub(super) fragment: Option<String>,
+}
+
 /// Parse container.xml to find the OPF file path
 pub(super) fn parse_container_xml(xml: &str) -> Result<String> {
     match roxmltree::Document::parse(xml) {
@@ -51,15 +57,53 @@ pub(super) fn read_file_from_zip(archive: &mut ZipArchive<Cursor<Vec<u8>>>, path
     }
 }
 
-/// Resolve a relative path within the manifest directory
-pub(super) fn resolve_path(base_dir: &str, relative_path: &str) -> String {
-    if relative_path.starts_with('/') {
+fn split_href(href: &str) -> (&str, Option<&str>) {
+    href.split_once('#')
+        .map_or((href, None), |(path, fragment)| (path, Some(fragment)))
+}
+
+/// Resolve an EPUB href relative to the OPF directory.
+///
+/// The returned path is package-relative and normalized. Attempts to escape the
+/// EPUB package root via leading `..` segments are rejected.
+pub(super) fn resolve_path(base_dir: &str, href: &str) -> Result<CanonicalHref> {
+    let (relative_path, fragment) = split_href(href);
+    let combined = if relative_path.starts_with('/') {
         relative_path.trim_start_matches('/').to_string()
     } else if base_dir.is_empty() || base_dir == "." {
         relative_path.to_string()
     } else {
         format!("{}/{}", base_dir.trim_end_matches('/'), relative_path)
+    };
+
+    let mut normalized = Vec::new();
+    for segment in combined.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if normalized.pop().is_none() {
+                    return Err(crate::KreuzbergError::Parsing {
+                        message: format!("EPUB href '{}' escapes the package root", href),
+                        source: None,
+                    });
+                }
+            }
+            _ => normalized.push(segment),
+        }
     }
+
+    let path = normalized.join("/");
+    if path.is_empty() {
+        return Err(crate::KreuzbergError::Parsing {
+            message: format!("EPUB href '{}' does not contain a resolvable path", href),
+            source: None,
+        });
+    }
+
+    Ok(CanonicalHref {
+        path,
+        fragment: fragment.filter(|value| !value.is_empty()).map(ToString::to_string),
+    })
 }
 
 #[cfg(test)]
@@ -68,19 +112,42 @@ mod tests {
 
     #[test]
     fn test_resolve_path_with_base_dir() {
-        let result = resolve_path("OEBPS", "chapter.xhtml");
-        assert_eq!(result, "OEBPS/chapter.xhtml");
+        let result = resolve_path("OEBPS", "chapter.xhtml").expect("path should resolve");
+        assert_eq!(result.path, "OEBPS/chapter.xhtml");
+        assert_eq!(result.fragment, None);
     }
 
     #[test]
     fn test_resolve_path_absolute() {
-        let result = resolve_path("OEBPS", "/chapter.xhtml");
-        assert_eq!(result, "chapter.xhtml");
+        let result = resolve_path("OEBPS", "/chapter.xhtml").expect("path should resolve");
+        assert_eq!(result.path, "chapter.xhtml");
+        assert_eq!(result.fragment, None);
     }
 
     #[test]
     fn test_resolve_path_empty_base() {
-        let result = resolve_path("", "chapter.xhtml");
-        assert_eq!(result, "chapter.xhtml");
+        let result = resolve_path("", "chapter.xhtml").expect("path should resolve");
+        assert_eq!(result.path, "chapter.xhtml");
+        assert_eq!(result.fragment, None);
+    }
+
+    #[test]
+    fn test_resolve_path_parent_segment() {
+        let result = resolve_path("OEBPS/text", "../images/cover.xhtml").expect("path should resolve");
+        assert_eq!(result.path, "OEBPS/images/cover.xhtml");
+        assert_eq!(result.fragment, None);
+    }
+
+    #[test]
+    fn test_resolve_path_preserves_fragment() {
+        let result = resolve_path("OEBPS", "toc.xhtml#nav").expect("path should resolve");
+        assert_eq!(result.path, "OEBPS/toc.xhtml");
+        assert_eq!(result.fragment.as_deref(), Some("nav"));
+    }
+
+    #[test]
+    fn test_resolve_path_rejects_root_escape() {
+        let err = resolve_path("", "../chapter.xhtml").expect_err("path should be rejected");
+        assert!(err.to_string().contains("escapes the package root"));
     }
 }

--- a/crates/kreuzberg/tests/epub_native_extractor_tests.rs
+++ b/crates/kreuzberg/tests/epub_native_extractor_tests.rs
@@ -228,7 +228,8 @@ async fn test_native_epub_deterministic_extraction() {
 async fn test_native_epub_no_content_loss() {
     let epub_files = vec![
         ("epub2_cover.epub", 10),
-        ("epub2_no_cover.epub", 50),
+        // This fixture contains a single title line in one XHTML body document.
+        ("epub2_no_cover.epub", 10),
         ("img.epub", 50),
         ("features.epub", 1000),
         ("wasteland.epub", 2000),

--- a/crates/kreuzberg/tests/epub_spine_semantics_tests.rs
+++ b/crates/kreuzberg/tests/epub_spine_semantics_tests.rs
@@ -1,0 +1,595 @@
+//! EPUB integration tests.
+//!
+//! These tests validate EPUB-specific spine and navigation semantics.
+
+#![cfg(feature = "office")]
+
+use kreuzberg::core::config::{ExtractionConfig, OutputFormat};
+use kreuzberg::extractors::EpubExtractor;
+use kreuzberg::plugins::DocumentExtractor;
+use std::io::{Cursor, Write};
+use zip::write::FileOptions;
+
+fn start_epub_writer(cursor: &mut Cursor<Vec<u8>>) -> zip::ZipWriter<&mut Cursor<Vec<u8>>> {
+    let mut writer = zip::ZipWriter::new(cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+
+    writer.start_file("mimetype", options).expect("zip start_file failed");
+    writer
+        .write_all(b"application/epub+zip")
+        .expect("zip write mimetype failed");
+    writer
+        .add_directory("META-INF/", options)
+        .expect("zip add_directory failed");
+
+    writer
+}
+
+fn build_epub3_with_navigation_and_auxiliary_spine_items() -> Vec<u8> {
+    let container_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    let opf_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Spine Semantics Test Book</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="intro" href="intro.xhtml" media-type="application/xhtml+xml"/>
+    <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>
+    <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="appendix" href="appendix.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="intro"/>
+    <itemref idref="nav"/>
+    <itemref idref="chapter1"/>
+    <itemref idref="appendix" linear="no"/>
+  </spine>
+</package>"#;
+
+    let intro_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Intro</title></head>
+  <body>
+    <h1>Intro</h1>
+    <p>Opening paragraph.</p>
+  </body>
+</html>"#;
+
+    let nav_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Table of Contents</title></head>
+  <body>
+    <p>Reading note outside navigation.</p>
+    <nav epub:type="toc" xmlns:epub="http://www.idpf.org/2007/ops">
+      <h1>Table of Contents</h1>
+      <ol>
+        <li><a href="chapter1.xhtml">Chapter One</a></li>
+      </ol>
+    </nav>
+  </body>
+</html>"#;
+
+    let chapter_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter One</title></head>
+  <body>
+    <h1>Chapter One</h1>
+    <p>Main chapter text.</p>
+  </body>
+</html>"#;
+
+    let appendix_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Appendix</title></head>
+  <body>
+    <h1>Appendix</h1>
+    <p>Auxiliary back matter.</p>
+  </body>
+</html>"#;
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut writer = start_epub_writer(&mut cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+    writer
+        .add_directory("OEBPS/", options)
+        .expect("zip add_directory failed");
+
+    for (path, contents) in [
+        ("META-INF/container.xml", container_xml),
+        ("OEBPS/content.opf", opf_xml),
+        ("OEBPS/intro.xhtml", intro_xhtml),
+        ("OEBPS/nav.xhtml", nav_xhtml),
+        ("OEBPS/chapter1.xhtml", chapter_xhtml),
+        ("OEBPS/appendix.xhtml", appendix_xhtml),
+    ] {
+        writer.start_file(path, options).expect("zip start_file failed");
+        writer.write_all(contents.as_bytes()).expect("zip write file failed");
+    }
+
+    writer.finish().expect("zip finish failed");
+    cursor.into_inner()
+}
+
+fn build_epub2_with_guide_toc_in_spine() -> Vec<u8> {
+    let container_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    let opf_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="2.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>EPUB 2 TOC Test</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="toc-page" href="toc.xhtml" media-type="application/xhtml+xml"/>
+    <item id="chapter1" href="chapter1.xhtml" media-type="application/xhtml+xml"/>
+    <item id="appendix" href="appendix.xhtml" media-type="application/xhtml+xml"/>
+    <item id="ncx" href="toc.ncx" media-type="application/x-dtbncx+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="toc-page"/>
+    <itemref idref="chapter1"/>
+    <itemref idref="appendix" linear="no"/>
+  </spine>
+  <guide>
+    <reference type="toc" title="Contents" href="./text/../toc.xhtml#toc"/>
+  </guide>
+</package>"#;
+
+    let toc_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Contents</title></head>
+  <body>
+    <h1 id="toc">Contents</h1>
+    <ol>
+      <li><a href="chapter1.xhtml">Chapter One</a></li>
+      <li><a href="appendix.xhtml">Appendix</a></li>
+    </ol>
+  </body>
+</html>"#;
+
+    let chapter_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter One</title></head>
+  <body>
+    <h1>Chapter One</h1>
+    <p>Main chapter text.</p>
+  </body>
+</html>"#;
+
+    let appendix_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Appendix</title></head>
+  <body>
+    <h1>Appendix</h1>
+    <p>Supplemental material.</p>
+  </body>
+</html>"#;
+
+    let ncx = r#"<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <navMap>
+    <navPoint id="chapter1" playOrder="1">
+      <navLabel><text>Chapter One</text></navLabel>
+      <content src="chapter1.xhtml"/>
+    </navPoint>
+  </navMap>
+</ncx>"#;
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut writer = start_epub_writer(&mut cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+    writer
+        .add_directory("OEBPS/", options)
+        .expect("zip add_directory failed");
+
+    for (path, contents) in [
+        ("META-INF/container.xml", container_xml),
+        ("OEBPS/content.opf", opf_xml),
+        ("OEBPS/toc.xhtml", toc_xhtml),
+        ("OEBPS/chapter1.xhtml", chapter_xhtml),
+        ("OEBPS/appendix.xhtml", appendix_xhtml),
+        ("OEBPS/toc.ncx", ncx),
+    ] {
+        writer.start_file(path, options).expect("zip start_file failed");
+        writer.write_all(contents.as_bytes()).expect("zip write file failed");
+    }
+
+    writer.finish().expect("zip finish failed");
+    cursor.into_inner()
+}
+
+fn build_epub_with_fallback_content_document() -> Vec<u8> {
+    let container_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    let opf_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Fallback Test</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="chapter-foreign" href="../art/chapter.svg" media-type="image/svg+xml" fallback="chapter-xhtml"/>
+    <item id="chapter-xhtml" href="../text/chapter.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter-foreign"/>
+  </spine>
+</package>"#;
+
+    let chapter_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Fallback Chapter</title></head>
+  <body>
+    <h1>Fallback Chapter</h1>
+    <p>Resolved through manifest fallback.</p>
+  </body>
+</html>"#;
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut writer = start_epub_writer(&mut cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+    writer
+        .add_directory("OEBPS/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/package/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/text/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/art/", options)
+        .expect("zip add_directory failed");
+
+    for (path, contents) in [
+        ("META-INF/container.xml", container_xml),
+        ("OEBPS/package/content.opf", opf_xml),
+        ("OEBPS/text/chapter.xhtml", chapter_xhtml),
+        (
+            "OEBPS/art/chapter.svg",
+            "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
+        ),
+    ] {
+        writer.start_file(path, options).expect("zip start_file failed");
+        writer.write_all(contents.as_bytes()).expect("zip write file failed");
+    }
+
+    writer.finish().expect("zip finish failed");
+    cursor.into_inner()
+}
+
+fn build_epub_with_root_escaping_manifest_href() -> Vec<u8> {
+    let container_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    let opf_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Invalid Path Test</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="chapter1" href="../../../chapter.xhtml" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter1"/>
+  </spine>
+</package>"#;
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut writer = start_epub_writer(&mut cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+    writer
+        .add_directory("OEBPS/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/package/", options)
+        .expect("zip add_directory failed");
+
+    for (path, contents) in [
+        ("META-INF/container.xml", container_xml),
+        ("OEBPS/package/content.opf", opf_xml),
+    ] {
+        writer.start_file(path, options).expect("zip start_file failed");
+        writer.write_all(contents.as_bytes()).expect("zip write file failed");
+    }
+
+    writer.finish().expect("zip finish failed");
+    cursor.into_inner()
+}
+
+fn build_epub_with_unused_invalid_manifest_asset() -> Vec<u8> {
+    let container_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+  <rootfiles>
+    <rootfile full-path="OEBPS/package/content.opf" media-type="application/oebps-package+xml"/>
+  </rootfiles>
+</container>"#;
+
+    let opf_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" unique-identifier="bookid" xmlns="http://www.idpf.org/2007/opf">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Unused Asset Test</dc:title>
+    <dc:language>en</dc:language>
+  </metadata>
+  <manifest>
+    <item id="chapter1" href="../text/chapter.xhtml" media-type="application/xhtml+xml"/>
+    <item id="unused-cover" href="../../../../cover.png" media-type="image/png"/>
+  </manifest>
+  <spine>
+    <itemref idref="chapter1"/>
+  </spine>
+</package>"#;
+
+    let chapter_xhtml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head><title>Chapter One</title></head>
+  <body>
+    <h1>Chapter One</h1>
+    <p>Main chapter text.</p>
+  </body>
+</html>"#;
+
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let mut writer = start_epub_writer(&mut cursor);
+    let options = FileOptions::<()>::default().compression_method(zip::CompressionMethod::Stored);
+    writer
+        .add_directory("OEBPS/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/package/", options)
+        .expect("zip add_directory failed");
+    writer
+        .add_directory("OEBPS/text/", options)
+        .expect("zip add_directory failed");
+
+    for (path, contents) in [
+        ("META-INF/container.xml", container_xml),
+        ("OEBPS/package/content.opf", opf_xml),
+        ("OEBPS/text/chapter.xhtml", chapter_xhtml),
+    ] {
+        writer.start_file(path, options).expect("zip start_file failed");
+        writer.write_all(contents.as_bytes()).expect("zip write file failed");
+    }
+
+    writer.finish().expect("zip finish failed");
+    cursor.into_inner()
+}
+
+#[tokio::test]
+async fn test_epub3_excludes_navigation_but_keeps_non_linear_spine_content() {
+    let bytes = build_epub3_with_navigation_and_auxiliary_spine_items();
+    let extractor = EpubExtractor::new();
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        ..Default::default()
+    };
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &config)
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.processing_warnings.is_empty(),
+        "Expected no warnings, got: {:?}",
+        result.processing_warnings
+    );
+    assert!(
+        !result.content.contains("?xml version"),
+        "XML declarations should not leak into Markdown output:\n{}",
+        result.content
+    );
+    assert!(
+        !result.content.contains("Table of Contents"),
+        "Navigation documents should not be rendered as body content:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Reading note outside navigation."),
+        "Expected prose outside specialized nav content to be preserved:\n{}",
+        result.content
+    );
+    assert!(result.content.contains("# Intro"), "Expected intro heading");
+    assert!(result.content.contains("# Chapter One"), "Expected chapter heading");
+    assert!(
+        result.content.contains("# Appendix"),
+        "Non-linear spine content should still be extracted:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Auxiliary back matter."),
+        "Expected non-linear appendix text in extracted content"
+    );
+}
+
+#[tokio::test]
+async fn test_epub3_plain_output_excludes_specialized_navigation_but_keeps_body_prose() {
+    let bytes = build_epub3_with_navigation_and_auxiliary_spine_items();
+    let extractor = EpubExtractor::new();
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &ExtractionConfig::default())
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.content.contains("Reading note outside navigation."),
+        "Expected prose outside specialized nav content to be preserved:\n{}",
+        result.content
+    );
+    assert!(
+        !result.content.contains("Table of Contents"),
+        "Specialized navigation content should stay out of plain-text extraction:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Main chapter text."),
+        "Expected real chapter body content in plain-text extraction:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Auxiliary back matter."),
+        "Expected non-linear spine prose to remain in plain-text extraction:\n{}",
+        result.content
+    );
+}
+
+#[tokio::test]
+async fn test_epub_document_structure_excludes_navigation_but_keeps_non_linear_spine_content() {
+    let bytes = build_epub3_with_navigation_and_auxiliary_spine_items();
+    let extractor = EpubExtractor::new();
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        include_document_structure: true,
+        ..Default::default()
+    };
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &config)
+        .await
+        .expect("EPUB extraction should succeed");
+
+    let document = result.document.expect("Document structure should be present");
+    let all_text = document
+        .nodes
+        .iter()
+        .filter_map(|node| node.content.text())
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    assert!(
+        all_text.contains("Intro"),
+        "Expected intro content in document structure"
+    );
+    assert!(
+        all_text.contains("Chapter One"),
+        "Expected chapter content in document structure"
+    );
+    assert!(
+        all_text.contains("Reading note outside navigation."),
+        "Expected non-nav prose from the navigation document in document structure"
+    );
+    assert!(
+        all_text.contains("Appendix"),
+        "Expected non-linear appendix content in document structure"
+    );
+    assert!(
+        !all_text.contains("Table of Contents"),
+        "Navigation documents should be excluded from document structure:\n{}",
+        all_text
+    );
+}
+
+#[tokio::test]
+async fn test_epub2_guide_toc_document_is_excluded_but_auxiliary_content_remains() {
+    let bytes = build_epub2_with_guide_toc_in_spine();
+    let extractor = EpubExtractor::new();
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &ExtractionConfig::default())
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        !result.content.contains("Contents"),
+        "EPUB 2 guide TOC document should not be rendered as body content:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Chapter One"),
+        "Expected main chapter content in EPUB 2 extraction"
+    );
+    assert!(
+        result.content.contains("Supplemental material."),
+        "Expected non-linear appendix content in EPUB 2 extraction"
+    );
+}
+
+#[tokio::test]
+async fn test_epub_ignores_invalid_unused_manifest_assets_when_body_content_is_valid() {
+    let bytes = build_epub_with_unused_invalid_manifest_asset();
+    let extractor = EpubExtractor::new();
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &ExtractionConfig::default())
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.content.contains("Chapter One"),
+        "Expected valid spine content to be extracted"
+    );
+    assert!(
+        result.content.contains("Main chapter text."),
+        "Expected chapter body text to be extracted"
+    );
+}
+
+#[tokio::test]
+async fn test_epub_manifest_fallback_resolves_renderable_body_document() {
+    let bytes = build_epub_with_fallback_content_document();
+    let extractor = EpubExtractor::new();
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        ..Default::default()
+    };
+
+    let result = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &config)
+        .await
+        .expect("EPUB extraction should succeed");
+
+    assert!(
+        result.processing_warnings.is_empty(),
+        "Expected fallback resolution without warnings, got: {:?}",
+        result.processing_warnings
+    );
+    assert!(
+        result.content.contains("# Fallback Chapter"),
+        "Expected heading from fallback XHTML document:\n{}",
+        result.content
+    );
+    assert!(
+        result.content.contains("Resolved through manifest fallback."),
+        "Expected body text from fallback XHTML document"
+    );
+}
+
+#[tokio::test]
+async fn test_epub_rejects_manifest_paths_that_escape_package_root() {
+    let bytes = build_epub_with_root_escaping_manifest_href();
+    let extractor = EpubExtractor::new();
+
+    let err = extractor
+        .extract_bytes(&bytes, "application/epub+zip", &ExtractionConfig::default())
+        .await
+        .expect_err("EPUB extraction should reject root-escaping manifest paths");
+
+    assert!(
+        err.to_string().contains("escapes the package root"),
+        "Expected root-escape validation error, got: {err}"
+    );
+}


### PR DESCRIPTION
## What is this?

The native EPUB extractor was too brittle for real-world packages that are valid enough to be consumed by reading systems but do not fit a narrow "manifest href -> XHTML spine item -> dump text" model.

In practice, the previous implementation had a few structural problems:

- It flattened the OPF into metadata plus a list of resolved spine hrefs, which meant we lost manifest-level semantics such as media types, fallback chains, and EPUB 2 guide references.
- It treated navigation content too literally, so EPUB 3 navigation documents and EPUB 2 guide-based TOC pages could leak "Table of Contents" chrome into extracted output.
- It did not canonicalize package-relative hrefs robustly, which made nested relative paths and package-root traversal edge cases harder to reason about.
- It rendered content and document structure through separate paths, which increased duplication and made it easier for Markdown/plain-text/document-structure output to diverge.

The extractor's internal model was too lossy: once OPF parsing collapsed the package into metadata plus a flat list of hrefs, the downstream pipeline no longer had the information it needed to make correct extraction decisions. That is why fixes for fallback chains, guide TOCs, non-linear spine items, and path safety would have kept turning into special cases bolted onto an already faulty representation.

The refactor in this PR changes that boundary. Instead of treating the package document as a thin lookup table, the extractor now keeps the package semantics it needs long enough to make correct extraction decisions. The result is more complete extraction for complex books, less TOC noise, safer path handling, and more consistent output across plain text, Markdown/Djot, and document structure generation.

## Why a Refactor Was Needed

The main reason this became a refactor instead of a bug-fix PR is because the previous architecture discarded important EPUB semantics too early.

- Once manifest items were flattened into hrefs, later stages could no longer distinguish "this spine entry is a foreign resource with a valid XHTML fallback" from "this is just a missing chapter."
- Once guide references were discarded, later stages had no principled way to tell an EPUB 2 TOC page from ordinary chapter content.
- Once content rendering and document-structure rendering were split into separate passes, every EPUB rule change had to be implemented twice or the outputs would drift.

The new package model and normalized spine-document pipeline give the extractor a stable place to apply those rules once, with tests around the behavior that matters.

## What Changed

### 1. Parse the OPF into a richer package model

`parse_opf` now returns an `EpubPackageDocument` instead of `(metadata, spine_hrefs)`.

That package model keeps:

- normalized metadata
- manifest entries with `media-type`
- manifest fallback chains
- spine items as `idref`s
- EPUB 2 guide TOC candidates

This is the key refactor that enables the rest of the change set. Once the extractor retains manifest semantics, it can make spine decisions using the actual package model instead of inferred file paths or output-specific heuristics.

### 2. Resolve manifest hrefs canonically and reject package-root escapes

Path resolution now:

- splits fragments from paths
- resolves hrefs relative to the OPF directory
- normalizes `.` and `..` segments
- rejects hrefs that escape the EPUB package root

Benefits:

- nested package layouts work correctly
- guide references like `./text/../toc.xhtml#toc` normalize to the same package-relative path as manifest entries
- unsafe or malformed paths fail early instead of producing ambiguous ZIP lookups

### 3. Follow manifest fallback chains for spine items

When a spine item points at a foreign resource, the extractor now walks the manifest fallback chain until it finds a renderable XHTML or DTBook document.

That matters because both EPUB 2 and EPUB 3 allow spine references to foreign resources as long as the fallback chain resolves to a valid content document. Before this change, those packages could be skipped or mishandled even though the OPF declared a legitimate reading fallback.

### 4. Keep non-linear spine content instead of silently dropping it

This PR intentionally preserves `linear="no"` spine content during extraction.

For reading systems, `linear="no"` is a presentation hint for auxiliary content, not a statement that the content is disposable. For extraction, dropping auxiliary spine content means losing appendices, notes, answer keys, and similar material that still belongs to the publication.

The new tests explicitly lock in that behavior for both EPUB 2 and EPUB 3.

### 5. Remove specialized navigation chrome while preserving real prose

The content pipeline now sanitizes each XHTML spine document before rendering:

- XML declarations and doctypes are stripped
- `<head>` is removed
- specialized navigation sections are removed when they are clearly navigation-only
- EPUB 2 guide-linked TOC documents are skipped when they behave like dedicated navigation pages

The important nuance is that the extractor does not blindly discard entire navigation documents. If a navigation document contains body prose outside specialized `<nav epub:type="toc|landmarks|page-list">` sections, that prose is preserved.

That gives us cleaner output without throwing away legitimate reader-facing text. The goal is extraction hygiene, not navigation rendering.

### 6. Render each spine document once and reuse the result

The extractor now has a clearer pipeline:

```mermaid
flowchart TD
    A[container.xml] --> B[Locate OPF]
    B --> C[Parse OPF into EpubPackageDocument]
    C --> D[Resolve each spine item through manifest and fallback chain]
    D --> E[Read body documents from ZIP]
    E --> F[Normalize XHTML and strip specialized navigation]
    F --> G[Render content fragment]
    F --> H[Build document structure]
    G --> I[Concatenate final extracted content]
    H --> J[Merge final document structure]
```

This has two concrete benefits:

- content extraction and document structure now operate on the same normalized XHTML
- warning handling is localized per spine document instead of being spread across two separate passes

### 7. Improve degradation behavior

The new implementation is stricter where safety matters and more permissive where completeness matters:

- invalid body-document reads become processing warnings when the package can otherwise continue
- manifest fallback cycles are detected explicitly
- non-renderable spine items are skipped with actionable warnings
- document structure extraction falls back to a plain-text structure when the HTML structure walker returns nothing

That is a better failure model for extraction workloads: hard-fail on unsafe package semantics, warn on partial recoverable issues, and keep extracting as much valid publication content as possible.

## Spec Alignment

### EPUB 3 spine semantics

This PR aligns the extractor with EPUB 3.3 package semantics around the spine, specifically where those semantics affect extraction correctness:

- EPUB 3.3 says the `spine` defines the default reading order and includes both linear and non-linear content.
- EPUB 3.3 also says each `itemref` must reference either an EPUB content document or a foreign content document with an EPUB content document in its manifest fallback chain.
- EPUB 3.3 further clarifies that `linear="no"` is auxiliary-content signaling, not a prohibition against presentation.

Why that matters here:

- following fallback chains is required for valid foreign-content spine entries
- keeping `linear="no"` content avoids losing valid auxiliary publication content
- treating the navigation document specially avoids polluting extraction with machine-oriented navigation markup while still preserving prose outside those nav structures

Relevant references:

- EPUB 3.3, Package Document, spine and itemref semantics: <https://www.w3.org/TR/epub-33/>
- EPUB 3.3 notes that the spine covers both linear and non-linear content, and that `itemref` may target foreign content with a manifest fallback chain: <https://www.w3.org/TR/epub-33/>
- EPUB 3.3 navigation document rules, including `toc`, `page-list`, `landmarks`, and using the navigation document in the spine: <https://www.w3.org/TR/epub-33/>

### EPUB 3 navigation document behavior

EPUB 3.3 describes the navigation document as a specialized XHTML content document. It explicitly allows the navigation document to appear in the spine, and it also says content outside specialized navigation elements can be structured like any other XHTML content document.

That is exactly the behavior this PR implements:

- strip specialized navigation sections from extraction
- preserve non-navigation prose that happens to live in the same XHTML file
- avoid assuming that "navigation document in spine" means "drop the whole document"

### EPUB 2 spine and guide behavior

This PR also restores EPUB 2-specific semantics that matter in the wild for extraction:

- OPF 2.0.1 says spine order organizes OPS Content Documents into the linear reading order.
- It also allows spine entries whose fallback chain includes an OPS Content Document.
- It explicitly documents `linear="no"` as auxiliary content, and allows reading systems to either treat it specially or ignore the distinction.
- The EPUB 2 guide identifies structural components such as the table of contents through `reference` elements.

Why that matters here:

- guide-linked TOC pages should not be mistaken for regular body chapters
- auxiliary EPUB 2 spine documents should still be extractable content
- fallback-aware spine resolution is required for valid non-XHTML manifest items that resolve to XHTML/DTBook

Relevant references:

- OPF 2.0.1, manifest/spine/linear/fallback semantics: <https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm>
- OPF 2.0.1, guide semantics and `reference type="toc"`: <https://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm>

## Key Code Paths

- `crates/kreuzberg/src/extractors/epub/metadata.rs`
  - introduces `EpubPackageDocument`, `ManifestItem`, and `EpubSpineItem`
  - moves OPF parsing from "metadata plus href list" to package-aware parsing
  - stores fallback chains and EPUB 2 guide TOC candidates

- `crates/kreuzberg/src/extractors/epub/parsing.rs`
  - introduces canonical href resolution with fragment preservation
  - normalizes relative paths and rejects package-root traversal

- `crates/kreuzberg/src/extractors/epub/content.rs`
  - resolves renderable body documents via manifest fallback chains
  - normalizes XHTML before extraction
  - strips navigation-only sections while preserving meaningful prose
  - prepares a normalized spine-document representation reused downstream

- `crates/kreuzberg/src/extractors/epub/mod.rs`
  - rewires extraction around parsed package semantics
  - renders normalized spine documents once
  - reuses those rendered documents for final content and document structure output

## Benefits

- Better compatibility with EPUBs that use foreign-resource spine items plus XHTML/DTBook fallbacks.
- Cleaner extracted content with fewer duplicated or navigation-only TOC artifacts.
- No silent loss of non-linear spine content such as appendices, notes, and other auxiliary matter.
- Safer manifest href handling for nested package layouts and malformed traversal attempts.
- More consistent behavior across plain text, Markdown/Djot, and document structure extraction.
- Stronger regression protection through targeted spine-semantics coverage.

## Tests

Added `crates/kreuzberg/tests/epub_spine_semantics_tests.rs` to cover:

- EPUB 3 navigation document stripping while preserving non-nav prose
- preservation of non-linear spine content
- document-structure behavior for the same cases
- EPUB 2 guide TOC exclusion
- manifest fallback resolution to a renderable body document
- rejection of package-root escaping manifest hrefs
- tolerance for invalid unused manifest assets when the actual body content is valid

Also updated the native EPUB fixture expectation comment in `epub_native_extractor_tests.rs` to match the observed fixture semantics.

Validated with:

```bash
cargo test -p kreuzberg --test epub_spine_semantics_tests --features office
cargo test -p kreuzberg --test epub_native_extractor_tests --features office
task lint
```