### PR TITLE
feat: add minimal Helm chart for Kubernetes deployment

### DIFF
--- a/charts/kreuzberg/.helmignore
+++ b/charts/kreuzberg/.helmignore
@@ -1,0 +1,9 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.idea/
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/charts/kreuzberg/Chart.yaml
+++ b/charts/kreuzberg/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kreuzberg
+description: >-
+  A Helm chart for Kreuzberg — polyglot document intelligence framework with
+  a Rust core. Extract text, metadata, images, and structured information from
+  PDFs, Office documents, images, and 91+ formats.
+type: application
+version: 0.1.0
+appVersion: "4.8.3"
+home: https://kreuzberg.dev
+sources:
+  - https://github.com/kreuzberg-dev/kreuzberg
+keywords:
+  - document-intelligence
+  - text-extraction
+  - pdf
+  - ocr
+  - tesseract
+  - rag
+  - rust
+maintainers:
+  - name: kreuzberg-dev
+    url: https://github.com/kreuzberg-dev
+icon: https://raw.githubusercontent.com/kreuzberg-dev/kreuzberg/main/docs/assets/logo.png

--- a/charts/kreuzberg/templates/_helpers.tpl
+++ b/charts/kreuzberg/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kreuzberg.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "kreuzberg.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kreuzberg.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "kreuzberg.labels" -}}
+helm.sh/chart: {{ include "kreuzberg.chart" . }}
+{{ include "kreuzberg.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "kreuzberg.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kreuzberg.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "kreuzberg.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kreuzberg.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container image reference.
+*/}}
+{{- define "kreuzberg.image" -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.repository (.Values.image.tag | default .Chart.AppVersion) }}
+{{- end }}

--- a/charts/kreuzberg/templates/deployment.yaml
+++ b/charts/kreuzberg/templates/deployment.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kreuzberg.fullname" . }}
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "kreuzberg.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "kreuzberg.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "kreuzberg.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.cache.enabled }}
+      initContainers:
+        - name: init-cache
+          image: busybox:latest
+          command: ['sh', '-c', 'mkdir -p /app/.kreuzberg && chown -R 1000:1000 /app/.kreuzberg']
+          volumeMounts:
+            - name: cache
+              mountPath: /app/.kreuzberg
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "kreuzberg.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["serve", "--host", "0.0.0.0", "--port", "8000"]
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+          env:
+            - name: RUST_LOG
+              value: {{ .Values.kreuzberg.logLevel | quote }}
+            - name: TESSDATA_PREFIX
+              value: {{ .Values.kreuzberg.tessdataPrefix | quote }}
+            - name: KREUZBERG_OCR_LANGUAGE
+              value: {{ .Values.kreuzberg.ocrLanguage | quote }}
+            - name: KREUZBERG_CACHE_DIR
+              value: "/app/.kreuzberg"
+            - name: HF_HOME
+              value: "/app/.kreuzberg/huggingface"
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+            failureThreshold: 30
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 2
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.cache.enabled }}
+            - name: cache
+              mountPath: /app/.kreuzberg
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        {{- if .Values.cache.enabled }}
+        - name: cache
+          persistentVolumeClaim:
+            claimName: {{ include "kreuzberg.fullname" . }}-cache
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/kreuzberg/templates/hpa.yaml
+++ b/charts/kreuzberg/templates/hpa.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.autoscaling.enabled -}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "kreuzberg.fullname" . }}
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "kreuzberg.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/kreuzberg/templates/ingress.yaml
+++ b/charts/kreuzberg/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "kreuzberg.fullname" . }}
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "kreuzberg.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/kreuzberg/templates/pdb.yaml
+++ b/charts/kreuzberg/templates/pdb.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.podDisruptionBudget.enabled -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "kreuzberg.fullname" . }}
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "kreuzberg.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/kreuzberg/templates/pvc.yaml
+++ b/charts/kreuzberg/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.cache.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kreuzberg.fullname" . }}-cache
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.cache.accessModes | nindent 4 }}
+  {{- if .Values.cache.storageClass }}
+  storageClassName: {{ .Values.cache.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.cache.size }}
+{{- end }}

--- a/charts/kreuzberg/templates/service.yaml
+++ b/charts/kreuzberg/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kreuzberg.fullname" . }}
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "kreuzberg.selectorLabels" . | nindent 4 }}

--- a/charts/kreuzberg/templates/serviceaccount.yaml
+++ b/charts/kreuzberg/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "kreuzberg.serviceAccountName" . }}
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/kreuzberg/templates/tests/test-connection.yaml
+++ b/charts/kreuzberg/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "kreuzberg.fullname" . }}-test-connection"
+  labels:
+    {{- include "kreuzberg.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox:latest
+      command: ['wget']
+      args: ['--spider', '--timeout=5', '{{ include "kreuzberg.fullname" . }}:{{ .Values.service.port }}/health']
+  restartPolicy: Never

--- a/charts/kreuzberg/values.yaml
+++ b/charts/kreuzberg/values.yaml
@@ -1,0 +1,138 @@
+# -- Number of replicas
+replicaCount: 2
+
+image:
+  # -- Container image registry
+  registry: ghcr.io
+  # -- Container image repository
+  repository: kreuzberg-dev/kreuzberg
+  # -- Image tag. Use "latest" for the full image (Tesseract + PaddleOCR + layout models)
+  # or "core" for the minimal image (no pre-downloaded models).
+  tag: "latest"
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for private registries
+imagePullSecrets: []
+
+# -- Override the chart name
+nameOverride: ""
+# -- Override the full release name
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Create a ServiceAccount
+  create: true
+  # -- Annotations for the ServiceAccount
+  annotations: {}
+  # -- Override the ServiceAccount name (defaults to release fullname)
+  name: ""
+
+# -- Pod-level annotations
+podAnnotations: {}
+
+# -- Pod-level security context
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+# -- Container-level security context
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- Service port
+  port: 80
+
+ingress:
+  # -- Enable Ingress
+  enabled: false
+  # -- Ingress class name (e.g. "nginx")
+  className: ""
+  # -- Ingress annotations
+  annotations: {}
+  # -- Ingress hosts
+  hosts:
+    - host: kreuzberg.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- Ingress TLS configuration
+  tls: []
+  #  - secretName: kreuzberg-tls
+  #    hosts:
+  #      - kreuzberg.local
+
+# -- Container resource requests and limits
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "500m"
+  limits:
+    memory: "2Gi"
+    cpu: "2000m"
+
+autoscaling:
+  # -- Enable HorizontalPodAutoscaler
+  enabled: false
+  # -- Minimum replicas
+  minReplicas: 2
+  # -- Maximum replicas
+  maxReplicas: 10
+  # -- Target CPU utilization (percent)
+  targetCPUUtilizationPercentage: 80
+  # -- Target memory utilization (percent). Leave unset to disable.
+  # targetMemoryUtilizationPercentage: 80
+
+# -- Node selector for pod scheduling
+nodeSelector: {}
+
+# -- Tolerations for pod scheduling
+tolerations: []
+
+# -- Affinity rules for pod scheduling
+affinity: {}
+
+# -- Extra environment variables
+extraEnv: []
+#  - name: KREUZBERG_CORS_ORIGINS
+#    value: "https://app.example.com"
+#  - name: KREUZBERG_MAX_UPLOAD_SIZE_MB
+#    value: "500"
+
+# -- Kreuzberg-specific configuration
+kreuzberg:
+  # -- Log level: trace, debug, info, warn, error
+  logLevel: "info"
+  # -- Tesseract data prefix path (must match the container image)
+  tessdataPrefix: "/usr/share/tesseract-ocr/5/tessdata"
+  # -- Default OCR language
+  ocrLanguage: "eng"
+
+cache:
+  # -- Enable persistent cache for embedding models and downloaded assets.
+  # Models range from 90 MB to 1.2 GB and are re-downloaded on every pod
+  # restart without a PVC.
+  enabled: true
+  # -- Storage size for the cache PVC
+  size: 2Gi
+  # -- StorageClass for the cache PVC (empty string uses cluster default)
+  storageClass: ""
+  # -- Access modes for the cache PVC
+  accessModes:
+    - ReadWriteOnce
+
+podDisruptionBudget:
+  # -- Enable PodDisruptionBudget
+  enabled: false
+  # -- Minimum available pods during disruption
+  minAvailable: 1


### PR DESCRIPTION
## Summary

Adds a minimal, focused Helm chart for deploying Kreuzberg to Kubernetes — addressing [#539](https://github.com/kreuzberg-dev/kreuzberg/issues/539) and incorporating the maintainer's feedback from [#540](https://github.com/kreuzberg-dev/kreuzberg/pull/540) to keep it lean (no postgres, redis, or other external dependencies).

### What's included

- **Deployment** with three-tier health probes (startup/liveness/readiness on `/health`), non-root security context (UID/GID 1000), and `readOnlyRootFilesystem`
- **Service** (ClusterIP default) and optional **Ingress** with TLS support
- **PersistentVolumeClaim** for model cache (`/app/.kreuzberg`) — embedding models are 90 MB–1.2 GB and re-download on every restart without persistence
- **ServiceAccount** with configurable annotations (for IRSA, workload identity, etc.)
- **HorizontalPodAutoscaler** (opt-in) with CPU/memory targets
- **PodDisruptionBudget** (opt-in) for HA deployments
- **Init container** that fixes PVC permissions for the non-root kreuzberg user
- **Helm test** that validates the `/health` endpoint post-install
- Support for both image variants via `image.tag`: `latest` (full) or `core` (minimal)

### What's NOT included (by design)

No postgres, redis, or any external dependencies. No custom skills. This is purely the kreuzberg API server with its cache volume — exactly what the maintainer asked for.

### Validation

```
$ helm lint charts/kreuzberg
==> Linting charts/kreuzberg
1 chart(s) linted, 0 chart(s) failed

$ helm template test-release charts/kreuzberg  # renders all resources correctly
$ helm template test-release charts/kreuzberg --set cache.enabled=false  # no PVC, no init container
$ helm template test-release charts/kreuzberg --set autoscaling.enabled=true  # HPA, no static replicas
$ helm template test-release charts/kreuzberg --set ingress.enabled=true  # ingress renders
$ helm template test-release charts/kreuzberg --set image.tag=core  # core variant
```

### Quick start

```bash
helm install kreuzberg ./charts/kreuzberg

# With ingress
helm install kreuzberg ./charts/kreuzberg \
  --set ingress.enabled=true \
  --set ingress.className=nginx \
  --set ingress.hosts[0].host=kreuzberg.example.com

# Production with HA
helm install kreuzberg ./charts/kreuzberg \
  --set replicaCount=3 \
  --set podDisruptionBudget.enabled=true \
  --set autoscaling.enabled=true \
  --set resources.limits.memory=4Gi
```

## Test plan

- [x] `helm lint charts/kreuzberg` passes with 0 failures
- [x] `helm template` renders correctly with default values
- [x] `helm template` renders correctly with `cache.enabled=false` (no PVC/init container)
- [x] `helm template` renders correctly with `autoscaling.enabled=true` (HPA, no static replicas)
- [x] `helm template` renders correctly with `ingress.enabled=true`
- [x] `helm template` renders correctly with `podDisruptionBudget.enabled=true`
- [x] `helm template` renders correctly with `image.tag=core`
- [ ] `helm install` + `helm test` against a live cluster (maintainer validation)

Closes #539