### PR TITLE
fix(docs): remove invalid config params from demo extractFromFile call

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -441,10 +441,7 @@
 
         outputScreen.style.display = "flex";
         try {
-          const result = await extractFromFile(file, file.type || null, {
-            extractTables: true,
-            extractMetadata: true,
-          });
+          const result = await extractFromFile(file, file.type || null);
           const mdEl   = document.getElementById("content-markdown");
           const jsonEl = document.getElementById("content-json");
           if (mdEl)   mdEl.innerHTML  = result.content ? renderMarkdown(result.content) : '<p style="color:#888">No content extracted.</p>';


### PR DESCRIPTION
## Summary

- Remove invalid `extractTables` and `extractMetadata` config params from `extractFromFile()` call in the live demo page
- These are not valid `ExtractionConfig` fields and cause WASM extraction to fail
- Tables and metadata are non-optional fields on `ExtractionResult` — always included by default

Closes #651