### PR TITLE
fix: preserve _internal_bindings.pyi during wheel artifact cleanup

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -595,7 +595,7 @@ jobs:
 
       - name: Clean previous wheel artifacts
         shell: bash
-        run: rm -rf target/wheels target/maturin && rm -f packages/python/kreuzberg/_internal_bindings.*
+        run: rm -rf target/wheels target/maturin && find packages/python/kreuzberg -name "_internal_bindings.*" ! -name "*.pyi" -delete
 
       - name: Build CLI binary (native)
         if: runner.os != 'Linux'


### PR DESCRIPTION
## Problem

Published wheels do not contain `_internal_bindings.pyi`, even though the file exists in the source tree and is listed in `[tool.maturin].include`. The `py.typed` marker is present, so type checkers expect inline types but find nothing for the core binding module.

This affects all published versions I checked (4.0.8 through 4.8.6).

```
$ unzip -l kreuzberg-4.8.6-cp310-abi3-manylinux_2_28_x86_64.whl | grep pyi
# (no output)
```

## Cause

The "Clean previous wheel artifacts" step in `publish.yaml` (line 598) runs:

```bash
rm -f packages/python/kreuzberg/_internal_bindings.*
```

This glob deletes the `.pyi` stub along with the compiled `.abi3.so`/`.pyd` artifacts it targets. Maturin then builds the wheel without the stub file.

## Fix

Replace the glob with a `find` that excludes `.pyi` files:

```bash
find packages/python/kreuzberg -name "_internal_bindings.*" ! -name "*.pyi" -delete
```

This still cleans compiled artifacts from previous builds without touching the type stub.

## Note

`ensure_stub_file()` in `packages/python/build.py` looks like a previous attempt to solve this, but it is not reached during CI builds because `maturin-action` invokes `maturin build` directly, bypassing PEP 517 hooks. Its generated stub also only covers a few types, unlike the comprehensive `_internal_bindings.pyi` in the source tree.

Relates to #422.