### PR TITLE
fix: honor ocr.enabled=false config and drop trailing newline in --format text

### DIFF
--- a/crates/kreuzberg-cli/src/commands/extract.rs
+++ b/crates/kreuzberg-cli/src/commands/extract.rs
@@ -27,7 +27,7 @@ pub fn extract_command(
 
     match format {
         WireFormat::Text => {
-            println!("{}", result.content);
+            print!("{}", result.content);
         }
         WireFormat::Json => {
             println!(

--- a/crates/kreuzberg-cli/src/commands/overrides.rs
+++ b/crates/kreuzberg-cli/src/commands/overrides.rs
@@ -407,6 +407,7 @@ impl ExtractionOverrides {
                 let existing_element_config = config.ocr.as_ref().and_then(|o| o.element_config.clone());
                 let auto_rotate = self.ocr_auto_rotate.unwrap_or(false);
                 config.ocr = Some(OcrConfig {
+                    enabled: true,
                     backend: backend.to_string(),
                     language,
                     tesseract_config: None,
@@ -465,6 +466,7 @@ impl ExtractionOverrides {
 
             // If OCR config already exists, update it; otherwise create a new one
             let ocr = config.ocr.get_or_insert_with(|| OcrConfig {
+                enabled: true,
                 backend: "vlm".to_string(),
                 language: "eng".to_string(),
                 tesseract_config: None,
@@ -850,6 +852,7 @@ mod tests {
     fn test_ocr_language_without_ocr_flag_existing_config() {
         let mut config = ExtractionConfig {
             ocr: Some(OcrConfig {
+                enabled: true,
                 backend: "tesseract".to_string(),
                 language: "eng".to_string(),
                 tesseract_config: None,

--- a/crates/kreuzberg-node/typescript/types.ts
+++ b/crates/kreuzberg-node/typescript/types.ts
@@ -198,6 +198,9 @@ export interface PaddleOcrConfig {
  * Controls which OCR engine to use and how it processes images.
  */
 export interface OcrConfig {
+	/** Whether OCR is enabled. Setting to false disables OCR entirely (equivalent to disable_ocr: true on ExtractionConfig). Default: true. */
+	enabled?: boolean;
+
 	/** OCR backend name (e.g., 'tesseract', 'paddleocr', 'easyocr'). Required. */
 	backend: string;
 

--- a/crates/kreuzberg-py/src/config/types.rs
+++ b/crates/kreuzberg-py/src/config/types.rs
@@ -665,7 +665,7 @@ pub struct OcrConfig {
 #[pymethods]
 impl OcrConfig {
     #[new]
-    #[pyo3(signature = (backend=None, language=None, tesseract_config=None, paddle_ocr_config=None, element_config=None, vlm_config=None, vlm_prompt=None))]
+    #[pyo3(signature = (backend=None, language=None, tesseract_config=None, paddle_ocr_config=None, element_config=None, vlm_config=None, vlm_prompt=None, enabled=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
@@ -676,6 +676,7 @@ impl OcrConfig {
         element_config: Option<Bound<'_, pyo3::types::PyAny>>,
         vlm_config: Option<PyLlmConfig>,
         vlm_prompt: Option<String>,
+        enabled: Option<bool>,
     ) -> PyResult<Self> {
         let paddle_ocr_json = if let Some(obj) = paddle_ocr_config {
             let json_mod = py.import("json")?;
@@ -699,6 +700,7 @@ impl OcrConfig {
         };
         Ok(Self {
             inner: kreuzberg::OcrConfig {
+                enabled: enabled.unwrap_or(true),
                 backend: backend.unwrap_or_else(|| "tesseract".to_string()),
                 language: language.unwrap_or_else(|| "eng".to_string()),
                 tesseract_config: tesseract_config.map(Into::into),
@@ -712,6 +714,16 @@ impl OcrConfig {
                 vlm_prompt,
             },
         })
+    }
+
+    #[getter]
+    fn enabled(&self) -> bool {
+        self.inner.enabled
+    }
+
+    #[setter]
+    fn set_enabled(&mut self, value: bool) {
+        self.inner.enabled = value;
     }
 
     #[getter]

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -593,9 +593,6 @@ mod tests {
     fn test_ocr_enabled_defaults_to_true() {
         let json = r#"{"ocr": {"backend": "tesseract"}}"#;
         let config: ExtractionConfig = serde_json::from_str(json).unwrap();
-        assert!(
-            !config.effective_disable_ocr(),
-            "OCR should be enabled by default"
-        );
+        assert!(!config.effective_disable_ocr(), "OCR should be enabled by default");
     }
 }

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -496,7 +496,7 @@ impl ExtractionConfig {
     /// `disable_ocr = true`. This method is the single source of truth for whether
     /// OCR should be skipped.
     pub fn effective_disable_ocr(&self) -> bool {
-        self.disable_ocr || self.ocr.as_ref().map_or(false, |o| !o.enabled)
+        self.disable_ocr || self.ocr.as_ref().is_some_and(|o| !o.enabled)
     }
 
     /// Check if image processing is needed by examining OCR and image extraction settings.

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -489,6 +489,16 @@ impl ExtractionConfig {
         Ok(())
     }
 
+    /// Returns the effective disable-OCR value, accounting for both the top-level
+    /// `disable_ocr` flag and the `ocr.enabled` shorthand on [`OcrConfig`].
+    ///
+    /// Setting `ocr.enabled = false` in configuration is treated as equivalent to
+    /// `disable_ocr = true`. This method is the single source of truth for whether
+    /// OCR should be skipped.
+    pub fn effective_disable_ocr(&self) -> bool {
+        self.disable_ocr || self.ocr.as_ref().map_or(false, |o| !o.enabled)
+    }
+
     /// Check if image processing is needed by examining OCR and image extraction settings.
     ///
     /// Returns `true` if either OCR is enabled or image extraction is configured,
@@ -501,7 +511,7 @@ impl ExtractionConfig {
     /// decompression can improve CPU utilization by 5-10% by avoiding wasteful
     /// image I/O and processing when results won't be used.
     pub fn needs_image_processing(&self) -> bool {
-        let ocr_enabled = !self.disable_ocr && (self.ocr.is_some() || self.force_ocr);
+        let ocr_enabled = !self.effective_disable_ocr() && (self.ocr.is_some() || self.force_ocr);
 
         let image_extraction_enabled = self.images.as_ref().map(|i| i.extract_images).unwrap_or(false);
 
@@ -520,4 +530,72 @@ fn default_true() -> bool {
 
 fn default_archive_depth() -> usize {
     3
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::config::OcrConfig;
+
+    #[test]
+    fn test_effective_disable_ocr_from_top_level_flag() {
+        let config = ExtractionConfig {
+            disable_ocr: true,
+            ..Default::default()
+        };
+        assert!(config.effective_disable_ocr());
+    }
+
+    #[test]
+    fn test_effective_disable_ocr_from_ocr_enabled_false() {
+        let config = ExtractionConfig {
+            ocr: Some(OcrConfig {
+                enabled: false,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(
+            config.effective_disable_ocr(),
+            "ocr.enabled = false should be treated as disable_ocr = true"
+        );
+    }
+
+    #[test]
+    fn test_effective_disable_ocr_default_is_false() {
+        let config = ExtractionConfig::default();
+        assert!(!config.effective_disable_ocr());
+    }
+
+    #[test]
+    fn test_effective_disable_ocr_ocr_enabled_true_does_not_disable() {
+        let config = ExtractionConfig {
+            ocr: Some(OcrConfig {
+                enabled: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert!(!config.effective_disable_ocr());
+    }
+
+    #[test]
+    fn test_ocr_enabled_false_deserialized_from_json() {
+        let json = r#"{"ocr": {"enabled": false}}"#;
+        let config: ExtractionConfig = serde_json::from_str(json).unwrap();
+        assert!(
+            config.effective_disable_ocr(),
+            "JSON ocr.enabled=false should disable OCR"
+        );
+    }
+
+    #[test]
+    fn test_ocr_enabled_defaults_to_true() {
+        let json = r#"{"ocr": {"backend": "tesseract"}}"#;
+        let config: ExtractionConfig = serde_json::from_str(json).unwrap();
+        assert!(
+            !config.effective_disable_ocr(),
+            "OCR should be enabled by default"
+        );
+    }
 }

--- a/crates/kreuzberg/src/core/config/ocr.rs
+++ b/crates/kreuzberg/src/core/config/ocr.rs
@@ -204,6 +204,16 @@ pub struct OcrPipelineConfig {
 /// OCR configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OcrConfig {
+    /// Whether OCR is enabled.
+    ///
+    /// Setting `enabled: false` is a shorthand for `disable_ocr: true` on the parent
+    /// [`ExtractionConfig`](crate::core::config::ExtractionConfig). Images return
+    /// metadata only; PDFs use native text extraction without OCR fallback.
+    ///
+    /// Defaults to `true`. When `false`, all other OCR settings are ignored.
+    #[serde(default = "default_ocr_enabled")]
+    pub enabled: bool,
+
     /// OCR backend: tesseract, easyocr, paddleocr
     #[serde(default = "default_tesseract_backend")]
     pub backend: String,
@@ -266,6 +276,7 @@ pub struct OcrConfig {
 impl Default for OcrConfig {
     fn default() -> Self {
         Self {
+            enabled: true,
             backend: default_tesseract_backend(),
             language: default_eng(),
             tesseract_config: None,
@@ -352,6 +363,10 @@ impl OcrConfig {
             None
         }
     }
+}
+
+fn default_ocr_enabled() -> bool {
+    true
 }
 
 fn default_tesseract_backend() -> String {

--- a/crates/kreuzberg/src/core/extractor/bytes.rs
+++ b/crates/kreuzberg/src/core/extractor/bytes.rs
@@ -67,7 +67,7 @@ pub async fn extract_bytes(content: &[u8], mime_type: &str, config: &ExtractionC
     use crate::core::mime;
 
     let result = async {
-        if config.force_ocr && config.disable_ocr {
+        if config.force_ocr && config.effective_disable_ocr() {
             return Err(crate::KreuzbergError::Validation {
                 message: "force_ocr and disable_ocr cannot both be true".to_string(),
                 source: None,

--- a/crates/kreuzberg/src/core/extractor/file.rs
+++ b/crates/kreuzberg/src/core/extractor/file.rs
@@ -85,7 +85,7 @@ pub async fn extract_file(
     let result = async {
         io::validate_file_exists(path)?;
 
-        if config.force_ocr && config.disable_ocr {
+        if config.force_ocr && config.effective_disable_ocr() {
             return Err(crate::KreuzbergError::Validation {
                 message: "force_ocr and disable_ocr cannot both be true".to_string(),
                 source: None,

--- a/crates/kreuzberg/src/extractors/image.rs
+++ b/crates/kreuzberg/src/extractors/image.rs
@@ -407,8 +407,8 @@ impl DocumentExtractor for ImageExtractor {
             source_path: None,
         };
 
-        // When disable_ocr is set, skip OCR and return metadata only
-        if config.disable_ocr {
+        // When disable_ocr is set (or ocr.enabled = false), skip OCR and return metadata only
+        if config.effective_disable_ocr() {
             let mut doc = build_image_internal_document(None, Some(extracted_image));
             doc.metadata = Metadata {
                 format: Some(crate::types::FormatMetadata::Image(image_metadata)),

--- a/crates/kreuzberg/src/extractors/pdf/mod.rs
+++ b/crates/kreuzberg/src/extractors/pdf/mod.rs
@@ -541,7 +541,7 @@ impl PdfExtractor {
         #[cfg(feature = "ocr")]
         let mut ocr_internal_doc: Option<crate::types::internal::InternalDocument> = None;
         #[cfg(feature = "ocr")]
-        let (text, used_ocr) = if config.disable_ocr {
+        let (text, used_ocr) = if config.effective_disable_ocr() {
             (native_text, false)
         } else if config.force_ocr {
             let (ocr_text, ocr_tbls, ocr_elems, ocr_doc) = run_ocr_with_layout(content, config, path).await?;
@@ -1122,7 +1122,7 @@ impl PdfExtractor {
         let mut ocr_internal_doc: Option<InternalDocument> = None;
 
         #[cfg(feature = "ocr")]
-        let (text, _used_ocr) = if config.disable_ocr {
+        let (text, _used_ocr) = if config.effective_disable_ocr() {
             (native_text, false)
         } else if config.force_ocr {
             let (ocr_text, ocr_tbls, ocr_elems, ocr_doc) = run_ocr_with_layout(content, config, path).await?;


### PR DESCRIPTION
## Summary

- **#704** — `{"ocr": {"enabled": false}}` was silently ignored because `OcrConfig` had no `enabled` field and serde discarded unknown keys without error. This adds `enabled: bool` (default `true`) to `OcrConfig` and a new `ExtractionConfig::effective_disable_ocr()` method that treats `ocr.enabled = false` as equivalent to `disable_ocr = true`. All extraction-path checks that previously read `config.disable_ocr` now call `config.effective_disable_ocr()` so both flags are honoured uniformly.

- **#709** — `kreuzberg extract --format text` appended a trailing `\n` from `println!` that wasn't present in the `content` field of `--format json` output. Changed to `print!` for parity.

## Changes

| File | Change |
|---|---|
| `core/config/ocr.rs` | Add `enabled: bool` field + `default_ocr_enabled()` fn, update `Default` impl |
| `core/config/extraction/core.rs` | Add `effective_disable_ocr()` method + 6 unit tests |
| `core/extractor/file.rs`, `bytes.rs` | Use `effective_disable_ocr()` in conflict validation |
| `extractors/image.rs`, `pdf/mod.rs` | Use `effective_disable_ocr()` for OCR-skip decision |
| `kreuzberg-cli/commands/extract.rs` | `println!` → `print!` for `WireFormat::Text` |
| `kreuzberg-cli/commands/overrides.rs` | Add `enabled: true` to all `OcrConfig` struct literals |
| `kreuzberg-py/src/config/types.rs` | Expose `enabled` param + getter/setter in Python binding |
| `kreuzberg-node/typescript/types.ts` | Add `enabled?: boolean` to Node `OcrConfig` interface |

## Test plan

- [ ] `cargo test -p kreuzberg --lib core::config::extraction::core::tests` — 6 new tests all pass
- [ ] `cargo test -p kreuzberg --lib` — 986 tests pass, 0 failures
- [ ] `task lint` / `task check` — all hooks pass
- [ ] Manually verify: `echo '{"ocr":{"enabled":false}}' | kreuzberg extract --config - <image>` returns metadata only
- [ ] Manually verify: `kreuzberg extract --format text <file>` output has no trailing newline (`xxd | tail` shows last byte is not `0a` unless the document itself ends with one)

fixes #704 
fixes #709 