### PR TITLE
fix: call enableOcr() in live demo and throw on missing Rust registry export 

### DIFF
--- a/crates/kreuzberg-wasm/typescript/ocr/enabler.spec.ts
+++ b/crates/kreuzberg-wasm/typescript/ocr/enabler.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Tests for enableOcr() and the JS→Rust OCR registry bridge.
+ *
+ * Key invariant under test:
+ *   After enableOcr() completes, the Rust-side plugin registry must contain a
+ *   backend named "tesseract" — because that is the default OcrConfig.backend
+ *   the image extractor queries at extraction time.
+ *
+ * The critical failure mode is registerBackendInRustRegistry() silently returning
+ * when wasm.register_ocr_backend is absent/undefined, leaving the Rust registry
+ * empty while the JS registry appears populated.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+// Mock state module so we can control isInitialized() and getWasmModule()
+vi.mock("../extraction/internal.js", () => ({
+	isInitialized: vi.fn(() => true),
+}));
+
+vi.mock("../initialization/state.js", () => ({
+	getWasmModule: vi.fn(),
+}));
+
+// Mock runtime detection
+vi.mock("../runtime.js", () => ({
+	isBrowser: vi.fn(() => false),
+	isNode: vi.fn(() => false),
+}));
+
+// Mock the worker bridge — we don't need real Worker threads in unit tests
+vi.mock("./worker-bridge.js", () => ({
+	createOcrWorker: vi.fn(async () => undefined),
+	runOcrInWorker: vi.fn(async () => "mocked ocr text"),
+	terminateOcrWorker: vi.fn(async () => undefined),
+}));
+
+// Mock the JS-side OCR registry so we can observe registrations there too
+vi.mock("./registry.js", () => ({
+	registerOcrBackend: vi.fn(),
+}));
+
+// ── Imports (after mocks are declared) ───────────────────────────────────────
+
+import { isInitialized } from "../extraction/internal.js";
+import { getWasmModule } from "../initialization/state.js";
+import { isBrowser } from "../runtime.js";
+import { registerOcrBackend as registerJsOcrBackend } from "./registry.js";
+import { enableOcr } from "./enabler.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Build a minimal mock WasmModule with register_ocr_backend included. */
+function makeWasmModule(overrides: Record<string, unknown> = {}) {
+	return {
+		ocrIsAvailable: vi.fn(() => true),
+		ocrRecognize: vi.fn(() => "ocr text"),
+		register_ocr_backend: vi.fn(),
+		...overrides,
+	};
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("enableOcr()", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(isInitialized).mockReturnValue(true);
+		vi.mocked(isBrowser).mockReturnValue(false);
+	});
+
+	it("throws if WASM is not initialized", async () => {
+		vi.mocked(isInitialized).mockReturnValue(false);
+		vi.mocked(getWasmModule).mockReturnValue(null as any);
+
+		await expect(enableOcr()).rejects.toThrow("WASM module not initialized");
+	});
+
+	describe("when ocr-wasm feature is available (ocrIsAvailable returns true)", () => {
+		it("registers the JS-side backend", async () => {
+			const wasm = makeWasmModule();
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+
+			await enableOcr();
+
+			expect(registerJsOcrBackend).toHaveBeenCalledOnce();
+		});
+
+		it("registers a backend named 'tesseract' in the Rust registry", async () => {
+			const wasm = makeWasmModule();
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+
+			await enableOcr();
+
+			expect(wasm.register_ocr_backend).toHaveBeenCalledOnce();
+
+			// The adapter passed to the Rust registry MUST be named "tesseract"
+			// because that is what OcrConfig.backend defaults to.
+			const rustAdapter = vi.mocked(wasm.register_ocr_backend).mock.calls[0][0] as any;
+			expect(rustAdapter.name()).toBe("tesseract");
+		});
+
+		it("rust adapter has a supportedLanguages() method", async () => {
+			const wasm = makeWasmModule();
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+
+			await enableOcr();
+
+			const rustAdapter = vi.mocked(wasm.register_ocr_backend).mock.calls[0][0] as any;
+			const langs = rustAdapter.supportedLanguages();
+			expect(Array.isArray(langs)).toBe(true);
+			expect(langs.length).toBeGreaterThan(0);
+		});
+
+		it("rust adapter has a processImage() method that returns a JSON string", async () => {
+			const wasm = makeWasmModule();
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+
+			// Stub fetch so NativeWasmOcrBackend.getTessdata() doesn't hit the CDN.
+			const fakeTessdata = new Uint8Array([1, 2, 3]);
+			vi.stubGlobal(
+				"fetch",
+				vi.fn(async () => ({
+					ok: true,
+					arrayBuffer: async () => fakeTessdata.buffer,
+				})),
+			);
+
+			await enableOcr();
+
+			const rustAdapter = vi.mocked(wasm.register_ocr_backend).mock.calls[0][0] as any;
+			const result = await rustAdapter.processImage("base64imagedata", "eng");
+
+			vi.unstubAllGlobals();
+
+			// The Rust bridge expects a JSON string, not an object
+			expect(typeof result).toBe("string");
+			expect(() => JSON.parse(result)).not.toThrow();
+		});
+
+		it("throws immediately when register_ocr_backend is absent from the wasm module", async () => {
+			// Simulates the failure mode: the property is undefined because
+			// wasm-bindgen exports it under a different name at runtime, or the
+			// WASM binary was built without the 'ocr-wasm' feature.
+			//
+			// The fix (issue #719): enableOcr() must THROW rather than succeed
+			// silently. A silent return leaves the Rust registry empty, causing the
+			// cryptic "OCR backend 'tesseract' not registered. Available backends: []"
+			// error at extraction time — far harder to diagnose than an early throw.
+			const wasm = makeWasmModule({ register_ocr_backend: undefined });
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+
+			await expect(enableOcr()).rejects.toThrow("register_ocr_backend is not exported");
+		});
+	});
+
+	describe("when ocr-wasm feature is NOT available", () => {
+		it("falls back to TesseractWasmBackend in a browser environment", async () => {
+			const wasm = makeWasmModule({ ocrIsAvailable: vi.fn(() => false) });
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+			vi.mocked(isBrowser).mockReturnValue(true);
+
+			// TesseractWasmBackend.initialize() will fail because tesseract-wasm
+			// isn't installed in the test environment — that's fine, we just check
+			// it is attempted.
+			await expect(enableOcr()).rejects.toThrow();
+		});
+
+		it("throws a descriptive error in non-browser environments", async () => {
+			const wasm = makeWasmModule({ ocrIsAvailable: vi.fn(() => false) });
+			vi.mocked(getWasmModule).mockReturnValue(wasm as any);
+			vi.mocked(isBrowser).mockReturnValue(false);
+
+			await expect(enableOcr()).rejects.toThrow(/No OCR backend available/);
+		});
+	});
+});

--- a/crates/kreuzberg-wasm/typescript/ocr/enabler.ts
+++ b/crates/kreuzberg-wasm/typescript/ocr/enabler.ts
@@ -280,9 +280,21 @@ export async function enableOcr(): Promise<void> {
  * - processImage() returns a JSON string (not an object)
  */
 function registerBackendInRustRegistry(wasm: ReturnType<typeof getWasmModule>, backend: OcrBackendProtocol): void {
+	// wasm-bindgen exports the function as "register_ocr_backend" (snake_case).
+	// Guard against it being absent so we can emit a clear warning instead of
+	// silently leaving the Rust registry empty (which causes the "OCR backend
+	// 'tesseract' not registered. Available backends: []" error at extraction time).
 	const registerFn = wasm?.register_ocr_backend;
 	if (!registerFn) {
-		return;
+		// Fail fast: if the Rust bridge is absent, enableOcr() must throw rather
+		// than succeed silently. A silent return leaves the Rust registry empty,
+		// causing the cryptic "OCR backend 'tesseract' not registered. Available
+		// backends: []" error at extraction time — the exact bug in issue #719.
+		throw new Error(
+			"wasm.register_ocr_backend is not exported by the WASM module. " +
+				"The Rust-side OCR plugin registry cannot be populated. " +
+				"Ensure the WASM binary was built with the 'ocr-wasm' feature and the pkg glue is up to date.",
+		);
 	}
 
 	const rustAdapter = {
@@ -296,7 +308,12 @@ function registerBackendInRustRegistry(wasm: ReturnType<typeof getWasmModule>, b
 
 	try {
 		registerFn(rustAdapter);
-	} catch {
-		// Registration may fail if already registered; non-fatal
+	} catch (err) {
+		// wasm-bindgen throws if a backend with the same name is already registered.
+		// That is safe to ignore (idempotent re-registration). Re-throw anything else.
+		const msg = err instanceof Error ? err.message : String(err);
+		if (!msg.toLowerCase().includes("already registered")) {
+			throw new Error(`Failed to register OCR backend in the Rust plugin registry: ${msg}`);
+		}
 	}
 }

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -324,7 +324,7 @@
     </footer>
 
     <script type="module">
-      import { extractFromFile, initWasm } from 'https://cdn.jsdelivr.net/npm/@kreuzberg/wasm@latest/dist/index.js';
+      import { enableOcr, extractFromFile, initWasm } from 'https://cdn.jsdelivr.net/npm/@kreuzberg/wasm@latest/dist/index.js';
 
       const dropZone = document.getElementById("dropZone");
       const fileInput = document.getElementById("fileInput");
@@ -337,6 +337,10 @@
       let wasmReady = false;
       try {
         await initWasm('https://cdn.jsdelivr.net/npm/@kreuzberg/wasm@latest/dist/pkg/kreuzberg_wasm_bg.wasm');
+        // Enable OCR so image files (WebP, PNG, JPEG, etc.) can be extracted.
+        // Without this the Rust-side OCR plugin registry stays empty and any
+        // image upload fails with "OCR backend 'tesseract' not registered".
+        await enableOcr();
         wasmReady = true;
       } catch (e) {
         console.error('WASM initialization failed:', e);


### PR DESCRIPTION
  ## summary                                                                               
                                                            
  - `docs/demo.html`: the live demo never called `enableOcr()` after `initWasm()`, so the Rust-side OCR plugin registry was always empty. Any image extraction with an OCR config failed with the cryptic "OCR backend 'tesseract' not registered. Available backends: []" error. Added `await enableOcr()` to the initialization block.                                 
  - `enabler.ts`: `registerBackendInRustRegistry()` now throws immediately when `wasm.register_ocr_backend` is absent, rather than silently returning and leaving the Rust registry empty. Previously this silent failure made the error appear at extraction time with no indication of where registration went wrong.   
  - `enabler.spec.ts`: new test suite covering the critical failure mode (missing export throws), the full adapter contract (`name()` returns `"tesseract"`, `supportedLanguages()`, `processImage()` returns a JSON string), WASM-not-initialized guard, browser fallback, and non-browser error.          
                                                                                           
  ## test plan                                                                             
                                                                                           
  - [ ] `task wasm:test` - all unit tests pass including the 8 new `enabler.spec.ts` tests 
  - [ ] Manual: open `docs/demo.html` in a browser, drop in an image with text,
        confirm OCR output appears without errors in the console                           
  - [ ] Confirm `enableOcr()` rejects with a clear message when called before `initWasm()` 
                                                                                           
  closes #719    