### PR TITLE
docs: theme-colored language icons, footer nav, and card formatting

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -17,7 +17,9 @@ exclude = ["node_modules", "target", "dist", "vendor"]
 # MD046: Code block style (Zensical tabs indent fenced blocks)
 # MD051: Link fragment checking (incompatible with Zensical anchor generation)
 # MD076: Blank lines between list items (intentional formatting in READMEs)
-disable = ["MD012", "MD013", "MD024", "MD033", "MD036", "MD041", "MD046", "MD051", "MD076"]
+# MD030: Spaces after list markers (MkDocs Material grid cards require 3 spaces)
+# MD035: Horizontal rule style (grid cards use indented --- as card separators)
+disable = ["MD012", "MD013", "MD024", "MD030", "MD033", "MD035", "MD036", "MD041", "MD046", "MD051", "MD076"]
 
 # MD024: Allow duplicate heading names if they are not siblings
 [MD024]

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -997,7 +997,40 @@ strong {
 }
 
 .md-footer__inner.md-grid {
-	display: none;
+	background-color: #323040;
+	max-width: 100%;
+	width: 100%;
+	padding-left: 2rem;
+	padding-right: 2rem;
+}
+
+.md-footer__link {
+	color: rgba(255, 255, 255, 0.7);
+	transition: color 0.2s;
+}
+
+.md-footer__link:hover {
+	color: #fff;
+}
+
+[data-md-color-scheme="default"] .md-footer__link:hover .md-footer__title {
+	color: #da2ae0;
+}
+
+[data-md-color-scheme="slate"] .md-footer__link:hover .md-footer__title {
+	color: #58fbda;
+}
+
+.md-footer__inner .md-footer__button.md-icon svg {
+	fill: none;
+	stroke: rgba(255, 255, 255, 0.7);
+}
+
+.md-footer-meta__inner.md-grid {
+	max-width: 100%;
+	width: 100%;
+	padding-left: 2rem;
+	padding-right: 2rem;
 }
 
 .md-footer-meta {
@@ -1757,14 +1790,16 @@ body:has(.full-width-iframe) article {
 	font-size: 1rem;
 }
 
-/* Language icon color — black in light mode */
-.md-typeset .install-cards .lg svg {
-	fill: #1a1926 !important;
+/* Language icon color — pink accent in light mode */
+.md-typeset .install-cards .lg svg,
+.md-typeset .install-cards .lg svg path {
+	fill: #da2ae0;
 }
 
-/* Language icon color — white in dark mode */
-[data-md-color-scheme="slate"] .md-typeset .install-cards .lg svg {
-	fill: #ffffff !important;
+/* Language icon color — teal accent in dark mode */
+[data-md-color-scheme="slate"] .md-typeset .install-cards .lg svg,
+[data-md-color-scheme="slate"] .md-typeset .install-cards .lg svg path {
+	fill: #58fbda;
 }
 
 .md-typeset .install-cards .highlight {

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -62,9 +62,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
 
 <div class="grid cards install-cards" markdown>
 
-- :fontawesome-brands-python:{ .lg .middle } **Python**
+-   :fontawesome-brands-python:{ .lg .middle } **Python**
 
----
+    ---
 
     ```bash
     pip install kreuzberg
@@ -73,9 +73,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-python.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-node-js:{ .lg .middle } **TypeScript (Node.js / Bun)**
+-   :fontawesome-brands-node-js:{ .lg .middle } **TypeScript (Node.js / Bun)**
 
----
+    ---
 
     ```bash
     npm install @kreuzberg/node
@@ -84,9 +84,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-typescript.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#typescript){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-js:{ .lg .middle } **TypeScript (Browser / Edge)**
+-   :fontawesome-brands-js:{ .lg .middle } **TypeScript (Browser / Edge)**
 
----
+    ---
 
     ```bash
     npm install @kreuzberg/wasm
@@ -95,9 +95,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-wasm.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#typescript){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-rust:{ .lg .middle } **Rust**
+-   :fontawesome-brands-rust:{ .lg .middle } **Rust**
 
----
+    ---
 
     ```bash
     cargo add kreuzberg
@@ -106,9 +106,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-rust.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-golang:{ .lg .middle } **Go**
+-   :fontawesome-brands-golang:{ .lg .middle } **Go**
 
----
+    ---
 
     ```bash
     go get github.com/kreuzberg-dev/kreuzberg/packages/go/v4@latest
@@ -117,9 +117,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-go.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-java:{ .lg .middle } **Java**
+-   :fontawesome-brands-java:{ .lg .middle } **Java**
 
----
+    ---
 
     ```gradle
     implementation 'dev.kreuzberg:kreuzberg:4.8.5'
@@ -128,9 +128,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-java.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#java){ .install-btn .install-btn--solid }
 
-- :material-language-ruby:{ .lg .middle } **Ruby**
+-   :material-language-ruby:{ .lg .middle } **Ruby**
 
----
+    ---
 
     ```bash
     gem install kreuzberg
@@ -139,9 +139,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-ruby.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :material-language-csharp:{ .lg .middle } **C# / .NET**
+-   :material-language-csharp:{ .lg .middle } **C# / .NET**
 
----
+    ---
 
     ```bash
     dotnet add package Kreuzberg
@@ -150,9 +150,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-csharp.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](../guides/csharp.md){ .install-btn .install-btn--solid }
 
-- :fontawesome-brands-php:{ .lg .middle } **PHP**
+-   :fontawesome-brands-php:{ .lg .middle } **PHP**
 
----
+    ---
 
     ```bash
     composer require kreuzberg/kreuzberg
@@ -161,9 +161,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-php.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :simple-elixir:{ .lg .middle } **Elixir**
+-   :simple-elixir:{ .lg .middle } **Elixir**
 
----
+    ---
 
     ```elixir
     {:kreuzberg, "~> 4.0"}
@@ -172,9 +172,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-elixir.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](#elixir){ .install-btn .install-btn--solid }
 
-- :simple-r:{ .lg .middle } **R**
+-   :simple-r:{ .lg .middle } **R**
 
----
+    ---
 
     ```r
     install.packages("kreuzberg",
@@ -184,9 +184,9 @@ The fastest way to try Kreuzberg - no SDK, no code, just your terminal.
     [API Reference](../reference/api-r.md){ .install-btn .install-btn--ghost }
     [:material-lightning-bolt: Quick Start](quickstart.md){ .install-btn .install-btn--solid }
 
-- :simple-cplusplus:{ .lg .middle } **C / C++**
+-   :simple-cplusplus:{ .lg .middle } **C / C++**
 
----
+    ---
 
     ```bash
     cargo build -p kreuzberg-ffi


### PR DESCRIPTION
## Summary

- Fix language icons to use theme accent colors (`#da2ae0` pink in light / `#58fbda` teal in dark) consistently across FontAwesome, Material, and SimpleIcons sources
- Enable footer navigation with theme-colored hover states
- Fix MkDocs grid card list formatting (3-space indentation) and disable related linter rules (MD030, MD035)

Closes #455