### PR TITLE
docs: correct Cargo feature name from llm to liter-llm 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Incorrect `llm` Cargo feature name in docs** — `llm-integration.md`, `api-rust.md`, and `configuration.md` referenced a `llm` feature that does not exist; the correct name is `liter-llm`. (#717)
 - **LLM embedding provider panics in server mode** — `embed_texts` called `block_on` inside a new runtime, which panics when already inside tokio (HTTP server, MCP). Uses `block_in_place` with the current runtime handle when available, falls back to a new runtime for standalone sync callers. (#713, #714)
 - **Duplicate `output_format` key in OCR metadata** — stale `additional` HashMap insert caused a duplicate JSON key violating RFC 8259. The value is already on the typed `Metadata::output_format` field. (#712)
 - **OCR table metadata serialized as strings instead of numbers** — `table_count`, `tables_detected`, `table_rows`, and `table_cols` were `"0"` instead of `0`, breaking numeric comparisons in all bindings. (#712)

--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -3,7 +3,7 @@
 Kreuzberg integrates with 146 LLM providers (including local inference engines) via [liter-llm](https://github.com/kreuzberg-dev/liter-llm) for three capabilities: VLM OCR, structured extraction, and provider-hosted embeddings.
 
 !!! Note "Feature gate"
-    Requires the `llm` Cargo feature. Not included in the default feature set.
+    Requires the `liter-llm` Cargo feature. Not included in the default feature set.
 
 ## VLM OCR
 

--- a/docs/reference/api-rust.md
+++ b/docs/reference/api-rust.md
@@ -1812,7 +1812,7 @@ pub fn get_extensions_for_mime(mime_type: &str) -> Result<Vec<String>>
 
 ## LLM Integration
 
-Kreuzberg integrates with LLMs via the `liter-llm` crate for structured extraction and VLM-based OCR. Requires the `llm` feature flag. See the [LLM Integration Guide](../guides/llm-integration.md) for full details.
+Kreuzberg integrates with LLMs via the `liter-llm` crate for structured extraction and VLM-based OCR. Requires the `liter-llm` feature flag. See the [LLM Integration Guide](../guides/llm-integration.md) for full details.
 
 ### Structured Extraction
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -253,7 +253,7 @@ Main extraction configuration controlling all aspects of document processing.
 | `acceleration`               | `AccelerationConfig?`      | `None`                 | Hardware acceleration configuration for ONNX Runtime inference (layout detection and embeddings). See [AccelerationConfig](#accelerationconfig).                                                 |
 | `include_document_structure` | `bool`                     | `false`                | Enable structured document model output. When true, the `document` field on ExtractionResult is populated with a tree-based representation of document content.                                  |
 | `tree_sitter`                | `TreeSitterConfig?`        | `None`                 | Tree-sitter code intelligence configuration. Controls code analysis features when extracting source code files. Only available with `tree-sitter` feature.                                       |
-| `structured_extraction`      | `StructuredExtractionConfig?` | `None`              | Structured extraction configuration for LLM-powered schema-based extraction. When set, extraction results include a `structured_output` field with data conforming to the provided JSON schema. Only available with `llm` feature. |
+| `structured_extraction`      | `StructuredExtractionConfig?` | `None`              | Structured extraction configuration for LLM-powered schema-based extraction. When set, extraction results include a `structured_output` field with data conforming to the provided JSON schema. Only available with `liter-llm` feature. |
 
 ### Result Format vs Output Format
 
@@ -586,7 +586,7 @@ Configuration for OCR (Optical Character Recognition) processing on images and s
 | `language`         | `str`              | `"eng"`       | Language code(s) for OCR, for example, `"eng"`, `"eng+fra"`, `"eng+deu+fra"` |
 | `tesseract_config` | `TesseractConfig?` | `None`        | Tesseract-specific configuration options                              |
 | `paddle_ocr_config` | `PaddleOcrConfig?` | `None`       | PaddleOCR-specific configuration options                              |
-| `vlm_config`       | `LlmConfig?`       | `None`        | Vision Language Model configuration for VLM-based OCR. When set, enables using a VLM as an OCR backend. Requires the `llm` feature. |
+| `vlm_config`       | `LlmConfig?`       | `None`        | Vision Language Model configuration for VLM-based OCR. When set, enables using a VLM as an OCR backend. Requires the `liter-llm` feature. |
 | `vlm_prompt`       | `String?`           | `None`        | Custom prompt for VLM-based OCR. Overrides the default OCR prompt sent to the vision model. Useful for domain-specific extraction instructions. |
 
 ### Example
@@ -863,7 +863,7 @@ model = { type = "llm", model = "openai/text-embedding-3-small" }
 batch_size = 32
 ```
 
-**Note**: When `api_key` is not set in `LlmConfig`, liter-llm falls back to provider-standard environment variables (for example, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). Requires the `llm` feature.
+**Note**: When `api_key` is not set in `LlmConfig`, liter-llm falls back to provider-standard environment variables (for example, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`). Requires the `liter-llm` feature.
 
 ### Cache Directory
 


### PR DESCRIPTION
four occurrences across three doc files referenced a `llm` Cargo feature that doesn't exist. The correct name is `liter-llm`.

fixes #717   