### PR TITLE
fix: correct HWP tag constants and control character handling

### DIFF
--- a/crates/kreuzberg/src/extraction/hwp/model.rs
+++ b/crates/kreuzberg/src/extraction/hwp/model.rs
@@ -55,10 +55,10 @@ pub struct Paragraph {
 }
 
 // ---------------------------------------------------------------------------
-// ParaText — decodes a TAG_PARA_TEXT (0x51) record
+// ParaText — decodes a TAG_PARA_TEXT (0x43) record
 // ---------------------------------------------------------------------------
 
-/// Plain text content decoded from a ParaText record (tag 0x51).
+/// Plain text content decoded from a ParaText record (tag 0x43).
 #[derive(Debug)]
 pub struct ParaText {
     pub content: String,
@@ -84,16 +84,25 @@ impl ParaText {
         while i < chars.len() {
             let ch = chars[i];
             match ch {
-                0x0000 => {} // null — skip
-                // Extended control characters 0x0001–0x0008 occupy 8 u16 units
-                // total (the control char + 7 parameter units). Skip all 8.
+                0x0000 => {} // null — 1 u16, no parameters
+                // HWP 5.x control characters that occupy 8 u16 units total
+                // (the control char itself + 7 parameter units):
+                //   0x0001–0x0008: inline extended controls
+                //   0x0009:        tab
+                //   0x000B–0x000C: drawing objects, reserved
+                //   0x000E–0x001F: extended controls (field, bookmark, etc.)
                 0x0001..=0x0008 => {
-                    i += 7; // skip 7 additional parameter units (loop increments by 1)
+                    i += 7;
                 }
-                0x0009 => content.push('\t'),           // horizontal tab
-                0x000A => content.push('\n'),           // line feed
-                0x000D => content.push('\r'),           // carriage return
-                0x000B..=0x000C | 0x000E..=0x001F => {} // skip remaining C0 controls
+                0x0009 => {
+                    content.push('\t');
+                    i += 7;
+                }
+                0x000A => content.push('\n'), // line feed — 1 u16
+                0x000D => {}                  // paragraph end — 1 u16
+                0x000B..=0x000C | 0x000E..=0x001F => {
+                    i += 7;
+                }
                 0xF020..=0xF07F => {}                   // HWP private-use controls — skip
                 _ => {
                     if let Some(c) = char::from_u32(ch as u32) {

--- a/crates/kreuzberg/src/extraction/hwp/parser.rs
+++ b/crates/kreuzberg/src/extraction/hwp/parser.rs
@@ -107,10 +107,12 @@ impl Record {
 // HWP tag constants (only the ones we need)
 // ---------------------------------------------------------------------------
 
-/// HWP 5.0 body-text record tag 0x50: paragraph header.
-const TAG_PARA_HEADER: u16 = 0x50;
-/// HWP 5.0 body-text record tag 0x51: paragraph text (UTF-16LE).
-const TAG_PARA_TEXT: u16 = 0x51;
+/// HWPTAG_BEGIN as defined by the HWP 5.x specification.
+const HWPTAG_BEGIN: u16 = 0x010;
+/// HWP 5.x body-text record tag: paragraph header (HWPTAG_BEGIN + 50).
+const TAG_PARA_HEADER: u16 = HWPTAG_BEGIN + 50; // 0x42
+/// HWP 5.x body-text record tag: paragraph text, UTF-16LE (HWPTAG_BEGIN + 51).
+const TAG_PARA_TEXT: u16 = HWPTAG_BEGIN + 51; // 0x43
 
 // ---------------------------------------------------------------------------
 // BodyTextParser — parse a single decompressed section into paragraphs


### PR DESCRIPTION
## Summary

Fix two bugs in the HWP 5.x text extractor that caused broken extraction for all HWP files:

- **Wrong tag constants**: `TAG_PARA_HEADER`/`TAG_PARA_TEXT` were `0x50`/`0x51` instead of `0x42`/`0x43` (`HWPTAG_BEGIN(0x10) + 50/51`). This caused all HWP 5.x files to return empty text with no error.
- **Missing control char parameter skip**: Extended control characters `0x0009`, `0x000B–0x000C`, and `0x000E–0x001F` occupy 8 u16 units per the HWP spec, but the decoder only skipped the control char itself, causing trailing parameter bytes to be decoded as garbage text (e.g. `湰灧`).

## Test plan

- [x] Verified with `cargo build --release` (compiles cleanly)
- [x] Tested against two real HWP 5.x files (Korean government documents): both extracted correctly with clean Korean text and no garbage characters
- [x] Before fix: 0 chars extracted; after fix: 20k–33k chars extracted per file

Closes #658