### PR TITLE
fix(docs): exclude MkDocs grid card files from rumdl-fmt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -171,7 +171,7 @@ repos:
     rev: "v0.1.67"
     hooks:
       - id: rumdl-fmt
-        exclude: '^(test_apps/|tools/benchmark-harness/vendored/)'
+        exclude: '^(test_apps/|tools/benchmark-harness/vendored/|docs/index\.md|docs/getting-started/installation\.md)'
 
   # Spelling: fast Rust-based spell checker
   - repo: https://github.com/crate-ci/typos

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,9 +59,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
 
 <div class="grid cards install-cards" markdown>
 
-- :fontawesome-brands-python:{ .lg .middle } **Python**
+-   :fontawesome-brands-python:{ .lg .middle } **Python**
 
----
+    ---
 
     ```bash
     pip install kreuzberg
@@ -70,9 +70,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-python.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-node-js:{ .lg .middle } **TypeScript (Node.js / Bun)**
+-   :fontawesome-brands-node-js:{ .lg .middle } **TypeScript (Node.js / Bun)**
 
----
+    ---
 
     ```bash
     npm install @kreuzberg/node
@@ -81,9 +81,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-typescript.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#typescript){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-js:{ .lg .middle } **TypeScript (Browser / Edge)**
+-   :fontawesome-brands-js:{ .lg .middle } **TypeScript (Browser / Edge)**
 
----
+    ---
 
     ```bash
     npm install @kreuzberg/wasm
@@ -92,9 +92,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-wasm.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#typescript){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-rust:{ .lg .middle } **Rust**
+-   :fontawesome-brands-rust:{ .lg .middle } **Rust**
 
----
+    ---
 
     ```bash
     cargo add kreuzberg
@@ -103,9 +103,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-rust.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-golang:{ .lg .middle } **Go**
+-   :fontawesome-brands-golang:{ .lg .middle } **Go**
 
----
+    ---
 
     ```bash
     go get github.com/kreuzberg-dev/kreuzberg/packages/go/v4@latest
@@ -114,9 +114,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-go.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-java:{ .lg .middle } **Java**
+-   :fontawesome-brands-java:{ .lg .middle } **Java**
 
----
+    ---
 
     ```gradle
     implementation 'dev.kreuzberg:kreuzberg:4.7.3'
@@ -125,9 +125,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-java.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#java){ .install-btn .install-btn--solid }
 
-- :material-language-ruby:{ .lg .middle } **Ruby**
+-   :material-language-ruby:{ .lg .middle } **Ruby**
 
----
+    ---
 
     ```bash
     gem install kreuzberg
@@ -136,9 +136,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-ruby.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :material-language-csharp:{ .lg .middle } **C# / .NET**
+-   :material-language-csharp:{ .lg .middle } **C# / .NET**
 
----
+    ---
 
     ```bash
     dotnet add package Kreuzberg
@@ -147,9 +147,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-csharp.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](../guides/csharp.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-php:{ .lg .middle } **PHP**
+-   :fontawesome-brands-php:{ .lg .middle } **PHP**
 
----
+    ---
 
     ```bash
     composer require kreuzberg/kreuzberg
@@ -158,9 +158,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-php.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :simple-elixir:{ .lg .middle } **Elixir**
+-   :simple-elixir:{ .lg .middle } **Elixir**
 
----
+    ---
 
     ```elixir
     {:kreuzberg, "~> 4.0"}
@@ -169,9 +169,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-elixir.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#elixir){ .install-btn .install-btn--solid }
 
-- :simple-r:{ .lg .middle } **R**
+-   :simple-r:{ .lg .middle } **R**
 
----
+    ---
 
     ```r
     install.packages("kreuzberg",
@@ -181,9 +181,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-r.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :simple-cplusplus:{ .lg .middle } **C / C++**
+-   :simple-cplusplus:{ .lg .middle } **C / C++**
 
----
+    ---
 
     ```bash
     cargo build -p kreuzberg-ffi

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,45 +25,45 @@ Kreuzberg is a document intelligence platform with a high‑performance Rust cor
 
 <div class="grid cards" markdown>
 
-- :material-flash:{ .lg .middle } **High Performance**
+-   :material-flash:{ .lg .middle } **High Performance**
 
----
+    ---
 
     Rust core with native PDFium, SIMD optimizations, and full parallelism. Process thousands of documents per minute without a GPU.
 
-- :material-file-document-multiple:{ .lg .middle } **91+ File Formats**
+-   :material-file-document-multiple:{ .lg .middle } **91+ File Formats**
 
----
+    ---
 
     PDF, DOCX, XLSX, PPTX, images, HTML, XML, emails, archives, academic formats — one API handles them all.
 
-- :material-eye:{ .lg .middle } **Multi-Engine OCR**
+-   :material-eye:{ .lg .middle } **Multi-Engine OCR**
 
----
+    ---
 
     Tesseract and PaddleOCR work across all language bindings. EasyOCR is available for Python only.
 
-- :material-translate:{ .lg .middle } **12 Language Bindings**
+-   :material-translate:{ .lg .middle } **12 Language Bindings**
 
----
+    ---
 
     Native bindings for Python, TypeScript, Rust, Go, Java, C#, Ruby, PHP, Elixir, R, C, and WebAssembly.
 
-- :material-code-tags:{ .lg .middle } **Code Intelligence**
+-   :material-code-tags:{ .lg .middle } **Code Intelligence**
 
----
+    ---
 
     Extract functions, classes, imports, symbols, and docstrings from 248 programming languages. Results in `code_intelligence` field with semantic chunking.
 
-- :material-puzzle:{ .lg .middle } **Plugin System**
+-   :material-puzzle:{ .lg .middle } **Plugin System**
 
----
+    ---
 
     Register custom extractors, OCR backends, post-processors, and validators. Plugin authoring is primarily supported in Python; all bindings can consume registered plugins.
 
-- :material-server:{ .lg .middle } **Flexible Deployment**
+-   :material-server:{ .lg .middle } **Flexible Deployment**
 
----
+    ---
 
     Use as a library, CLI tool, REST API server, MCP server, or Docker container. Pick what fits your stack.
 
@@ -106,49 +106,49 @@ Precompiled binaries for Linux (x86_64 & aarch64), macOS (Apple Silicon), and Wi
 
 <div class="grid cards" markdown>
 
-- :material-rocket-launch:{ .lg .middle } **Getting Started**
+-   :material-rocket-launch:{ .lg .middle } **Getting Started**
 
----
+    ---
 
     Install Kreuzberg and extract your first document in minutes.
 
     [:octicons-arrow-right-24: Quick Start](getting-started/quickstart.md)
 
-- :material-book-open-variant:{ .lg .middle } **Guides**
+-   :material-book-open-variant:{ .lg .middle } **Guides**
 
----
+    ---
 
     Configuration, OCR setup, Docker deployment, plugins, and more.
 
     [:octicons-arrow-right-24: All Guides](guides/extraction.md)
 
-- :material-puzzle-outline:{ .lg .middle } **Concepts**
+-   :material-puzzle-outline:{ .lg .middle } **Concepts**
 
----
+    ---
 
     Architecture, extraction pipeline, MIME detection, and performance.
 
     [:octicons-arrow-right-24: Architecture](concepts/architecture.md)
 
-- :material-api:{ .lg .middle } **API Reference**
+-   :material-api:{ .lg .middle } **API Reference**
 
----
+    ---
 
     Complete API docs for every language binding, types, and errors.
 
     [:octicons-arrow-right-24: References](reference/api-python.md)
 
-- :material-console:{ .lg .middle } **CLI & Servers**
+-   :material-console:{ .lg .middle } **CLI & Servers**
 
----
+    ---
 
     Command-line tool, REST API server, and MCP server for AI agents.
 
     [:octicons-arrow-right-24: CLI Usage](cli/usage.md)
 
-- :material-swap-horizontal:{ .lg .middle } **Migration**
+-   :material-swap-horizontal:{ .lg .middle } **Migration**
 
----
+    ---
 
     Upgrade from v3 to v4, or migrate from Unstructured.
 


### PR DESCRIPTION
## Summary

MkDocs Material grid cards require non-standard markdown list indentation (`-   ` with 3 spaces and indented `    ---` separators). The `rumdl-fmt` pre-commit hook auto-fixes these via MD030 (spaces after list markers) and MD035 (horizontal rule indentation), which breaks the card layout on every commit.

This is fundamentally a compatibility conflict between standard markdown linting and MkDocs Material's extended syntax — there's no rumdl configuration to make both coexist, so the pragmatic fix is to exclude the two files that use grid cards from `rumdl-fmt`.

## Changes

- Restored correct grid card indentation in `docs/index.md` and `docs/getting-started/installation.md`
- Added both files to the `rumdl-fmt` exclude pattern in `.pre-commit-config.yaml`