### PR TITLE
fix: expose structured_output on Ruby Result

### DIFF
--- a/packages/ruby/ext/kreuzberg_rb/native/src/result.rs
+++ b/packages/ruby/ext/kreuzberg_rb/native/src/result.rs
@@ -751,6 +751,10 @@ pub fn extraction_result_to_ruby(ruby: &Ruby, result: RustExtractionResult) -> R
         set_hash_entry(ruby, &hash, "llm_usage", ruby.qnil().as_value())?;
     }
 
+    // Convert structured output (Value::Null maps to qnil via json_value_to_ruby)
+    let structured_ruby = json_value_to_ruby(ruby, &result.structured_output)?;
+    set_hash_entry(ruby, &hash, "structured_output", structured_ruby)?;
+
     // Convert annotations
     if let Some(annotations) = result.annotations {
         let annotations_array = ruby.ary_new();

--- a/packages/ruby/lib/kreuzberg/result.rb
+++ b/packages/ruby/lib/kreuzberg/result.rb
@@ -15,7 +15,7 @@ module Kreuzberg
     attr_reader :content, :mime_type, :metadata, :metadata_json, :tables,
                 :detected_languages, :chunks, :images, :pages, :elements, :ocr_elements, :djot_content,
                 :document, :extracted_keywords, :quality_score, :processing_warnings, :annotations,
-                :uris, :children
+                :uris, :children, :structured_output
 
     # @!attribute [r] cells
     #   @return [Array<Array<String>>] Table cells (2D array)
@@ -342,6 +342,7 @@ module Kreuzberg
       @annotations = parse_annotations(get_value(hash, 'annotations'))
       @uris = parse_uris(get_value(hash, 'uris'))
       @children = parse_children(get_value(hash, 'children'))
+      @structured_output = get_value(hash, 'structured_output')
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
@@ -369,7 +370,8 @@ module Kreuzberg
         processing_warnings: @processing_warnings.map(&:to_h),
         annotations: @annotations&.map(&:to_h),
         uris: @uris&.map(&:to_h),
-        children: @children&.map(&:to_h)
+        children: @children&.map(&:to_h),
+        structured_output: @structured_output
       }
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength

--- a/packages/ruby/sig/kreuzberg.rbs
+++ b/packages/ruby/sig/kreuzberg.rbs
@@ -1548,6 +1548,7 @@ module Kreuzberg
     attr_reader uris: Array[uri_hash]?
     attr_reader children: Array[archive_entry_hash]?
     attr_reader llm_usage: Array[LlmUsage]?
+    attr_reader structured_output: (Hash[String, untyped] | Array[untyped] | Integer | Float | String | bool | nil)
 
     # PDF annotation extracted from a document page (Struct from result.rb)
     class PdfAnnotation


### PR DESCRIPTION
                                                                                           
  ## problem                                                

  `Kreuzberg::Result` had no `structured_output` accessor, and the native extension never included it in the hash returned to Ruby. Passing a `structured_extraction` config was silently ignored ,. the LLM call was never made, and `result.structured_output` raised `NoMethodError`.                       
                                                                                           
  ## root cause (two separate gaps)                                                        
                                                                                           
  1. `extraction_result_to_ruby` in `result.rs` serialized every field of  `ExtractionResult` into the Ruby hash except `structured_output`. assignment, and no entry in `to_h` for the field.                                     
                                                                                           
  ## fix                                                                                   
                                                                                           
  - Serialize `structured_output` via `json_value_to_ruby` in the native extension. Since the field is `serde_json::Value` (not `Option`), `Value::Null` maps to `nil` automatically — no conditional needed.
  - Add `attr_reader :structured_output` and assign it in `initialize`  with a plain `get_value` call, identical to how `quality_score` is handled.                                                                               
  - Include `structured_output` in `Result#to_h`.                                          
  - Update `kreuzberg.rbs` with the precise JSON union type instead of  `untyped`.                                                                             
                                                                                           
  ## testing
                                                                                           
  Existing contract spec (`e2e/ruby/spec/contract_spec.rb`) covers `assert_structured_output` assertions. All checks pass (`task check`).      
  
  closes #722 