### PR TITLE
fix: resolve type inference failures in docx parser and fictionbook extractor (#622)

### DIFF
--- a/crates/kreuzberg/src/extraction/docx/parser.rs
+++ b/crates/kreuzberg/src/extraction/docx/parser.rs
@@ -1279,7 +1279,7 @@ impl<R: Read + Seek> DocxParser<R> {
                     b"w:fldChar" => {
                         for attr in e.attributes().flatten() {
                             if attr.key.as_ref() == b"w:fldCharType" {
-                                match attr.value.as_ref() {
+                                match attr.value.as_ref() as &[u8] {
                                     b"begin" => in_field_instruction = true,
                                     b"separate" | b"end" => in_field_instruction = false,
                                     _ => {}
@@ -1413,7 +1413,7 @@ impl<R: Read + Seek> DocxParser<R> {
                     b"w:fldChar" => {
                         for attr in e.attributes().flatten() {
                             if attr.key.as_ref() == b"w:fldCharType" {
-                                match attr.value.as_ref() {
+                                match attr.value.as_ref() as &[u8] {
                                     b"begin" => in_field_instruction = true,
                                     b"separate" | b"end" => in_field_instruction = false,
                                     _ => {}

--- a/crates/kreuzberg/src/extractors/fictionbook.rs
+++ b/crates/kreuzberg/src/extractors/fictionbook.rs
@@ -109,7 +109,7 @@ impl FictionBookExtractor {
                     let decoded = String::from_utf8_lossy(t.as_ref()).to_string();
                     let had_trailing_space = decoded.ends_with(char::is_whitespace);
                     let normalized = crate::utils::normalize_whitespace(&decoded);
-                    let trimmed = normalized.as_ref();
+                    let trimmed: &str = normalized.as_ref();
                     if !trimmed.is_empty() {
                         let starts_with_punct = trimmed.starts_with(['.', ',', ';', ':', '!', '?', ')', ']', '[']);
                         if !text.is_empty() && !text.ends_with(' ') && !text.ends_with('\n') && !starts_with_punct {
@@ -828,7 +828,7 @@ impl FictionBookExtractor {
                 Ok(Event::Text(t)) => {
                     let decoded = String::from_utf8_lossy(t.as_ref()).to_string();
                     let normalized = crate::utils::normalize_whitespace(&decoded);
-                    let trimmed = normalized.as_ref();
+                    let trimmed: &str = normalized.as_ref();
                     if !trimmed.is_empty() {
                         if !text.is_empty() && !text.ends_with(' ') {
                             text.push(' ');


### PR DESCRIPTION
## Summary

Second occurrence of the type inference regression class fixed in #519.

Two missed sites in `docx/parser.rs` matched `attr.value.as_ref()` without an explicit `as &[u8]` cast. The compiler locked the inferred type to `&[u8; 5]` from the first arm (`b"begin"`), then rejected `b"separate"` (8 bytes) and `b"end"` (3 bytes) with E0308. The prior fix in #519 caught `e.name().as_ref()` call sites but missed the `attr.value.as_ref()` pattern.

Two sites in `fictionbook.rs` called `.as_ref()` on a `Cow<'_, str>` without an explicit `&str` annotation, producing E0282 on newer toolchains where type inference is stricter.

## Changes

- `extraction/docx/parser.rs`: added `as &[u8]` cast at both `attr.value.as_ref()` match sites (lines 1282 and 1416)
- `extractors/fictionbook.rs`: added `: &str` annotation to both `let trimmed = normalized.as_ref()` bindings (lines 112 and 831)

## Test plan

- [ ] `cargo check -p kreuzberg` passes (verified locally)
- [ ] `cargo test -p kreuzberg` — docx and fictionbook extraction tests pass
- [ ] Reporter can build against this patch on Rust 1.94.0-aarch64-apple-darwin

Closes #622