### PR TITLE
fix(python): downgrade manylinux to 2.28 for glibc compatibility (#588)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -468,7 +468,7 @@ jobs:
             os: ubuntu-latest
             artifact: python-wheels-linux-x86_64
             rust_target: x86_64-unknown-linux-gnu
-            manylinux: manylinux_2_39
+            manylinux: manylinux_2_28
             python: "3.10"
             needs_qemu: false
             extra_args: ""
@@ -476,7 +476,7 @@ jobs:
             os: ubuntu-24.04-arm
             artifact: python-wheels-linux-aarch64
             rust_target: aarch64-unknown-linux-gnu
-            manylinux: manylinux_2_39
+            manylinux: manylinux_2_28
             python: "3.10"
             needs_qemu: false
             extra_args: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Python wheel `__isoc23_strtoll` error on older Linux distributions** (#588): Downgraded the Linux build environment `manylinux` target from `manylinux_2_39` to `manylinux_2_28` for pre-compiled Python wheels to ensure compatibility with systems using glibc versions prior to 2.39 (e.g., Ubuntu 20.04/22.04, Debian 11/12).
+
+---
+
 ## [4.6.3] - 2026-03-27
 
 ### Added


### PR DESCRIPTION
**Problem**

Issue #588 reports an `undefined symbol: __isoc23_strtoll` error when importing the `kreuzberg` Python package. This is caused by the Python wheels being built against the latest `manylinux_2_39` target (glibc 2.39) on Ubuntu 24.04 runners. As a result, users on older Linux distributions (e.g., Ubuntu 20.04/22.04 or Debian 11/12) encounter glibc compatibility issues when trying to install the pre-compiled native extension.

**Solution**

Downgraded the `manylinux` target from `manylinux_2_39` to `manylinux_2_28` in [.github/workflows/publish.yaml](file:///home/eternity/dev/kreuzberg/.github/workflows/publish.yaml) for both Python `linux-x86_64` and `linux-aarch64` wheel builds. This ensures the native bindings are linked against older glibc versions (2.28+), providing broad compatibility across older Linux environments without sacrificing functionality.

**Testing**

1. Verified [.github/workflows/publish.yaml](kreuzberg/.github/workflows/publish.yaml) syntax changes via `task check`.
2. Verified [CHANGELOG.md](kreuzberg/CHANGELOG.md) entry was added under `[Unreleased]`.
3. CI check will automatically catch standard Python workflow regressions if any.

closes #588
