### PR TITLE
fix: honor explicit OCR backend selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OCR backend dispatch**: `OcrConfig(backend=...)` with a non-default backend no longer silently falls back to paddleocr when the chosen backend errors — auto-fallback is limited to the default tesseract backend; users who want multi-backend fallback configure it via `OcrConfig.pipeline` (unchanged).
+- **EasyOCR on PDFs**: `EasyOCRBackend.supports_document_processing()` returns `False` so Rust's `PdfRenderer` handles page rendering, removing the implicit `pdf2image`/`pymupdf` requirement that was never declared in the `[easyocr]` extra.
 - **Cross-format parity test failure** — HTML extractor now normalizes setext headings to ATX and strips trailing whitespace from html-to-markdown-rs output.
 - **Broken wasm-deno/wasm-workers e2e tasks** — removed non-functional deno and workers e2e generate/lint/test tasks that referenced invalid generator lang values.
 - **oxlint path in node e2e lint** — `oxlint --fix typescript` changed to `oxlint --fix .` (was looking for nonexistent `typescript/` directory).

--- a/crates/kreuzberg/src/core/config/ocr.rs
+++ b/crates/kreuzberg/src/core/config/ocr.rs
@@ -323,9 +323,12 @@ impl OcrConfig {
     /// Returns the effective pipeline config.
     ///
     /// - If `pipeline` is explicitly set, returns it.
-    /// - If `paddle-ocr` feature is compiled in and no explicit pipeline is set,
-    ///   auto-constructs a default pipeline: primary backend (priority 100) + paddleocr (priority 50).
-    /// - Otherwise returns `None` (single-backend mode, same as today).
+    /// - If `paddle-ocr` is compiled in and the backend is the default
+    ///   (tesseract), auto-constructs `[tesseract @ 100, paddleocr @ 50]`.
+    /// - Otherwise returns `None` (single-backend mode).
+    ///
+    /// Explicit non-default backend selections are honored as-is — a silent
+    /// paddleocr fallback would mask errors from the chosen backend.
     pub fn effective_pipeline(&self) -> Option<OcrPipelineConfig> {
         if self.pipeline.is_some() {
             return self.pipeline.clone();
@@ -333,25 +336,28 @@ impl OcrConfig {
 
         #[cfg(feature = "paddle-ocr")]
         {
-            let mut stages = vec![OcrPipelineStage {
-                backend: self.backend.clone(),
-                priority: 100,
-                language: None,
-                tesseract_config: self.tesseract_config.clone(),
-                paddle_ocr_config: None,
-                vlm_config: self.vlm_config.clone(),
-            }];
-            // Only add paddleocr fallback if primary backend isn't already paddleocr
-            if self.backend != "paddleocr" {
-                stages.push(OcrPipelineStage {
+            if self.backend != default_tesseract_backend() {
+                return None;
+            }
+
+            let stages = vec![
+                OcrPipelineStage {
+                    backend: self.backend.clone(),
+                    priority: 100,
+                    language: None,
+                    tesseract_config: self.tesseract_config.clone(),
+                    paddle_ocr_config: None,
+                    vlm_config: self.vlm_config.clone(),
+                },
+                OcrPipelineStage {
                     backend: "paddleocr".to_string(),
                     priority: 50,
                     language: None,
                     tesseract_config: None,
                     paddle_ocr_config: self.paddle_ocr_config.clone(),
                     vlm_config: None,
-                });
-            }
+                },
+            ];
             Some(OcrPipelineConfig {
                 stages,
                 quality_thresholds: self.effective_thresholds(),
@@ -485,29 +491,21 @@ mod tests {
     }
 
     #[test]
-    fn test_effective_pipeline_paddleocr_backend_no_duplicate() {
-        // When primary backend is "paddleocr", effective_pipeline should NOT add
-        // a second paddleocr stage (issue #6 fix).
+    fn test_effective_pipeline_explicit_paddleocr_no_autofallback() {
         let config = OcrConfig {
             backend: "paddleocr".to_string(),
             ..Default::default()
         };
-        let result = config.effective_pipeline();
-        // With paddle-ocr feature: should have exactly 1 stage (no duplicate)
-        // Without paddle-ocr feature: should be None
-        #[cfg(feature = "paddle-ocr")]
-        {
-            let pipeline = result.unwrap();
-            let paddle_count = pipeline.stages.iter().filter(|s| s.backend == "paddleocr").count();
-            assert_eq!(
-                paddle_count, 1,
-                "Should not have duplicate paddleocr stages, found {paddle_count}"
-            );
-        }
-        #[cfg(not(feature = "paddle-ocr"))]
-        {
-            assert!(result.is_none());
-        }
+        assert!(config.effective_pipeline().is_none());
+    }
+
+    #[test]
+    fn test_effective_pipeline_explicit_easyocr_no_autofallback() {
+        let config = OcrConfig {
+            backend: "easyocr".to_string(),
+            ..Default::default()
+        };
+        assert!(config.effective_pipeline().is_none());
     }
 
     #[test]

--- a/packages/python/kreuzberg/ocr/easyocr.py
+++ b/packages/python/kreuzberg/ocr/easyocr.py
@@ -209,8 +209,14 @@ class EasyOCRBackend:
         logger.info("EasyOCR backend shutdown")
 
     def supports_document_processing(self) -> bool:
-        """EasyOCR supports native document-level processing for PDFs and multi-page images."""
-        return True
+        """Delegate PDF/multi-page rendering to kreuzberg's Rust core.
+
+        EasyOCR's ``_process_pdf`` required ``pdf2image``/``pymupdf`` (not in
+        the ``[easyocr]`` extra). Returning False lets kreuzberg render pages
+        and call :meth:`process_image` per page, aligning with tesseract and
+        paddleocr.
+        """
+        return False
 
     def process_image(self, image_bytes: bytes, language: str) -> dict[str, Any]:
         """Process image bytes and extract text using EasyOCR.

--- a/packages/python/tests/binding/ocr/test_easyocr_backend.py
+++ b/packages/python/tests/binding/ocr/test_easyocr_backend.py
@@ -258,27 +258,11 @@ def test_easyocr_supported_languages() -> None:
     assert "en" in supported
 
 
-def test_easyocr_process_document() -> None:
-    """Test process_document correctly delegates to PDF or image extraction."""
+def test_easyocr_does_not_support_document_processing() -> None:
+    """Delegate PDF rendering to the Rust core — no pdf2image/pymupdf needed."""
     pytest.importorskip("easyocr", reason="EasyOCR not installed")
 
     from kreuzberg.ocr.easyocr import EasyOCRBackend
 
     backend = EasyOCRBackend(languages=["en"], use_gpu=False)
-    backend._reader = Mock()
-
-    # Mock readtext to return a known mock result
-    backend._reader.readtext.return_value = [
-        ([[0, 0], [10, 0], [10, 10], [0, 10]], "Extracted Header", 0.99),
-        ([[0, 10], [10, 10], [10, 20], [0, 20]], "Mocked Content", 0.90),
-    ]
-
-    with patch.object(backend, "_process_pdf") as mock_pdf:
-        mock_pdf.return_value = {
-            "content": "Mocked Content from PDF",
-            "metadata": {"mean_text_conf": 99, "page_count": 2},
-            "tables": [],
-        }
-        res = backend.process_document("fake_file.pdf", "en")
-        assert res["content"] == "Mocked Content from PDF"
-        mock_pdf.assert_called_once_with("fake_file.pdf", "en")
+    assert backend.supports_document_processing() is False


### PR DESCRIPTION
## Problem

`OcrConfig(backend="easyocr")` on a PDF returns paddleocr's output with no error/warning. EasyOCR models download, but the returned text isn't from easyocr — it's paddleocr's.

Reproduction (fresh `pip install "kreuzberg[easyocr]==4.9.1"`):

```python
import asyncio, hashlib
from kreuzberg import ExtractionConfig, OcrConfig, extract_file

async def main():
    cfg = ExtractionConfig(
        force_ocr=True, use_cache=False,
        ocr=OcrConfig(backend="easyocr", language="ru"),
    )
    r = await extract_file("scan.pdf", config=cfg)
    print(hashlib.sha256((r.content or "").encode()).hexdigest()[:16])

asyncio.run(main())
```

Output sha matches `backend="paddleocr"` byte-for-byte. Confirmed distinct by running `easyocr.Reader(["ru"]).readtext(img)` standalone on the same rendered page — clearly different output.

## Root cause

Three pieces compound:

1. `effective_pipeline()` (`crates/kreuzberg/src/core/config/ocr.rs`) auto-constructs `[user_backend @ 100, paddleocr @ 50]` whenever `paddle-ocr` is compiled in — even for explicit non-default, non-paddleocr backends.
2. `EasyOCRBackend._process_pdf` (`packages/python/kreuzberg/ocr/easyocr.py`) requires `pdf2image` or `pymupdf`; neither is declared in the `[easyocr]` extra.
3. `run_ocr_pipeline` (`crates/kreuzberg/src/extractors/pdf/ocr.rs`) logs stage errors at `tracing::warn!`, which Python callers don't see.

Net: easyocr stage raises → swallowed → paddleocr stage runs → paddleocr output returned under the requested-backend label.

## Fix

- `effective_pipeline()`: only add the paddleocr fallback when the backend is the default (`tesseract`). Explicit non-default selections use single-backend mode; errors propagate to the caller. Callers who want multi-backend fallback configure `OcrConfig.pipeline` explicitly (unchanged).
- `EasyOCRBackend.supports_document_processing()`: return `False` so the Rust `PdfRenderer` handles page rendering (300 DPI, memory-aware) and calls `process_image` per page — aligning EasyOCR with tesseract/paddleocr. Removes the implicit `pdf2image`/`pymupdf` requirement; `[easyocr]` extra stays as declared.

## Tests

- `core::config::ocr`: 20 pass. Added `test_effective_pipeline_explicit_{paddleocr,easyocr}_no_autofallback`.
- `test_easyocr_backend.py`: 18 pass. Replaced `_process_pdf` delegation test with `supports_document_processing() is False`.
