### PR TITLE
fix(docs): add FileNotFoundError catch to Python error handling snippet

### DIFF
--- a/docs/snippets/python/utils/error_handling.md
+++ b/docs/snippets/python/utils/error_handling.md
@@ -10,6 +10,8 @@ from kreuzberg import (
 try:
     result = extract_file_sync("document.pdf")
     print(f"Extracted {len(result.content)} characters")
+except FileNotFoundError as e:
+    print(f"File not found: {e}")
 except ParsingError as e:
     print(f"Failed to parse document: {e}")
 except OCRError as e:


### PR DESCRIPTION
## Summary

- Add `FileNotFoundError` catch to the Python error handling doc snippet
- Python was the only binding where a missing file caused an unhandled crash — Ruby, Go, and Rust all had catch-all branches covering it

Closes KZB-150