### PR TITLE
fix(java): register Jdk8Module on ResultParser ObjectMapper for Jackson 2.21+

### DIFF
--- a/packages/java/pom.xml
+++ b/packages/java/pom.xml
@@ -70,6 +70,11 @@
             <version>2.21.2</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.21.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <version>1.0.0</version>

--- a/packages/java/src/main/java/dev/kreuzberg/ResultParser.java
+++ b/packages/java/src/main/java/dev/kreuzberg/ResultParser.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +13,7 @@ import java.util.Optional;
 
 final class ResultParser {
 	private static final ObjectMapper MAPPER = new ObjectMapper()
+			.registerModule(new Jdk8Module())
 			.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
 			.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 


### PR DESCRIPTION
## Summary

- Adds `jackson-datatype-jdk8` dependency to `pom.xml` (same 2.21.2 release train)
- Registers `Jdk8Module` on the static `ObjectMapper` in `ResultParser` so `Optional<T>` fields deserialize correctly with Jackson 2.21+

Fixes #654