### PR TITLE
fix: resolve Cow::as_ref() type inference ambiguity

### DIFF
--- a/crates/kreuzberg/src/extraction/derive.rs
+++ b/crates/kreuzberg/src/extraction/derive.rs
@@ -89,9 +89,7 @@ pub fn derive_document_structure(doc: &mut InternalDocument) -> DocumentStructur
 /// build_ocr_elements) must run before this function.
 fn derive_document_structure_inner(doc: &mut InternalDocument) -> DocumentStructure {
     let mut ds = DocumentStructure::with_capacity(doc.elements.len());
-    // Convert Cow<str> → String without double-allocation: as_ref() borrows the
-    // inner str regardless of Cow variant, then to_string() allocates once.
-    ds.source_format = Some(doc.source_format.as_ref().to_string());
+    ds.source_format = Some(doc.source_format.to_string());
 
     // Stack: (depth, NodeIndex) — depth is the element depth that "owns" this level
     let mut stack: Vec<(u16, NodeIndex)> = Vec::new();
@@ -1042,5 +1040,19 @@ mod tests {
         let ds = result.document.unwrap();
         assert!(ds.validate().is_ok());
         assert_eq!(ds.source_format.as_deref(), Some("pdf"));
+    }
+
+    #[test]
+    fn test_source_format_cow_owned_propagates() {
+        // Regression test for #622: Cow::Owned variant must not fail type inference
+        // when deriving document structure. Previously used unstable Cow::as_str().
+        let owned: std::borrow::Cow<'static, str> = std::borrow::Cow::Owned("epub".to_string());
+        let mut doc = InternalDocument::new(owned);
+        doc.push_element(InternalElement::text(ElementKind::Heading { level: 1 }, "Ch1", 0).with_page(1));
+        doc.push_element(InternalElement::text(ElementKind::Paragraph, "Body.", 1).with_page(1));
+
+        let result = derive_extraction_result(doc, true, crate::core::config::OutputFormat::Plain);
+        let ds = result.document.unwrap();
+        assert_eq!(ds.source_format.as_deref(), Some("epub"));
     }
 }

--- a/crates/kreuzberg/src/extractors/djot_format/extractor.rs
+++ b/crates/kreuzberg/src/extractors/djot_format/extractor.rs
@@ -408,7 +408,7 @@ impl DjotExtractor {
                         ocr_rotation: None,
                     });
                     // Collect image URI with alt text as label
-                    let src_str = src.as_ref();
+                    let src_str: &str = src.as_ref();
                     if !src_str.is_empty() {
                         let trimmed = image_alt.trim();
                         let label = if trimmed.is_empty() {
@@ -667,5 +667,22 @@ mod tests {
 
         assert!(result.content.contains("太字"), "Bold CJK content present");
         assert!(result.content.contains("これは"), "Leading CJK preserved");
+    }
+
+    #[tokio::test]
+    async fn test_image_uri_extraction_djot() {
+        // Regression test for #622: src.as_ref() on Cow<str> from jotdown's Container::Image
+        // must compile without type-inference ambiguity introduced by typed-path.
+        let djot = b"![A diagram](https://example.com/diagram.png)\n\nSome text.";
+        let extractor = DjotExtractor::new();
+        let config = ExtractionConfig::default();
+
+        let doc = extractor
+            .extract_bytes(djot, "text/djot", &config)
+            .await
+            .expect("image djot should extract");
+
+        let has_image_uri = doc.uris.iter().any(|u| u.url.contains("diagram.png"));
+        assert!(has_image_uri, "image URI should be captured from Djot image node");
     }
 }


### PR DESCRIPTION
  ## Summary

  - `extraction/derive.rs`: replaced unstable `Cow::as_str()` with `.to_string()` directly on the `Cow<str>` value — routes through `Display`/`Deref` and avoids `AsRef` resolution entirely.
  - `extractors/djot_format/extractor.rs`: added explicit `: &str` type annotation on `src.as_ref()` so the compiler picks `AsRef<str>` over `typed-path`'s `AsRef<Utf8Path<T>>`.

  Both sites were left after the #519 fix and triggered `E0282`/`E0658` in downstream crates that pull in `typed-path` alongside kreuzberg.

  ## Test plan

  - [ ] `cargo test --package kreuzberg test_source_format_cow_owned_propagates`
  - [ ] `cargo test --package kreuzberg test_image_uri_extraction_djot`
  - [ ] `cargo check --package kreuzberg` exits 0
  - [ ] B\build a minimal downstream crate that depends on kreuzberg + typed-path and confirm it compiles
  
  
  
  fixes #622 