### PR TITLE
fix: remove duplicate output_format key and fix numeric types in OCR metadata

### DIFF
--- a/crates/kreuzberg/src/ocr/processor/execution.rs
+++ b/crates/kreuzberg/src/ocr/processor/execution.rs
@@ -1004,15 +1004,10 @@ pub(super) fn perform_ocr(
         serde_json::Value::String(config.language.clone()),
     );
     metadata.insert("psm".to_string(), serde_json::Value::String(config.psm.to_string()));
-    metadata.insert(
-        "output_format".to_string(),
-        serde_json::Value::String(config.output_format.clone()),
-    );
-    metadata.insert("table_count".to_string(), serde_json::Value::String("0".to_string()));
-    metadata.insert(
-        "tables_detected".to_string(),
-        serde_json::Value::String("0".to_string()),
-    );
+    // `output_format` is a typed field on `Metadata`; inserting it here into `additional`
+    // would produce a duplicate JSON key when both are serialized. Removed — see #703.
+    metadata.insert("table_count".to_string(), serde_json::Value::Number(0.into()));
+    metadata.insert("tables_detected".to_string(), serde_json::Value::Number(0.into()));
     if config.output_format == "markdown" {
         metadata.insert(
             "source_format".to_string(),
@@ -1093,18 +1088,15 @@ pub(super) fn perform_ocr(
                 #[cfg(not(feature = "pdf"))]
                 let cleaned = Some(table);
                 if let Some(cleaned) = cleaned {
-                    metadata.insert("table_count".to_string(), serde_json::Value::String("1".to_string()));
-                    metadata.insert(
-                        "tables_detected".to_string(),
-                        serde_json::Value::String("1".to_string()),
-                    );
+                    metadata.insert("table_count".to_string(), serde_json::Value::Number(1.into()));
+                    metadata.insert("tables_detected".to_string(), serde_json::Value::Number(1.into()));
                     metadata.insert(
                         "table_rows".to_string(),
-                        serde_json::Value::String(cleaned.len().to_string()),
+                        serde_json::Value::Number(cleaned.len().into()),
                     );
                     metadata.insert(
                         "table_cols".to_string(),
-                        serde_json::Value::String(cleaned[0].len().to_string()),
+                        serde_json::Value::Number(cleaned[0].len().into()),
                     );
 
                     let markdown_table = table_to_markdown(&cleaned);


### PR DESCRIPTION
## Summary

  - Removes a stale `additional` HashMap insert of `output_format` in `perform_ocr()` that caused a duplicate JSON key in OCR extraction results,.. a direct violation of RFC 8259 §4. The value is already owned by the typed `Metadata::output_format` field; the extra insert was left behind when the field was promoted from `additional`.
  - Fixes `table_count`, `tables_detected`, `table_rows`, and `table_cols` which were serialized as JSON strings (`"0"`, `"1"`) instead of numbers, breaking numeric comparisons in all language bindings.

  ## Test plan

  - [x] Extract any image file and confirm `output_format` appears exactly once in the metadata JSON:
    ```bash
    kreuzberg extract image.png --format json | grep -c '"output_format"'
    # expected: 1
  - Confirm table_count and tables_detected are integers, not strings:
  kreuzberg extract image.png --format json \
    | python3 -c "import sys,json; m=json.load(sys.stdin)['metadata'];
  print(type(m['table_count']))"
  # expected: <class 'int'>
  - cargo test -p kreuzberg --lib - 980 tests pass

  closes #703
  closes #708