### PR TITLE
fix: Use chars instead of indices for text_preview for tracing

### DIFF
--- a/crates/kreuzberg/src/pdf/structure/bridge.rs
+++ b/crates/kreuzberg/src/pdf/structure/bridge.rs
@@ -307,7 +307,7 @@ fn finalize_paragraph(
         is_list_item,
         is_code_block,
         is_page_furniture,
-        text_preview = %&trimmed[..trimmed.len().min(60)],
+        text_preview = %&trimmed.chars().take(60).collect::<String>(),
         "classified paragraph"
     );
 

--- a/crates/kreuzberg/src/pdf/structure/pipeline.rs
+++ b/crates/kreuzberg/src/pdf/structure/pipeline.rs
@@ -59,7 +59,7 @@ fn extract_structure_tree_pages(
                         page = i,
                         block_index = bi,
                         role = ?block.role,
-                        text_preview = &block.text[..block.text.len().min(60)],
+                        text_preview = block.text.chars().take(60).collect::<String>(),
                         font_size = ?block.font_size,
                         is_bold = block.is_bold,
                         child_count = block.children.len(),

--- a/crates/kreuzberg/src/rendering/comrak_bridge.rs
+++ b/crates/kreuzberg/src/rendering/comrak_bridge.rs
@@ -124,7 +124,7 @@ fn consolidate_paragraphs(elements: &[InternalElement]) -> Vec<ConsolidatedEleme
                 text_len = elem.text.len(),
                 annotation_count = elem.annotations.len(),
                 uniform_kind = ?uniform,
-                text_preview = &elem.text[..elem.text.len().min(60)],
+                text_preview = elem.text.chars().take(60).collect::<String>(),
                 "paragraph consolidation candidate"
             );
         }


### PR DESCRIPTION
This can cause panics when the log level is low enough. Example:
```
thread '<unnamed>' (590) panicked at crates/kreuzberg/src/pdf/structure/bridge.rs:310:33:

byte index 60 is not a char boundary; it is inside '•' (bytes 58..61) of `Login: ... • Access Code:`
```