### PR TITLE
fix: Use environment variables for hf_hub::ApiBuilder construction

### DIFF
--- a/crates/kreuzberg/src/embeddings/mod.rs
+++ b/crates/kreuzberg/src/embeddings/mod.rs
@@ -309,7 +309,7 @@ fn download_model_files(
     std::path::PathBuf,
     std::path::PathBuf,
 )> {
-    let api = hf_hub::api::sync::ApiBuilder::new()
+    let api = hf_hub::api::sync::ApiBuilder::from_env()
         .with_cache_dir(cache_directory.to_path_buf())
         .with_progress(true)
         .build()
@@ -513,7 +513,7 @@ pub fn download_model(
 
     tracing::info!(repo = %repo_name, "Downloading embedding model files (no ONNX init)");
 
-    let api = hf_hub::api::sync::ApiBuilder::new()
+    let api = hf_hub::api::sync::ApiBuilder::from_env()
         .with_cache_dir(cache_directory)
         .with_progress(true)
         .build()

--- a/crates/kreuzberg/src/model_download.rs
+++ b/crates/kreuzberg/src/model_download.rs
@@ -13,7 +13,7 @@ use sha2::{Digest, Sha256};
 pub fn hf_download(repo_id: &str, remote_filename: &str) -> Result<PathBuf, String> {
     tracing::info!(repo = repo_id, filename = remote_filename, "Downloading via hf-hub");
 
-    let api = hf_hub::api::sync::ApiBuilder::new()
+    let api = hf_hub::api::sync::ApiBuilder::from_env()
         .with_progress(true)
         .build()
         .map_err(|e| format!("Failed to initialize HuggingFace Hub API: {e}"))?;


### PR DESCRIPTION
Using `ApiBuilder::new()` discards the HF_HOME and HF_ENDPOINT environment variables which are documented in various places as being supported. Switch to `ApiBuilder::from_env()` to fix this.

Without this, you would see the following warnings when running as userid 1000 on Kubernetes:
```
Model download failed: Failed to download 'rtdetr/model.onnx' from Kreuzberg/layout-models: I/O error Permission denied (os error 13)
```
And it would change to read only file system error if the root filesystem were read only.