### PR TITLE
docs: dark-mode style fixes and content corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3029,6 +3029,7 @@ See [Migration Guide](https://docs.kreuzberg.dev/migration/v3-to-v4/) for detail
 - [Format Support](docs/reference/formats.md) - Supported file formats
 - [Extraction Guide](docs/guides/extraction.md) - Extraction examples
 
+[4.8.5]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.5
 [4.8.4]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.4
 [4.8.3]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.3
 [4.8.2]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.2

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -419,6 +419,18 @@ html {
 	color: #323040;
 }
 
+[data-md-color-scheme="slate"] .md-typeset details:not([class]),
+[data-md-color-scheme="slate"] .md-typeset details:not([class]) > summary,
+[data-md-color-scheme="slate"] .md-typeset details:not([class]) p,
+[data-md-color-scheme="slate"] .md-typeset details:not([class]) li,
+[data-md-color-scheme="slate"] .md-typeset details:not([class]) strong {
+	color: rgba(255, 255, 255, 0.9);
+}
+
+.md-typeset details:not([class])[open] {
+	padding-bottom: 0.6rem;
+}
+
 [data-md-color-scheme="slate"] .md-typeset .admonition > .admonition-title,
 [data-md-color-scheme="slate"] .md-typeset details > summary {
 	margin: 0 0 0.6rem 0;

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1422,7 +1422,12 @@ nav.md-nav--secondary > .md-nav__list > .md-nav__item > .md-nav > .md-nav__list 
 }
 
 [data-md-color-scheme="default"] .md-top svg {
-	fill: #323040;
+	color: #da2ae0;
+}
+
+[data-md-color-scheme="default"] .md-top svg circle {
+	fill: #000000;
+	stroke: #000000;
 }
 
 [data-md-color-scheme="default"] .md-top:hover {
@@ -1438,7 +1443,12 @@ nav.md-nav--secondary > .md-nav__list > .md-nav__item > .md-nav > .md-nav__list 
 }
 
 [data-md-color-scheme="slate"] .md-top svg {
-	fill: #000000 !important;
+	color: #58fbda;
+}
+
+[data-md-color-scheme="slate"] .md-top svg circle {
+	fill: #000000;
+	stroke: #000000;
 }
 
 .benchmark-dashboard {

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -419,6 +419,28 @@ html {
 	color: #323040;
 }
 
+[data-md-color-scheme="slate"] .md-typeset .admonition > .admonition-title,
+[data-md-color-scheme="slate"] .md-typeset details > summary {
+	margin: 0 0 0.6rem 0;
+	padding-top: 0.6rem;
+	padding-bottom: 0.6rem;
+	padding-left: 2.4rem;
+	padding-right: 1rem;
+	color: rgba(255, 255, 255, 0.9);
+}
+
+[data-md-color-scheme="slate"] .md-typeset .admonition > .admonition-title::before,
+[data-md-color-scheme="slate"] .md-typeset details > summary::before {
+	top: 0.6rem;
+	bottom: 0.6rem;
+	left: 1rem;
+}
+
+[data-md-color-scheme="slate"] .md-typeset details > summary::after {
+	top: 0.6rem;
+	right: 1rem;
+}
+
 [data-md-color-scheme="slate"] .md-typeset .admonition.note,
 [data-md-color-scheme="slate"] .md-typeset details.note {
 	border: 2px solid #2558ff;

--- a/docs/guides/docker.md
+++ b/docs/guides/docker.md
@@ -32,7 +32,7 @@ Official Docker images built on the Rust core with Debian 13 (Trixie). Each imag
 
 | | **Core** | **Full** |
 |---|---|---|
-| **Image** | `ghcr.io/kreuzberg-dev/kreuzberg:latest` | `ghcr.io/kreuzberg-dev/kreuzberg:latest` |
+| **Image** | `ghcr.io/kreuzberg-dev/kreuzberg:core` | `ghcr.io/kreuzberg-dev/kreuzberg:latest` |
 | **Size** | ~1.0–1.3 GB | ~1.5–2.1 GB |
 | **Tesseract OCR** | 12 languages | 12 languages |
 | **Modern Office** | DOCX, PPTX, XLSX | DOCX, PPTX, XLSX |

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -13,6 +13,7 @@ Kreuzberg integrates with AI frameworks, databases, and search engines — bring
 | LlamaIndex | [LlamaIndex](https://www.llamaindex.ai/) | [`llama-index-readers-kreuzberg`](https://pypi.org/project/llama-index-readers-kreuzberg/) | [GitHub](https://github.com/kreuzberg-dev/llama-index-kreuzberg) |
 | Haystack | [Haystack](https://haystack.deepset.ai/) | [`kreuzberg-haystack`](https://pypi.org/project/kreuzberg-haystack/) | [GitHub](https://github.com/deepset-ai/haystack-core-integrations/tree/main/integrations/kreuzberg) |
 | CrewAI | [CrewAI](https://www.crewai.com/) | [`kreuzberg-crewai`](https://pypi.org/project/kreuzberg-crewai/) | [GitHub](https://github.com/kreuzberg-dev/kreuzberg-crewai) |
+| txtAI | [txtAI](https://neuml.github.io/txtai/) | [`kreuzberg-txtai`](https://pypi.org/project/kreuzberg-txtai/) | [GitHub](https://github.com/kreuzberg-dev/kreuzberg-txtai) |
 | SurrealDB | [SurrealDB](https://surrealdb.com/) | [`kreuzberg-surrealdb`](https://pypi.org/project/kreuzberg-surrealdb/) | [SurrealDB](surrealdb.md) |
 
 !!! Tip "Building a new integration?"


### PR DESCRIPTION
Bundles docs CSS polish and content corrections on the `docs/fixes` branch.

**Dark-mode CSS (`docs/css/extra.css`)**
- Align admonition header padding (`0.6rem` vertical, `2.4rem`/`1rem` horizontal) and shift icon/chevron to match; default summary text color so untyped admonitions render correctly
- Make plain `<details>` readable in slate scheme: override text color to `rgba(255,255,255,0.9)` (scoped via `:not([class])` so styled admonitions are untouched) and add bottom padding when open
- Color the back-to-top icon with the theme accent (`#da2ae0` light / `#58fbda` slate) on a solid black circle for contrast

**Content fixes**
- `docs/guides/docker.md`: correct Core image tag from `:latest` to `:core` to match the publish-docker workflow
- `docs/integrations/index.md`: add `kreuzberg-txtai` row alongside other AI-framework integrations
- `CHANGELOG.md`: add v4.8.5 release link