### PR TITLE
feat: expose extraction_method on ExtractionResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Layout detection regions on PageContent** — new `layout_regions` field exposes detected layout regions (class, confidence, bounding box, area fraction) from the RT-DETR model when layout detection is enabled. Enables programmatic detection of diagrams, figures, tables, and other content types per page. Available across all 10 bindings. (#579)
 - **LayoutRegion type files** for Java, PHP, and Elixir bindings (were referenced but missing).
 - **E2E assertions for layout regions** — `has_layout_regions` and `layout_classes_include` assertion types in all 12 language generators.
+- `ExtractionResult.extraction_method` / `extractionMethod` is now surfaced in the TypeScript and PHP binding type definitions, and image OCR results now mark the extraction method as `ocr`.
 
 ### Fixed
 

--- a/crates/kreuzberg-node/metadata.d.ts
+++ b/crates/kreuzberg-node/metadata.d.ts
@@ -445,7 +445,6 @@ export interface ExtractionResult<T extends Record<string, unknown> = Record<str
 	content: string;
 	mimeType: string;
 	metadata: Metadata<T>;
-	extractionMethod?: "native" | "ocr" | "mixed";
 	tables: ExtractedTable[];
 	detectedLanguages?: string[];
 	chunks?: string[];

--- a/crates/kreuzberg-node/metadata.d.ts
+++ b/crates/kreuzberg-node/metadata.d.ts
@@ -445,6 +445,7 @@ export interface ExtractionResult<T extends Record<string, unknown> = Record<str
 	content: string;
 	mimeType: string;
 	metadata: Metadata<T>;
+	extractionMethod?: "native" | "ocr" | "mixed";
 	tables: ExtractedTable[];
 	detectedLanguages?: string[];
 	chunks?: string[];

--- a/crates/kreuzberg-node/src/result.rs
+++ b/crates/kreuzberg-node/src/result.rs
@@ -236,6 +236,8 @@ pub struct JsExtractionResult {
     pub mime_type: String,
     #[napi(ts_type = "Metadata")]
     pub metadata: serde_json::Value,
+    #[napi(js_name = "extractionMethod")]
+    pub extraction_method: Option<String>,
     pub tables: Vec<JsTable>,
     pub detected_languages: Vec<String>,
     pub chunks: Vec<JsChunk>,
@@ -612,6 +614,7 @@ impl TryFrom<RustExtractionResult> for JsExtractionResult {
             content: val.content,
             mime_type: val.mime_type.to_string(),
             metadata,
+            extraction_method: val.extraction_method.map(|method| method.as_str().to_string()),
             tables: val
                 .tables
                 .into_iter()
@@ -877,6 +880,9 @@ impl TryFrom<JsExtractionResult> for RustExtractionResult {
             content: val.content,
             mime_type: std::borrow::Cow::Owned(val.mime_type),
             metadata,
+            extraction_method: val
+                .extraction_method
+                .and_then(|method| serde_json::from_value(serde_json::Value::String(method)).ok()),
             tables: val
                 .tables
                 .into_iter()

--- a/crates/kreuzberg-node/typescript/core/type-converters.ts
+++ b/crates/kreuzberg-node/typescript/core/type-converters.ts
@@ -261,15 +261,6 @@ function convertResult(rawResult: unknown): ExtractionResult {
 		document: (result["document"] as Record<string, unknown> | null) ?? null,
 	};
 
-	const extractionMethodData = result["extractionMethod"];
-	if (
-		extractionMethodData === "native" ||
-		extractionMethodData === "ocr" ||
-		extractionMethodData === "mixed"
-	) {
-		returnObj.extractionMethod = extractionMethodData;
-	}
-
 	const chunksData = result["chunks"];
 	if (Array.isArray(chunksData)) {
 		returnObj.chunks = (chunksData as unknown[]).map((chunk) => convertChunk(chunk));

--- a/crates/kreuzberg-node/typescript/core/type-converters.ts
+++ b/crates/kreuzberg-node/typescript/core/type-converters.ts
@@ -261,6 +261,15 @@ function convertResult(rawResult: unknown): ExtractionResult {
 		document: (result["document"] as Record<string, unknown> | null) ?? null,
 	};
 
+	const extractionMethodData = result["extractionMethod"];
+	if (
+		extractionMethodData === "native" ||
+		extractionMethodData === "ocr" ||
+		extractionMethodData === "mixed"
+	) {
+		returnObj.extractionMethod = extractionMethodData;
+	}
+
 	const chunksData = result["chunks"];
 	if (Array.isArray(chunksData)) {
 		returnObj.chunks = (chunksData as unknown[]).map((chunk) => convertChunk(chunk));

--- a/crates/kreuzberg-node/typescript/types.ts
+++ b/crates/kreuzberg-node/typescript/types.ts
@@ -1351,9 +1351,6 @@ export interface ExtractionResult {
 	/** Document metadata including title, author, creation date, language, and format-specific fields */
 	metadata: Metadata;
 
-	/** How text was extracted from the source document. */
-	extractionMethod?: "native" | "ocr" | "mixed";
-
 	/** Tables extracted from the document (2D cell arrays with Markdown representation) */
 	tables: Table[];
 

--- a/crates/kreuzberg-node/typescript/types.ts
+++ b/crates/kreuzberg-node/typescript/types.ts
@@ -1351,6 +1351,9 @@ export interface ExtractionResult {
 	/** Document metadata including title, author, creation date, language, and format-specific fields */
 	metadata: Metadata;
 
+	/** How text was extracted from the source document. */
+	extractionMethod?: "native" | "ocr" | "mixed";
+
 	/** Tables extracted from the document (2D cell arrays with Markdown representation) */
 	tables: Table[];
 

--- a/crates/kreuzberg-php/src/types.rs
+++ b/crates/kreuzberg-php/src/types.rs
@@ -510,6 +510,11 @@ pub struct ExtractionResult {
     /// Document metadata (stored as serialized JSON, accessed via __get getter)
     metadata_json: String,
 
+    /// How text was extracted from the source document
+    #[php(prop)]
+    #[php(name = "extractionMethod")]
+    pub extraction_method: Option<String>,
+
     /// Extracted tables (accessed via getter property)
     pub tables: Vec<ExtractedTable>,
 
@@ -855,6 +860,13 @@ impl ExtractionResult {
                     Ok(None)
                 }
             }
+            "extractionMethod" | "extraction_method" => {
+                if let Some(method) = &self.extraction_method {
+                    Ok(Some(method.clone().into_zval(false)?))
+                } else {
+                    Ok(None)
+                }
+            }
             "annotations" => {
                 if let Some(annotations) = &self.annotations {
                     Ok(Some(annotations.clone().into_zval(false)?))
@@ -1167,6 +1179,7 @@ impl ExtractionResult {
             content: result.content,
             mime_type: result.mime_type.to_string(),
             metadata_json,
+            extraction_method: result.extraction_method.map(|method| method.as_str().to_string()),
             tables,
             detected_languages: result.detected_languages,
             images,

--- a/crates/kreuzberg-py/src/types.rs
+++ b/crates/kreuzberg-py/src/types.rs
@@ -17,6 +17,7 @@ use crate::plugins::json_value_to_py;
 ///     content (str): Extracted text content
 ///     mime_type (str): MIME type of the extracted document
 ///     metadata (dict): Document metadata as key-value pairs
+///     extraction_method (str | None): How text was extracted (`native`, `ocr`, or `mixed`)
 ///     tables (list[ExtractedTable]): Extracted tables
 ///     detected_languages (list[dict] | None): Detected languages with confidence scores
 ///     document (DocumentStructure | None): Hierarchical document structure if extraction enabled
@@ -40,6 +41,10 @@ pub struct ExtractionResult {
     pub mime_type: String,
 
     metadata: Py<PyDict>,
+
+    #[pyo3(get)]
+    pub extraction_method: Option<String>,
+
     tables: Py<PyList>,
 
     #[pyo3(get)]
@@ -794,6 +799,7 @@ impl ExtractionResult {
             content: result.content,
             mime_type: result.mime_type.to_string(),
             metadata,
+            extraction_method: result.extraction_method.map(|method| method.as_str().to_string()),
             tables: tables.unbind(),
             detected_languages,
             images,
@@ -848,6 +854,7 @@ mod tests {
             let rust_result = kreuzberg::ExtractionResult {
                 content: "hello".to_string(),
                 mime_type: Cow::Borrowed("text/plain"),
+                extraction_method: Some(kreuzberg::ExtractionMethod::Native),
                 detected_languages: Some(vec!["en".to_string()]),
                 quality_score: Some(0.85),
                 processing_warnings: vec![kreuzberg::ProcessingWarning {
@@ -863,6 +870,7 @@ mod tests {
             assert_eq!(py_result.mime_type, "text/plain");
             assert!(py_result.metadata(py).is_empty());
             assert_eq!(py_result.tables(py).len(), 0);
+            assert_eq!(py_result.extraction_method.as_deref(), Some("native"));
             assert!(py_result.detected_languages.is_some());
             assert!(py_result.document.is_none());
             assert!(py_result.extracted_keywords.is_none());

--- a/crates/kreuzberg/src/extraction/derive.rs
+++ b/crates/kreuzberg/src/extraction/derive.rs
@@ -16,7 +16,7 @@ use ahash::AHashMap;
 use crate::types::document_structure::{
     DocumentNode, DocumentRelationship, DocumentStructure, GridCell, NodeContent, NodeId, NodeIndex, TableGrid,
 };
-use crate::types::extraction::ExtractionResult;
+use crate::types::extraction::{ExtractionMethod, ExtractionResult};
 use crate::types::internal::{ElementKind, InternalDocument, InternalElement, RelationshipTarget};
 use crate::types::ocr_elements::{OcrConfidence, OcrElement};
 use crate::types::page::PageContent;
@@ -654,6 +654,13 @@ pub fn derive_extraction_result(
         _ => None,
     };
 
+    let extraction_method = doc
+        .metadata
+        .additional
+        .get("extraction_method")
+        .and_then(serde_json::Value::as_str)
+        .and_then(ExtractionMethod::from_metadata_value);
+
     tracing::debug!(
         content_length = content.len(),
         has_document_structure = document.is_some(),
@@ -663,6 +670,7 @@ pub fn derive_extraction_result(
         content,
         mime_type,
         metadata: doc.metadata,
+        extraction_method,
         tables: doc.tables,
         images,
         pages,
@@ -1059,5 +1067,31 @@ mod tests {
         let result = derive_extraction_result(doc, true, crate::core::config::OutputFormat::Plain);
         let ds = result.document.unwrap();
         assert_eq!(ds.source_format.as_deref(), Some("epub"));
+    }
+
+    #[test]
+    fn test_derive_extraction_result_promotes_extraction_method() {
+        let mut doc = make_doc("pdf");
+        doc.metadata.additional.insert(
+            Cow::Borrowed("extraction_method"),
+            serde_json::Value::String("mixed".to_string()),
+        );
+        doc.push_element(InternalElement::text(ElementKind::Paragraph, "Hello world.", 0));
+
+        let result = derive_extraction_result(doc, false, crate::core::config::OutputFormat::Plain);
+        assert_eq!(result.extraction_method, Some(ExtractionMethod::Mixed));
+    }
+
+    #[test]
+    fn test_derive_extraction_result_ignores_unknown_extraction_method() {
+        let mut doc = make_doc("pdf");
+        doc.metadata.additional.insert(
+            Cow::Borrowed("extraction_method"),
+            serde_json::Value::String("native_ole".to_string()),
+        );
+        doc.push_element(InternalElement::text(ElementKind::Paragraph, "Hello world.", 0));
+
+        let result = derive_extraction_result(doc, false, crate::core::config::OutputFormat::Plain);
+        assert_eq!(result.extraction_method, None);
     }
 }

--- a/crates/kreuzberg/src/extractors/image.rs
+++ b/crates/kreuzberg/src/extractors/image.rs
@@ -24,6 +24,13 @@ impl ImageExtractor {
         Self
     }
 
+    fn mark_ocr_extraction(doc: &mut InternalDocument) {
+        doc.metadata.additional.insert(
+            std::borrow::Cow::Borrowed("extraction_method"),
+            serde_json::Value::String(crate::types::ExtractionMethod::Ocr.as_str().to_string()),
+        );
+    }
+
     /// Extract text from image using OCR with optional page tracking for multi-frame TIFFs.
     #[cfg(any(feature = "ocr", feature = "ocr-wasm"))]
     async fn extract_with_ocr(
@@ -87,6 +94,7 @@ impl ImageExtractor {
             // Build InternalDocument from OCR text
             let mut doc = build_image_internal_document(Some(&ocr_extraction_result.content), None);
             doc.metadata = ocr_metadata;
+            Self::mark_ocr_extraction(&mut doc);
 
             // Store OCR elements directly to avoid injecting raw word tokens into the
             // rendering pipeline, which would double the top-level content (#706).
@@ -120,6 +128,7 @@ impl ImageExtractor {
             let _ = mime_type;
             let mut doc = build_image_internal_document(Some(&ocr_content), None);
             doc.metadata = ocr_metadata;
+            Self::mark_ocr_extraction(&mut doc);
             doc.prebuilt_ocr_elements = ocr_elements;
             let text = ocr_content.trim().to_string();
             if !text.is_empty() {
@@ -304,6 +313,7 @@ impl ImageExtractor {
             output_format: Some("markdown".to_string()),
             ..Default::default()
         };
+        Self::mark_ocr_extraction(&mut doc);
 
         Ok(doc)
     }

--- a/crates/kreuzberg/src/extractors/pdf/mod.rs
+++ b/crates/kreuzberg/src/extractors/pdf/mod.rs
@@ -1270,7 +1270,7 @@ impl PdfExtractor {
                         _ocr_elements_from_ocr = ocr_elems;
                         ocr_internal_doc = ocr_doc;
                         ocr_llm_usage = llm_usage;
-                        (ocr_text, true)
+                        (ocr_text, ExtractionMethod::Ocr)
                     }
                     Err(e) => {
                         tracing::warn!(

--- a/crates/kreuzberg/src/extractors/pdf/mod.rs
+++ b/crates/kreuzberg/src/extractors/pdf/mod.rs
@@ -10,8 +10,8 @@ mod pages;
 use crate::Result;
 use crate::core::config::{ExtractionConfig, OutputFormat};
 use crate::plugins::{DocumentExtractor, Plugin};
-use crate::types::Metadata;
 use crate::types::internal::{ElementKind, InternalDocument, InternalElement};
+use crate::types::{ExtractionMethod, Metadata};
 use async_trait::async_trait;
 #[cfg(feature = "tokio-runtime")]
 use std::path::Path;
@@ -627,8 +627,8 @@ impl PdfExtractor {
         #[cfg(feature = "ocr")]
         let mut ocr_llm_usage: Vec<crate::types::LlmUsage> = Vec::new();
         #[cfg(feature = "ocr")]
-        let (text, used_ocr) = if config.effective_disable_ocr() {
-            (native_text, false)
+        let (text, extraction_method) = if config.effective_disable_ocr() {
+            (native_text, ExtractionMethod::Native)
         } else if config.force_ocr {
             let (ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage) =
                 run_ocr_with_layout(content, config, path).await?;
@@ -636,7 +636,7 @@ impl PdfExtractor {
             _ocr_elements_from_ocr = ocr_elems;
             ocr_internal_doc = ocr_doc;
             ocr_llm_usage = llm_usage;
-            (ocr_text, true)
+            (ocr_text, ExtractionMethod::Ocr)
         } else if let Some(ref ocr_pages) = config.force_ocr_pages {
             if !ocr_pages.is_empty() {
                 if let Some(ref bounds) = boundaries {
@@ -645,17 +645,17 @@ impl PdfExtractor {
                             ocr::extract_mixed_ocr_native(&native_text, bounds, ocr_pages, content, config, path)
                                 .await?;
                         ocr_llm_usage = mixed_llm_usage;
-                        (mixed, true)
+                        (mixed, ExtractionMethod::Mixed)
                     } else {
                         tracing::warn!("force_ocr_pages set but no page boundaries available; using native text");
-                        (native_text, false)
+                        (native_text, ExtractionMethod::Native)
                     }
                 } else {
                     tracing::warn!("force_ocr_pages set but no page boundaries available; using native text");
-                    (native_text, false)
+                    (native_text, ExtractionMethod::Native)
                 }
             } else {
-                (native_text, false)
+                (native_text, ExtractionMethod::Native)
             }
         } else if let Some(ocr_config) = config.ocr.as_ref() {
             let thresholds = ocr_config.effective_thresholds();
@@ -724,7 +724,7 @@ impl PdfExtractor {
                     alnum_ws_chars,
                     "Skipping OCR: font encoding issues but content is non-textual and pre-rendered structured doc available"
                 );
-                (native_text, false)
+                (native_text, ExtractionMethod::Native)
             } else if has_substantive_doc {
                 tracing::debug!(
                     total_chars,
@@ -733,7 +733,7 @@ impl PdfExtractor {
                     has_font_encoding_issues,
                     "Skipping OCR: pre-rendered structured doc available with substantive native text"
                 );
-                (native_text, false)
+                (native_text, ExtractionMethod::Native)
             } else if decision.fallback || has_font_encoding_issues {
                 match run_ocr_with_layout(content, config, path).await {
                     Ok((ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage)) => {
@@ -741,25 +741,25 @@ impl PdfExtractor {
                         _ocr_elements_from_ocr = ocr_elems;
                         ocr_internal_doc = ocr_doc;
                         ocr_llm_usage = llm_usage;
-                        (ocr_text, true)
+                        (ocr_text, ExtractionMethod::Ocr)
                     }
                     Err(e) => {
                         tracing::warn!(
                             error = %e,
                             "OCR fallback failed; using native text extraction result"
                         );
-                        (native_text, false)
+                        (native_text, ExtractionMethod::Native)
                     }
                 }
             } else {
-                (native_text, false)
+                (native_text, ExtractionMethod::Native)
             }
         } else {
-            (native_text, false)
+            (native_text, ExtractionMethod::Native)
         };
 
         #[cfg(not(feature = "ocr"))]
-        let (text, used_ocr) = (native_text, false);
+        let (text, extraction_method) = (native_text, ExtractionMethod::Native);
 
         // Merge OCR-detected tables with native-extracted tables.
         // When OCR was used, its TATR-detected tables may be more accurate for scanned pages.
@@ -773,6 +773,7 @@ impl PdfExtractor {
         // The document was rendered during the first document load to avoid redundant PDF parsing.
         // OCR results already produce structured output via the hOCR path, so this only applies
         // when native text extraction was used and structured output was requested.
+        let used_ocr = extraction_method.used_ocr();
         #[cfg(feature = "pdf")]
         let use_structured_doc = !used_ocr && pre_rendered_doc.is_some();
         tracing::debug!(
@@ -1035,6 +1036,10 @@ impl PdfExtractor {
                 format: Some(crate::types::FormatMetadata::Pdf(pdf_metadata.pdf_specific)),
                 ..Default::default()
             };
+            doc.metadata.additional.insert(
+                std::borrow::Cow::Borrowed("extraction_method"),
+                serde_json::Value::String(extraction_method.as_str().to_string()),
+            );
             // When the OCR path produced a structured InternalDocument, its tables are
             // already embedded with matching ElementKind::Table indices. Overwriting
             // doc.tables would break those references. Instead, merge any additional
@@ -1239,8 +1244,8 @@ impl PdfExtractor {
         let mut ocr_llm_usage: Vec<crate::types::LlmUsage> = Vec::new();
 
         #[cfg(feature = "ocr")]
-        let (text, _used_ocr) = if config.effective_disable_ocr() {
-            (native_text, false)
+        let (text, extraction_method) = if config.effective_disable_ocr() {
+            (native_text, ExtractionMethod::Native)
         } else if config.force_ocr {
             let (ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage) =
                 run_ocr_with_layout(content, config, path).await?;
@@ -1248,7 +1253,7 @@ impl PdfExtractor {
             _ocr_elements_from_ocr = ocr_elems;
             ocr_internal_doc = ocr_doc;
             ocr_llm_usage = llm_usage;
-            (ocr_text, true)
+            (ocr_text, ExtractionMethod::Ocr)
         } else if let Some(ocr_config) = config.ocr.as_ref() {
             let thresholds = ocr_config.effective_thresholds();
             let decision = evaluate_per_page_ocr(
@@ -1272,18 +1277,18 @@ impl PdfExtractor {
                             error = %e,
                             "OCR fallback failed on oxide path; using native text"
                         );
-                        (native_text, false)
+                        (native_text, ExtractionMethod::Native)
                     }
                 }
             } else {
-                (native_text, false)
+                (native_text, ExtractionMethod::Native)
             }
         } else {
-            (native_text, false)
+            (native_text, ExtractionMethod::Native)
         };
 
         #[cfg(not(feature = "ocr"))]
-        let (text, _used_ocr) = (native_text, false);
+        let (text, extraction_method) = (native_text, ExtractionMethod::Native);
 
         #[cfg(feature = "ocr")]
         if !ocr_tables.is_empty() {
@@ -1341,15 +1346,7 @@ impl PdfExtractor {
 
         // When a pre-rendered structured document is available (headings, paragraphs from
         // font-size clustering), use it directly. Otherwise fall back to flat paragraph splitting.
-        let used_ocr;
-        #[cfg(feature = "ocr")]
-        {
-            used_ocr = ocr_internal_doc.is_some();
-        }
-        #[cfg(not(feature = "ocr"))]
-        {
-            used_ocr = false;
-        }
+        let used_ocr = extraction_method.used_ocr();
 
         let use_structured_doc = !used_ocr && pre_rendered_doc.is_some();
 
@@ -1400,6 +1397,10 @@ impl PdfExtractor {
             format: Some(crate::types::FormatMetadata::Pdf(pdf_metadata.pdf_specific)),
             ..Default::default()
         };
+        doc.metadata.additional.insert(
+            std::borrow::Cow::Borrowed("extraction_method"),
+            serde_json::Value::String(extraction_method.as_str().to_string()),
+        );
 
         // When using the structured doc, tables are already interleaved by the assembly pipeline.
         // Only add tables separately for the flat-text fallback path.
@@ -1539,6 +1540,85 @@ mod tests {
     use super::*;
     #[cfg(feature = "ocr")]
     use crate::core::config::OcrQualityThresholds;
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    use serial_test::serial;
+
+    #[cfg(feature = "pdf")]
+    fn pdf_test_document(name: &str) -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(format!("../../test_documents/pdf/{name}"))
+    }
+
+    #[cfg(feature = "pdf")]
+    fn extraction_method(result: &crate::types::ExtractionResult) -> Option<ExtractionMethod> {
+        result.extraction_method
+    }
+
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    struct MockPdfOcrBackend {
+        name: &'static str,
+        content: &'static str,
+    }
+
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    impl crate::plugins::Plugin for MockPdfOcrBackend {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn version(&self) -> String {
+            "1.0.0".to_string()
+        }
+
+        fn initialize(&self) -> crate::Result<()> {
+            Ok(())
+        }
+
+        fn shutdown(&self) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    #[async_trait::async_trait]
+    impl crate::plugins::OcrBackend for MockPdfOcrBackend {
+        fn backend_type(&self) -> crate::plugins::OcrBackendType {
+            crate::plugins::OcrBackendType::Custom
+        }
+
+        fn supports_language(&self, _lang: &str) -> bool {
+            true
+        }
+
+        async fn process_image(
+            &self,
+            _image_bytes: &[u8],
+            _config: &crate::core::config::OcrConfig,
+        ) -> crate::Result<crate::types::ExtractionResult> {
+            Ok(crate::types::ExtractionResult {
+                content: self.content.to_string(),
+                mime_type: std::borrow::Cow::Borrowed("text/plain"),
+                ..Default::default()
+            })
+        }
+    }
+
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    struct RegisteredOcrBackendGuard {
+        name: &'static str,
+    }
+
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    impl Drop for RegisteredOcrBackendGuard {
+        fn drop(&mut self) {
+            let _ = crate::plugins::unregister_ocr_backend(self.name);
+        }
+    }
+
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    fn register_mock_ocr_backend(name: &'static str, content: &'static str) -> RegisteredOcrBackendGuard {
+        crate::plugins::register_ocr_backend(std::sync::Arc::new(MockPdfOcrBackend { name, content })).unwrap();
+        RegisteredOcrBackendGuard { name }
+    }
 
     #[test]
     fn test_pdf_extractor_plugin_interface() {
@@ -1839,6 +1919,96 @@ mod tests {
                     "Page markers should be inserted when configured and document has multiple pages"
                 );
             }
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "pdf")]
+    async fn test_pdf_exposes_native_extraction_method() {
+        let extractor = PdfExtractor::new();
+        let config = ExtractionConfig::default();
+        let pdf_path = pdf_test_document("google_doc_document.pdf");
+
+        if let Ok(content) = std::fs::read(pdf_path) {
+            let result = extractor
+                .extract_bytes(&content, "application/pdf", &config)
+                .await
+                .expect("native PDF extraction should succeed");
+            let result = crate::extraction::derive::derive_extraction_result(
+                result,
+                true,
+                crate::core::config::OutputFormat::Plain,
+            );
+
+            assert_eq!(extraction_method(&result), Some(ExtractionMethod::Native));
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    #[serial]
+    async fn test_pdf_exposes_ocr_extraction_method() {
+        use crate::core::config::OcrConfig;
+
+        let _backend = register_mock_ocr_backend("pdf-extraction-method-ocr", "mock OCR text");
+        let extractor = PdfExtractor::new();
+        let config = ExtractionConfig {
+            force_ocr: true,
+            ocr: Some(OcrConfig {
+                backend: "pdf-extraction-method-ocr".to_string(),
+                language: "eng".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pdf_path = pdf_test_document("multi_page.pdf");
+
+        if let Ok(content) = std::fs::read(pdf_path) {
+            let result = extractor
+                .extract_bytes(&content, "application/pdf", &config)
+                .await
+                .expect("forced OCR extraction should succeed");
+            let result = crate::extraction::derive::derive_extraction_result(
+                result,
+                true,
+                crate::core::config::OutputFormat::Plain,
+            );
+
+            assert_eq!(extraction_method(&result), Some(ExtractionMethod::Ocr));
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(all(feature = "pdf", feature = "ocr"))]
+    #[serial]
+    async fn test_pdf_exposes_mixed_extraction_method() {
+        use crate::core::config::OcrConfig;
+
+        let _backend = register_mock_ocr_backend("pdf-extraction-method-mixed", "mixed OCR page");
+        let extractor = PdfExtractor::new();
+        let config = ExtractionConfig {
+            force_ocr_pages: Some(vec![1]),
+            ocr: Some(OcrConfig {
+                backend: "pdf-extraction-method-mixed".to_string(),
+                language: "eng".to_string(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pdf_path = pdf_test_document("multi_page.pdf");
+
+        if let Ok(content) = std::fs::read(pdf_path) {
+            let result = extractor
+                .extract_bytes(&content, "application/pdf", &config)
+                .await
+                .expect("mixed OCR/native extraction should succeed");
+            let result = crate::extraction::derive::derive_extraction_result(
+                result,
+                true,
+                crate::core::config::OutputFormat::Plain,
+            );
+
+            assert_eq!(extraction_method(&result), Some(ExtractionMethod::Mixed));
         }
     }
 

--- a/crates/kreuzberg/src/types/extraction.rs
+++ b/crates/kreuzberg/src/types/extraction.rs
@@ -12,6 +12,39 @@ use super::ocr_elements::OcrElement;
 use super::page::PageContent;
 use super::tables::Table;
 
+/// How the extracted text was produced.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractionMethod {
+    Native,
+    Ocr,
+    Mixed,
+}
+
+impl ExtractionMethod {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Ocr => "ocr",
+            Self::Mixed => "mixed",
+        }
+    }
+
+    pub fn used_ocr(self) -> bool {
+        !matches!(self, Self::Native)
+    }
+
+    pub(crate) fn from_metadata_value(value: &str) -> Option<Self> {
+        match value {
+            "native" => Some(Self::Native),
+            "ocr" => Some(Self::Ocr),
+            "mixed" => Some(Self::Mixed),
+            _ => None,
+        }
+    }
+}
+
 /// General extraction result used by the core extraction API.
 ///
 /// This is the main result type returned by all extraction functions.
@@ -23,6 +56,13 @@ pub struct ExtractionResult {
     #[cfg_attr(feature = "api", schema(value_type = String))]
     pub mime_type: Cow<'static, str>,
     pub metadata: Metadata,
+    /// Extraction strategy used to produce the returned text.
+    ///
+    /// Populated when the extractor can reliably distinguish native text extraction,
+    /// OCR-only extraction, or mixed native/OCR output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub extraction_method: Option<ExtractionMethod>,
     pub tables: Vec<Table>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detected_languages: Option<Vec<String>>,

--- a/e2e/c/helpers.c
+++ b/e2e/c/helpers.c
@@ -640,6 +640,23 @@ void assert_keywords(const CExtractionResult *result,
     }
 }
 
+void assert_extraction_method(const CExtractionResult *result,
+                              const char *expected) {
+    const char *metadata_json = result->metadata_json ? result->metadata_json : "";
+    char needle[128];
+    char spaced_needle[128];
+    snprintf(needle, sizeof(needle), "\"extraction_method\":\"%s\"", expected);
+    snprintf(spaced_needle, sizeof(spaced_needle), "\"extraction_method\": \"%s\"", expected);
+    if (str_contains_ci(metadata_json, needle) || str_contains_ci(metadata_json, spaced_needle)) {
+        return;
+    }
+    fprintf(stderr,
+            "FAIL: expected extraction_method \"%s\" in metadata_json but got %s\n",
+            expected,
+            metadata_json[0] ? metadata_json : "(null)");
+    exit(1);
+}
+
 void assert_quality_score(const CExtractionResult *result,
                           int has_score, int score_present,
                           int has_min, double min_score,

--- a/e2e/c/helpers.h
+++ b/e2e/c/helpers.h
@@ -119,6 +119,9 @@ void assert_keywords(const CExtractionResult *result,
                      int has_min, size_t min_count,
                      int has_max, size_t max_count);
 
+void assert_extraction_method(const CExtractionResult *result,
+                              const char *expected);
+
 void assert_quality_score(const CExtractionResult *result,
                           int has_score, int score_present,
                           int has_min, double min_score,

--- a/e2e/c/test_contract.c
+++ b/e2e/c/test_contract.c
@@ -467,6 +467,16 @@ static void test_contract_config_email_msg_fallback_codepage(void) {
     kreuzberg_free_result(result);
 }
 
+static void test_contract_config_extraction_method_mixed(void) {
+    if (skip_if_feature_unavailable("ocr")) return;
+    CExtractionResult *result = run_extraction("pdf/multi_page.pdf", "{\"force_ocr_pages\":[2],\"ocr\":{\"backend\":\"tesseract\",\"language\":\"eng\"}}");
+    if (!result) return; /* skipped */
+    assert_expected_mime(result, (const char *[]){"application/pdf"}, 1);
+    assert_min_content_length(result, 1);
+    assert_extraction_method(result, "mixed");
+    kreuzberg_free_result(result);
+}
+
 static void test_contract_config_extraction_timeout(void) {
     CExtractionResult *result = run_extraction("pdf/fake_memo.pdf", "{\"extraction_timeout_secs\":300}");
     if (!result) return; /* skipped */
@@ -873,6 +883,7 @@ int main(void) {
     test_contract_config_document_structure_with_headings();
     test_contract_config_element_types();
     test_contract_config_email_msg_fallback_codepage();
+    test_contract_config_extraction_method_mixed();
     test_contract_config_extraction_timeout();
     test_contract_config_force_ocr();
     test_contract_config_force_ocr_pages();

--- a/e2e/csharp/ContractTests.cs
+++ b/e2e/csharp/ContractTests.cs
@@ -504,6 +504,21 @@ namespace Kreuzberg.E2E.Contract
         }
 
         [SkippableFact]
+        public void ConfigExtractionMethodMixed()
+        {
+            TestHelpers.SkipIfFeatureUnavailable("ocr");
+            TestHelpers.SkipIfLegacyOfficeDisabled("pdf/multi_page.pdf");
+            TestHelpers.SkipIfOfficeTestOnWindows("pdf/multi_page.pdf");
+            var documentPath = TestHelpers.EnsureDocument("pdf/multi_page.pdf", true);
+            var config = TestHelpers.BuildConfig("{\"force_ocr_pages\":[2],\"ocr\":{\"backend\":\"tesseract\",\"language\":\"eng\"}}");
+
+            var result = KreuzbergClient.ExtractFileSync(documentPath, config);
+            TestHelpers.AssertExpectedMime(result, new[] { "application/pdf" });
+            TestHelpers.AssertMinContentLength(result, 1);
+            TestHelpers.AssertExtractionMethod(result, "mixed");
+        }
+
+        [SkippableFact]
         public void ConfigExtractionTimeout()
         {
             TestHelpers.SkipIfLegacyOfficeDisabled("pdf/fake_memo.pdf");

--- a/e2e/csharp/Helpers.cs
+++ b/e2e/csharp/Helpers.cs
@@ -832,6 +832,15 @@ public static class TestHelpers
         }
     }
 
+    public static void AssertExtractionMethod(ExtractionResult result, string expected)
+    {
+        var actual = result.Metadata?.Additional?["extraction_method"]?.ToString();
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw new XunitException($"Expected extraction_method={expected} but got {actual ?? "null"}");
+        }
+    }
+
     public static void AssertContentNotEmpty(ExtractionResult result)
     {
         if (string.IsNullOrEmpty(result.Content))

--- a/e2e/elixir/test/e2e/contract_test.exs
+++ b/e2e/elixir/test/e2e/contract_test.exs
@@ -814,6 +814,29 @@ defmodule E2E.ContractTest do
       end
     end
 
+    test "config_extraction_method_mixed" do
+      case E2E.Helpers.run_fixture(
+             "config_extraction_method_mixed",
+             "pdf/multi_page.pdf",
+             %{force_ocr_pages: [2], ocr: %{backend: "tesseract", language: "eng"}},
+             requirements: ["ocr"],
+             notes: nil,
+             skip_if_missing: true
+           ) do
+        {:ok, result} ->
+          result
+          |> E2E.Helpers.assert_expected_mime(["application/pdf"])
+          |> E2E.Helpers.assert_min_content_length(1)
+          |> E2E.Helpers.assert_extraction_method(is: "mixed")
+
+        {:skipped, reason} ->
+          IO.puts("SKIPPED: #{reason}")
+
+        {:error, reason} ->
+          flunk("Extraction failed: #{inspect(reason)}")
+      end
+    end
+
     test "config_extraction_timeout" do
       case E2E.Helpers.run_fixture(
              "config_extraction_timeout",

--- a/e2e/elixir/test/support/e2e_helpers.ex
+++ b/e2e/elixir/test/support/e2e_helpers.ex
@@ -636,6 +636,17 @@ defmodule E2E.Helpers do
     result
   end
 
+  def assert_extraction_method(result, opts) do
+    metadata = Map.get(result, :metadata) || Map.get(result, "metadata") || %{}
+    additional = Map.get(metadata, :additional) || Map.get(metadata, "additional") || %{}
+    actual = Map.get(additional, "extraction_method") || Map.get(additional, :extraction_method)
+
+    assert actual == opts[:is],
+           "Expected extraction_method=#{opts[:is]} but got #{inspect(actual)}"
+
+    result
+  end
+
   def assert_content_not_empty(result) do
     content_len = String.length(result.content || "")
 

--- a/e2e/go/contract_test.go
+++ b/e2e/go/contract_test.go
@@ -363,6 +363,22 @@ func TestContractConfigEmailMsgFallbackCodepage(t *testing.T) {
 	assertMinContentLength(t, result, 10)
 }
 
+func TestContractConfigExtractionMethodMixed(t *testing.T) {
+	skipIfFeatureUnavailable(t, "ocr")
+	result := runExtraction(t, "pdf/multi_page.pdf", []byte(`{
+"force_ocr_pages": [
+	2
+],
+"ocr": {
+	"backend": "tesseract",
+	"language": "eng"
+}
+}`))
+	assertExpectedMime(t, result, []string{"application/pdf"})
+	assertMinContentLength(t, result, 1)
+	assertExtractionMethod(t, result, "mixed")
+}
+
 func TestContractConfigExtractionTimeout(t *testing.T) {
 	result := runExtraction(t, "pdf/fake_memo.pdf", []byte(`{
 "extraction_timeout_secs": 300

--- a/e2e/go/helpers_test.go
+++ b/e2e/go/helpers_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"unicode"
 
-	kreuzberg "github.com/kreuzberg-dev/kreuzberg/packages/go/v4"
+	"github.com/kreuzberg-dev/kreuzberg/packages/go/v4"
 )
 
 var (
@@ -602,6 +602,24 @@ func assertKeywords(t *testing.T, result *kreuzberg.ExtractionResult, hasKeyword
 	}
 	if maxCount != nil && count > *maxCount {
 		t.Fatalf("expected at most %d keywords, found %d", *maxCount, count)
+	}
+}
+
+func assertExtractionMethod(t *testing.T, result *kreuzberg.ExtractionResult, expected string) {
+	t.Helper()
+	if result.Metadata.Additional == nil {
+		t.Fatalf("expected extraction_method=%q but metadata.additional was empty", expected)
+	}
+	raw, ok := result.Metadata.Additional["extraction_method"]
+	if !ok {
+		t.Fatalf("expected extraction_method=%q but metadata.additional had no extraction_method key", expected)
+	}
+	var actual string
+	if err := json.Unmarshal(raw, &actual); err != nil {
+		t.Fatalf("failed to decode extraction_method from metadata.additional: %v", err)
+	}
+	if actual != expected {
+		t.Fatalf("expected extraction_method=%q, got %q", expected, actual)
 	}
 }
 

--- a/e2e/java/src/test/java/com/kreuzberg/e2e/ContractTest.java
+++ b/e2e/java/src/test/java/com/kreuzberg/e2e/ContractTest.java
@@ -909,6 +909,26 @@ public class ContractTest {
   }
 
   @Test
+  public void configExtractionMethodMixed() throws Exception {
+    JsonNode config =
+        MAPPER.readTree(
+            "{\"force_ocr_pages\":[2],\"ocr\":{\"backend\":\"tesseract\",\"language\":\"eng\"}}");
+    E2EHelpers.skipIfFeatureUnavailable("ocr");
+    E2EHelpers.runFixture(
+        "config_extraction_method_mixed",
+        "pdf/multi_page.pdf",
+        config,
+        Arrays.asList("ocr"),
+        null,
+        true,
+        result -> {
+          E2EHelpers.Assertions.assertExpectedMime(result, Arrays.asList("application/pdf"));
+          E2EHelpers.Assertions.assertMinContentLength(result, 1);
+          E2EHelpers.Assertions.assertExtractionMethod(result, "mixed");
+        });
+  }
+
+  @Test
   public void configExtractionTimeout() throws Exception {
     JsonNode config = MAPPER.readTree("{\"extraction_timeout_secs\":300}");
     E2EHelpers.runFixture(

--- a/e2e/java/src/test/java/com/kreuzberg/e2e/E2EHelpers.java
+++ b/e2e/java/src/test/java/com/kreuzberg/e2e/E2EHelpers.java
@@ -1,5 +1,6 @@
 package com.kreuzberg.e2e;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -759,6 +760,14 @@ public final class E2EHelpers {
             count <= maxCount,
             String.format("Expected at most %d processing warnings, got %d", maxCount, count));
       }
+    }
+
+    public static void assertExtractionMethod(ExtractionResult result, String expected) {
+      Object actual = result.getMetadata().getAdditional().get("extraction_method");
+      assertEquals(
+          expected,
+          actual,
+          String.format("Expected extraction_method=%s, got %s", expected, actual));
     }
 
     public static void assertLlmUsage(ExtractionResult result, Integer maxCount, Boolean isEmpty) {

--- a/e2e/php/tests/ContractTest.php
+++ b/e2e/php/tests/ContractTest.php
@@ -731,6 +731,28 @@ class ContractTest extends TestCase
     }
 
     /**
+     * Tests that selective page OCR reports a mixed extraction method
+     */
+    public function test_config_extraction_method_mixed(): void
+    {
+        $documentPath = Helpers::resolveDocument('pdf/multi_page.pdf');
+        if (!file_exists($documentPath)) {
+            $this->markTestSkipped('Skipping config_extraction_method_mixed: missing document at ' . $documentPath);
+        }
+
+        Helpers::skipIfFeatureUnavailable('ocr');
+
+        $config = Helpers::buildConfig(['force_ocr_pages' => [2], 'ocr' => ['backend' => 'tesseract', 'language' => 'eng']]);
+
+        $kreuzberg = new Kreuzberg($config);
+        $result = $kreuzberg->extractFile($documentPath);
+
+        Helpers::assertExpectedMime($result, ['application/pdf']);
+        Helpers::assertMinContentLength($result, 1);
+        Helpers::assertExtractionMethod($result, 'mixed');
+    }
+
+    /**
      * Tests that extraction_timeout_secs config field is accepted and does not affect fast extractions
      */
     public function test_config_extraction_timeout(): void

--- a/e2e/php/tests/Helpers.php
+++ b/e2e/php/tests/Helpers.php
@@ -718,7 +718,7 @@ class Helpers
 
     public static function assertExtractionMethod(ExtractionResult $result, string $expected): void
     {
-        $actual = $result->metadata->getCustom('extraction_method');
+        $actual = $result->extractionMethod ?? $result->metadata->getCustom('extraction_method');
 
         Assert::assertSame(
             $expected,

--- a/e2e/php/tests/Helpers.php
+++ b/e2e/php/tests/Helpers.php
@@ -285,9 +285,7 @@ class Helpers
         }
         if ($contentStartsWithHeading === true) {
             foreach ($chunks as $i => $chunk) {
-                if (empty($chunk->metadata->heading_context ?? null)) {
-                    continue;
-                }
+                if (empty($chunk->metadata->heading_context ?? null)) continue;
                 Assert::assertStringStartsWith(
                     '#',
                     $chunk->content ?? '',
@@ -718,6 +716,17 @@ class Helpers
         }
     }
 
+    public static function assertExtractionMethod(ExtractionResult $result, string $expected): void
+    {
+        $actual = $result->metadata->getCustom('extraction_method');
+
+        Assert::assertSame(
+            $expected,
+            $actual,
+            sprintf('Expected extraction_method=%s, got %s', $expected, var_export($actual, true))
+        );
+    }
+
     public static function assertContentNotEmpty(ExtractionResult $result): void
     {
         Assert::assertNotEmpty(
@@ -960,21 +969,15 @@ class Helpers
 
     public static function assertIsPng(string $data): void
     {
-        Assert::assertGreaterThanOrEqual(
-            4,
-            strlen($data),
-            sprintf('Data too short for PNG: %d bytes', strlen($data))
-        );
+        Assert::assertGreaterThanOrEqual(4, strlen($data),
+            sprintf('Data too short for PNG: %d bytes', strlen($data)));
         Assert::assertSame("\x89PNG", substr($data, 0, 4), 'Missing PNG magic bytes');
     }
 
     public static function assertMinByteLength(string $data, int $minLength): void
     {
-        Assert::assertGreaterThanOrEqual(
-            $minLength,
-            strlen($data),
-            sprintf('Expected at least %d bytes, got %d', $minLength, strlen($data))
-        );
+        Assert::assertGreaterThanOrEqual($minLength, strlen($data),
+            sprintf('Expected at least %d bytes, got %d', $minLength, strlen($data)));
     }
 
     public static function assertEmbedResult(array $results, int $count, int $dimensions, bool $noNan, bool $noInf, bool $nonZero): void

--- a/e2e/python/tests/helpers.py
+++ b/e2e/python/tests/helpers.py
@@ -646,6 +646,24 @@ def assert_keywords(
             pytest.fail(f"Expected <= {max_count} keywords, found {len(keywords)}")
 
 
+def assert_extraction_method(result: Any, expected: str) -> None:
+    actual = getattr(result, "extraction_method", None)
+    if actual is None and isinstance(result, dict):
+        actual = result.get("extraction_method") or result.get("extractionMethod")
+
+    metadata = getattr(result, "metadata", None)
+    if isinstance(result, dict):
+        metadata = result.get("metadata")
+
+    if actual is None and isinstance(metadata, Mapping):
+        actual = metadata.get("extraction_method")
+        additional = metadata.get("additional")
+        if actual is None and isinstance(additional, Mapping):
+            actual = additional.get("extraction_method")
+
+    assert actual == expected, f"Expected extraction_method={expected!r}, got {actual!r}"
+
+
 def assert_content_not_empty(result: Any) -> None:
     content = getattr(result, "content", None)
     if content is None or len(content.strip()) == 0:

--- a/e2e/python/tests/test_contract.py
+++ b/e2e/python/tests/test_contract.py
@@ -740,6 +740,31 @@ def test_config_email_msg_fallback_codepage() -> None:
     helpers.assert_min_content_length(result, 10)
 
 
+def test_config_extraction_method_mixed() -> None:
+    """Tests that selective page OCR reports a mixed extraction method"""
+
+    document_path = helpers.resolve_document("pdf/multi_page.pdf")
+    if not document_path.exists():
+        pytest.skip(f"Skipping config_extraction_method_mixed: missing document at {document_path}")
+
+    try:
+        config = helpers.build_config({"force_ocr_pages": [2], "ocr": {"backend": "tesseract", "language": "eng"}})
+
+        result = extract_file_sync(document_path, None, config)
+
+        helpers.assert_expected_mime(result, ["application/pdf"])
+        helpers.assert_min_content_length(result, 1)
+        helpers.assert_extraction_method(result, "mixed")
+    except Exception as exc:
+        if (
+            "missing dependency" in str(exc).lower()
+            or "unsupported" in str(exc).lower()
+            or "parsing" in str(exc).lower()
+        ):
+            pytest.skip(f"Skipping config_extraction_method_mixed: {exc}")
+        raise
+
+
 def test_config_extraction_timeout() -> None:
     """Tests that extraction_timeout_secs config field is accepted and does not affect fast extractions"""
 

--- a/e2e/r/tests/testthat/helper-kreuzberg.R
+++ b/e2e/r/tests/testthat/helper-kreuzberg.R
@@ -10,21 +10,15 @@ find_workspace_root <- function() {
   if (!is.null(ofile)) {
     # From tests/testthat/helper-kreuzberg.R, go up 4 levels to repo root
     candidate <- normalizePath(file.path(dirname(ofile), "..", "..", "..", ".."), mustWork = FALSE)
-    if (dir.exists(file.path(candidate, "test_documents"))) {
-      return(candidate)
-    }
+    if (dir.exists(file.path(candidate, "test_documents"))) return(candidate)
   }
   # Fallback: testthat sets working dir to package root (e2e/r/)
   candidate <- normalizePath(file.path(getwd(), "..", ".."), mustWork = FALSE)
-  if (dir.exists(file.path(candidate, "test_documents"))) {
-    return(candidate)
-  }
+  if (dir.exists(file.path(candidate, "test_documents"))) return(candidate)
   # Last resort: walk up from current dir
   d <- getwd()
   for (i in seq_len(10)) {
-    if (dir.exists(file.path(d, "test_documents"))) {
-      return(d)
-    }
+    if (dir.exists(file.path(d, "test_documents"))) return(d)
     d <- dirname(d)
   }
   stop("Could not find workspace root (test_documents directory)")
@@ -37,16 +31,12 @@ resolve_document <- function(relative) {
 }
 
 build_config <- function(raw) {
-  if (is.null(raw) || length(raw) == 0) {
-    return(NULL)
-  }
+  if (is.null(raw) || length(raw) == 0) return(NULL)
   raw
 }
 
 build_extraction_config <- function(raw) {
-  if (is.null(raw) || length(raw) == 0) {
-    return(NULL)
-  }
+  if (is.null(raw) || length(raw) == 0) return(NULL)
   # Convert the raw config map into extraction_config() call
   do.call(extraction_config, raw)
 }
@@ -58,9 +48,7 @@ skip_reason_for <- function(error, fixture_id, requirements, notes = NULL) {
   missing_dependency <- grepl("missing dependency", downcased, fixed = TRUE)
   unsupported_format <- grepl("unsupported format", downcased, fixed = TRUE)
 
-  if (!missing_dependency && !unsupported_format && !requirement_hit) {
-    return(NULL)
-  }
+  if (!missing_dependency && !unsupported_format && !requirement_hit) return(NULL)
 
   reason <- if (missing_dependency) {
     "missing dependency"
@@ -88,12 +76,11 @@ skip_if_feature_unavailable <- function(feature) {
 
 run_fixture <- function(fixture_id, relative_path, config_hash, requirements, notes, skip_if_missing = TRUE) {
   run_fixture_with_method(fixture_id, relative_path, config_hash, "sync", "file",
-    requirements = requirements, notes = notes, skip_if_missing = skip_if_missing
-  )
+                          requirements = requirements, notes = notes, skip_if_missing = skip_if_missing)
 }
 
 run_fixture_with_method <- function(fixture_id, relative_path, config_hash, method, input_type,
-                                    requirements, notes, skip_if_missing = TRUE) {
+                                     requirements, notes, skip_if_missing = TRUE) {
   document_path <- resolve_document(relative_path)
 
   if (skip_if_missing && !file.exists(document_path)) {
@@ -149,9 +136,7 @@ perform_extraction <- function(document_path, config, method, input_type) {
 
 # Assertion helpers
 assert_expected_mime <- function(result, expected) {
-  if (length(expected) == 0) {
-    return(invisible(NULL))
-  }
+  if (length(expected) == 0) return(invisible(NULL))
   testthat::expect_true(any(vapply(expected, function(token) grepl(token, result$mime_type, fixed = TRUE), logical(1))))
 }
 
@@ -164,25 +149,19 @@ assert_max_content_length <- function(result, maximum) {
 }
 
 assert_content_contains_any <- function(result, snippets) {
-  if (length(snippets) == 0) {
-    return(invisible(NULL))
-  }
+  if (length(snippets) == 0) return(invisible(NULL))
   lowered <- tolower(result$content)
   testthat::expect_true(any(vapply(snippets, function(s) grepl(tolower(s), lowered, fixed = TRUE), logical(1))))
 }
 
 assert_content_contains_all <- function(result, snippets) {
-  if (length(snippets) == 0) {
-    return(invisible(NULL))
-  }
+  if (length(snippets) == 0) return(invisible(NULL))
   lowered <- tolower(result$content)
   testthat::expect_true(all(vapply(snippets, function(s) grepl(tolower(s), lowered, fixed = TRUE), logical(1))))
 }
 
 assert_content_contains_none <- function(result, snippets) {
-  if (length(snippets) == 0) {
-    return(invisible(NULL))
-  }
+  if (length(snippets) == 0) return(invisible(NULL))
   lowered <- tolower(result$content)
   found <- snippets[vapply(snippets, function(s) grepl(tolower(s), lowered, fixed = TRUE), logical(1))]
   testthat::expect_true(length(found) == 0, info = paste("Expected content to contain none of:", paste(snippets, collapse = ", "), "but found:", paste(found, collapse = ", ")))
@@ -195,9 +174,7 @@ assert_table_count <- function(result, minimum = NULL, maximum = NULL) {
 }
 
 assert_detected_languages <- function(result, expected, min_confidence = NULL) {
-  if (length(expected) == 0) {
-    return(invisible(NULL))
-  }
+  if (length(expected) == 0) return(invisible(NULL))
   languages <- result$detected_languages
   testthat::expect_false(is.null(languages))
   testthat::expect_true(all(expected %in% languages))
@@ -310,15 +287,13 @@ assert_elements <- function(result, min_count = NULL, types_include = NULL) {
 }
 
 assert_ocr_elements <- function(result, has_elements = NULL, elements_have_geometry = NULL,
-                                elements_have_confidence = NULL, min_count = NULL) {
+                                 elements_have_confidence = NULL, min_count = NULL) {
   ocr_elements <- result$ocr_elements
   if (isTRUE(has_elements)) {
     testthat::expect_false(is.null(ocr_elements))
     testthat::expect_gt(length(ocr_elements), 0)
   }
-  if (!is.list(ocr_elements)) {
-    return(invisible(NULL))
-  }
+  if (!is.list(ocr_elements)) return(invisible(NULL))
   if (!is.null(min_count)) testthat::expect_gte(length(ocr_elements), min_count)
   if (isTRUE(elements_have_geometry)) {
     for (el in ocr_elements) {
@@ -335,7 +310,7 @@ assert_ocr_elements <- function(result, has_elements = NULL, elements_have_geome
 }
 
 assert_document <- function(result, has_document = FALSE, min_node_count = NULL,
-                            node_types_include = NULL, has_groups = NULL) {
+                             node_types_include = NULL, has_groups = NULL) {
   document <- result$document
   if (has_document) {
     testthat::expect_false(is.null(document))
@@ -383,6 +358,18 @@ assert_keywords <- function(result, has_keywords = NULL, min_count = NULL, max_c
   }
 }
 
+assert_extraction_method <- function(result, expected) {
+  metadata <- result$metadata
+  actual <- NULL
+  if (!is.null(metadata$additional)) {
+    actual <- metadata$additional[["extraction_method"]]
+  }
+  if (is.null(actual)) {
+    actual <- metadata[["extraction_method"]]
+  }
+  testthat::expect_identical(actual, expected)
+}
+
 assert_content_not_empty <- function(result) {
   testthat::expect_false(is.null(result$content))
   testthat::expect_gt(nchar(result$content), 0)
@@ -396,9 +383,7 @@ assert_table_bounding_boxes <- function(result) {
 }
 
 assert_table_content_contains_any <- function(result, snippets) {
-  if (length(snippets) == 0) {
-    return(invisible(NULL))
-  }
+  if (length(snippets) == 0) return(invisible(NULL))
   tables <- if (is.null(result$tables)) list() else result$tables
   all_content <- tolower(paste(vapply(tables, function(t) t$content %||% "", character(1)), collapse = " "))
   testthat::expect_true(any(vapply(snippets, function(s) grepl(tolower(s), all_content, fixed = TRUE), logical(1))))
@@ -459,13 +444,9 @@ assert_annotations <- function(result, has_annotations = FALSE, min_count = NULL
 # Internal helpers
 fetch_metadata_value <- function(metadata, path) {
   value <- lookup_metadata_path(metadata, path)
-  if (!is.null(value)) {
-    return(value)
-  }
+  if (!is.null(value)) return(value)
   format_data <- metadata$format
-  if (is.list(format_data)) {
-    return(lookup_metadata_path(format_data, path))
-  }
+  if (is.list(format_data)) return(lookup_metadata_path(format_data, path))
   NULL
 }
 
@@ -473,24 +454,16 @@ lookup_metadata_path <- function(metadata, path) {
   current <- metadata
   segments <- strsplit(path, ".", fixed = TRUE)[[1]]
   for (segment in segments) {
-    if (!is.list(current)) {
-      return(NULL)
-    }
+    if (!is.list(current)) return(NULL)
     current <- current[[segment]]
-    if (is.null(current)) {
-      return(NULL)
-    }
+    if (is.null(current)) return(NULL)
   }
   current
 }
 
 values_equal <- function(lhs, rhs) {
-  if (is.character(lhs) && is.character(rhs)) {
-    return(identical(lhs, rhs))
-  }
-  if (is.numeric(lhs) && is.numeric(rhs)) {
-    return(as.numeric(lhs) == as.numeric(rhs))
-  }
+  if (is.character(lhs) && is.character(rhs)) return(identical(lhs, rhs))
+  if (is.numeric(lhs) && is.numeric(rhs)) return(as.numeric(lhs) == as.numeric(rhs))
   identical(lhs, rhs)
 }
 

--- a/e2e/r/tests/testthat/test-contract.R
+++ b/e2e/r/tests/testthat/test-contract.R
@@ -499,6 +499,21 @@ test_that("config_email_msg_fallback_codepage", {
   assert_min_content_length(result, 10L)
 })
 
+test_that("config_extraction_method_mixed", {
+  skip_if_feature_unavailable("ocr")
+  result <- run_fixture(
+    "config_extraction_method_mixed",
+    "pdf/multi_page.pdf",
+    list(force_ocr_pages = c(2L), ocr = list(backend = "tesseract", language = "eng")),
+    requirements = c("ocr"),
+    notes = NULL,
+    skip_if_missing = TRUE
+  )
+  assert_expected_mime(result, c("application/pdf"))
+  assert_min_content_length(result, 1L)
+  assert_extraction_method(result, "mixed")
+})
+
 test_that("config_extraction_timeout", {
   result <- run_fixture(
     "config_extraction_timeout",

--- a/e2e/ruby/spec/contract_spec.rb
+++ b/e2e/ruby/spec/contract_spec.rb
@@ -628,6 +628,25 @@ RSpec.describe 'contract fixtures' do
     end
   end
 
+  it 'config_extraction_method_mixed' do
+    E2ERuby.skip_if_feature_unavailable('ocr')
+    E2ERuby.run_fixture(
+      'config_extraction_method_mixed',
+      'pdf/multi_page.pdf',
+      { force_ocr_pages: [2], ocr: { backend: 'tesseract', language: 'eng' } },
+      requirements: %w[ocr],
+      notes: nil,
+      skip_if_missing: true
+    ) do |result|
+      E2ERuby::Assertions.assert_expected_mime(
+        result,
+        ['application/pdf']
+      )
+      E2ERuby::Assertions.assert_min_content_length(result, 1)
+      E2ERuby::Assertions.assert_extraction_method(result, 'mixed')
+    end
+  end
+
   it 'config_extraction_timeout' do
     E2ERuby.run_fixture(
       'config_extraction_timeout',
@@ -894,7 +913,7 @@ RSpec.describe 'contract fixtures' do
     E2ERuby.run_fixture(
       'config_llm_structured_extraction_with_prompt',
       'pdf/fake_memo.pdf',
-      { structured_extraction: { schema: { type: 'object', properties: { sender: { type: 'string' }, recipient: { type: 'string' }, subject: { type: 'string' } }, required: %w[sender recipient] }, schema_name: 'memo_parties', prompt: "Extract the sender and recipient from this memo document. If not found, use 'unknown'.", llm: { model: 'openai/gpt-4o' } } },
+      { structured_extraction: { schema: { type: 'object', properties: { sender: { type: 'string' }, recipient: { type: 'string' }, subject: { type: 'string' } }, required: ['sender', 'recipient'] }, schema_name: 'memo_parties', prompt: "Extract the sender and recipient from this memo document. If not found, use 'unknown'.", llm: { model: 'openai/gpt-4o' } } },
       requirements: %w[liter-llm],
       notes: 'Requires liter-llm feature and KREUZBERG_LLM_API_KEY env var',
       skip_if_missing: true
@@ -904,7 +923,7 @@ RSpec.describe 'contract fixtures' do
         ['application/pdf']
       )
       E2ERuby::Assertions.assert_min_content_length(result, 10)
-      E2ERuby::Assertions.assert_structured_output(result, has_output: true, field_exists: %w[sender recipient])
+      E2ERuby::Assertions.assert_structured_output(result, has_output: true, field_exists: ['sender', 'recipient'])
     end
   end
 
@@ -1201,7 +1220,7 @@ RSpec.describe 'contract fixtures' do
     E2ERuby.run_fixture(
       'config_tree_sitter',
       'code/hello.py',
-      { tree_sitter: { languages: %w[python rust], groups: ['web'], process: { structure: true, imports: true, exports: true, comments: false, docstrings: false, symbols: false, diagnostics: false } } },
+      { tree_sitter: { languages: ['python', 'rust'], groups: ['web'], process: { structure: true, imports: true, exports: true, comments: false, docstrings: false, symbols: false, diagnostics: false } } },
       requirements: %w[tree-sitter],
       notes: nil,
       skip_if_missing: true

--- a/e2e/ruby/spec/helpers.rb
+++ b/e2e/ruby/spec/helpers.rb
@@ -93,7 +93,7 @@ module E2ERuby
   def skip_if_feature_unavailable(feature)
     env_var = "KREUZBERG_#{feature.tr('-', '_').upcase}_DISABLED"
     flag = ENV.fetch(env_var, nil)
-    return unless flag == '1' || flag&.casecmp('true')&.zero?
+    return unless flag == '1' || (flag && flag.casecmp('true').zero?)
 
     raise RSpec::Core::Pending::SkipDeclaredInExample,
           "Feature #{feature} disabled (via #{env_var}=1)"
@@ -310,16 +310,18 @@ module E2ERuby
         expect(found_layout_regions).to be(true)
       end
 
-      return unless layout_classes_include
-      all_classes = Set.new
-      pages.each do |page|
-        next unless page.respond_to?(:layout_regions) && page.layout_regions
-        Array(page.layout_regions).each do |region|
-          all_classes.add(region.class) if region.respond_to?(:class)
+      if layout_classes_include
+        all_classes = Set.new
+        pages.each do |page|
+          if page.respond_to?(:layout_regions) && page.layout_regions
+            Array(page.layout_regions).each do |region|
+              all_classes.add(region.class) if region.respond_to?(:class)
+            end
+          end
         end
-      end
-      layout_classes_include.each do |expected_class|
-        expect(all_classes.include?(expected_class)).to be(true)
+        layout_classes_include.each do |expected_class|
+          expect(all_classes.include?(expected_class)).to be(true)
+        end
       end
     end
 
@@ -403,6 +405,14 @@ module E2ERuby
 
       expect(keywords.length).to be >= min_count if min_count
       expect(keywords.length).to be <= max_count if max_count
+    end
+
+    def self.assert_extraction_method(result, expected)
+      metadata_value =
+        if result.respond_to?(:metadata) && result.metadata.respond_to?(:additional)
+          result.metadata.additional['extraction_method']
+        end
+      expect(metadata_value).to eq(expected)
     end
 
     def self.assert_content_not_empty(result)
@@ -493,7 +503,7 @@ module E2ERuby
           expect(vec.any? { |v| v.to_f.infinite? }).to be(false), "Embedding #{i} contains Inf values"
         end
         if non_zero
-          expect(vec.all?(0.0)).to be(false), "Embedding #{i} is all zeros"
+          expect(vec.all? { |v| v == 0.0 }).to be(false), "Embedding #{i} is all zeros"
         end
         if normalized
           norm = Math.sqrt(vec.sum { |v| v * v })
@@ -514,11 +524,12 @@ module E2ERuby
         expect(output).not_to be_nil
         expect(output).to be_a(Hash).or be_a(Array)
       end
-      return unless field_exists
-      expect(output).not_to be_nil
-      expect(output).to be_a(Hash)
-      field_exists.each do |field|
-        expect(output).to have_key(field)
+      if field_exists
+        expect(output).not_to be_nil
+        expect(output).to be_a(Hash)
+        field_exists.each do |field|
+          expect(output).to have_key(field)
+        end
       end
     end
 

--- a/e2e/rust/src/lib.rs
+++ b/e2e/rust/src/lib.rs
@@ -583,6 +583,25 @@ pub mod assertions {
         }
     }
 
+    /// Assert the reported extraction method.
+    pub fn assert_extraction_method(result: &ExtractionResult, expected: &str) {
+        let actual = result.extraction_method.map(|method| method.as_str()).or_else(|| {
+            result
+                .metadata
+                .additional
+                .get("extraction_method")
+                .and_then(Value::as_str)
+        });
+
+        assert_eq!(
+            actual,
+            Some(expected),
+            "Expected extraction_method {:?}, got {:?}",
+            expected,
+            actual
+        );
+    }
+
     /// Assert that content is not empty.
     pub fn assert_content_not_empty(result: &ExtractionResult) {
         assert!(!result.content.trim().is_empty(), "Expected non-empty content");

--- a/e2e/rust/tests/fixtures/contract_test.rs
+++ b/e2e/rust/tests/fixtures/contract_test.rs
@@ -1332,6 +1332,59 @@ fn test_config_email_msg_fallback_codepage() {
 }
 
 #[test]
+fn test_config_extraction_method_mixed() {
+    // Tests that selective page OCR reports a mixed extraction method
+
+    let document_path = resolve_document("pdf/multi_page.pdf");
+    if !document_path.exists() {
+        println!(
+            "Skipping config_extraction_method_mixed: missing document at {}",
+            document_path.display()
+        );
+        return;
+    }
+    let config: ExtractionConfig = serde_json::from_str(
+        r#"{
+  "force_ocr_pages": [
+    2
+  ],
+  "ocr": {
+    "backend": "tesseract",
+    "language": "eng"
+  }
+}"#,
+    )
+    .expect("Fixture config should deserialize");
+
+    let result = match kreuzberg::extract_file_sync(&document_path, None, &config) {
+        Err(KreuzbergError::MissingDependency(dep)) => {
+            println!(
+                "Skipping config_extraction_method_mixed: missing dependency {dep}",
+                dep = dep
+            );
+            return;
+        }
+        Err(KreuzbergError::UnsupportedFormat(fmt)) => {
+            println!(
+                "Skipping config_extraction_method_mixed: unsupported format {fmt} (requires optional tool)",
+                fmt = fmt
+            );
+            return;
+        }
+        Err(KreuzbergError::Parsing { message: ref msg, .. }) => {
+            println!("Skipping config_extraction_method_mixed: parsing dependency unavailable: {msg}");
+            return;
+        }
+        Err(err) => panic!("Extraction failed for config_extraction_method_mixed: {err:?}"),
+        Ok(result) => result,
+    };
+
+    assertions::assert_expected_mime(&result, &["application/pdf"]);
+    assertions::assert_min_content_length(&result, 1);
+    assertions::assert_extraction_method(&result, "mixed");
+}
+
+#[test]
 fn test_config_extraction_timeout() {
     // Tests that extraction_timeout_secs config field is accepted and does not affect fast extractions
 

--- a/e2e/typescript/tests/contract.spec.ts
+++ b/e2e/typescript/tests/contract.spec.ts
@@ -998,6 +998,34 @@ describe("contract fixtures", () => {
 	);
 
 	it(
+		"config_extraction_method_mixed",
+		() => {
+			const documentPath = resolveDocument("pdf/multi_page.pdf");
+			if (!existsSync(documentPath)) {
+				console.warn("Skipping config_extraction_method_mixed: missing document at", documentPath);
+				return;
+			}
+			const config = buildConfig({ force_ocr_pages: [2], ocr: { backend: "tesseract", language: "eng" } });
+			let result: ExtractionResult | null = null;
+			try {
+				result = extractFileSync(documentPath, null, config);
+			} catch (error) {
+				if (shouldSkipFixture(error, "config_extraction_method_mixed", ["ocr"], undefined)) {
+					return;
+				}
+				throw error;
+			}
+			if (result === null) {
+				return;
+			}
+			assertions.assertExpectedMime(result, ["application/pdf"]);
+			assertions.assertMinContentLength(result, 1);
+			assertions.assertExtractionMethod(result, "mixed");
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
 		"config_extraction_timeout",
 		() => {
 			const documentPath = resolveDocument("pdf/fake_memo.pdf");

--- a/e2e/typescript/tests/helpers.ts
+++ b/e2e/typescript/tests/helpers.ts
@@ -629,6 +629,17 @@ export const assertions = {
 		}
 	},
 
+	assertExtractionMethod(result: ExtractionResult, expected: string): void {
+		const metadata = isPlainRecord(result.metadata) ? (result.metadata as PlainRecord) : null;
+		const additional = metadata && isPlainRecord(metadata.additional) ? (metadata.additional as PlainRecord) : null;
+		const actual =
+			(result as unknown as PlainRecord).extractionMethod ??
+			(result as unknown as PlainRecord).extraction_method ??
+			metadata?.extraction_method ??
+			additional?.extraction_method;
+		expect(actual).toBe(expected);
+	},
+
 	assertContentNotEmpty(result: ExtractionResult): void {
 		expect(result.content).toBeDefined();
 		expect(result.content.trim().length).toBeGreaterThan(0);

--- a/e2e/wasm/contract.spec.ts
+++ b/e2e/wasm/contract.spec.ts
@@ -823,6 +823,30 @@ describe("contract fixtures", () => {
 	);
 
 	it(
+		"config_extraction_method_mixed",
+		async () => {
+			const config = buildConfig({ force_ocr_pages: [2], ocr: { backend: "tesseract", language: "eng" } });
+			let result: ExtractionResult | null = null;
+			try {
+				const documentBytes = new Uint8Array(resolveDocument("pdf/multi_page.pdf"));
+				result = await extractBytes(documentBytes, "application/octet-stream", config);
+			} catch (error) {
+				if (shouldSkipFixture(error, "config_extraction_method_mixed", ["ocr"], undefined)) {
+					return;
+				}
+				throw error;
+			}
+			if (result === null) {
+				return;
+			}
+			assertions.assertExpectedMime(result, ["application/pdf"]);
+			assertions.assertMinContentLength(result, 1);
+			assertions.assertExtractionMethod(result, "mixed");
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
 		"config_extraction_timeout",
 		async () => {
 			const config = buildConfig({ extraction_timeout_secs: 300 });

--- a/e2e/wasm/helpers.ts
+++ b/e2e/wasm/helpers.ts
@@ -706,6 +706,17 @@ export const assertions = {
 		}
 	},
 
+	assertExtractionMethod(result: ExtractionResult, expected: string): void {
+		const metadata = isPlainRecord(result.metadata) ? (result.metadata as PlainRecord) : null;
+		const additional = metadata && isPlainRecord(metadata.additional) ? (metadata.additional as PlainRecord) : null;
+		const actual =
+			(result as unknown as PlainRecord).extractionMethod ??
+			(result as unknown as PlainRecord).extraction_method ??
+			metadata?.extraction_method ??
+			additional?.extraction_method;
+		expect(actual).toBe(expected);
+	},
+
 	assertContentNotEmpty(result: ExtractionResult): void {
 		expect(result.content.length > 0).toBe(true);
 	},

--- a/fixtures/contract/config_extraction_method_mixed.json
+++ b/fixtures/contract/config_extraction_method_mixed.json
@@ -1,0 +1,29 @@
+{
+	"id": "config_extraction_method_mixed",
+	"description": "Tests that selective page OCR reports a mixed extraction method",
+	"tags": ["contract", "config", "ocr", "extraction_method"],
+	"document": {
+		"path": "pdf/multi_page.pdf"
+	},
+	"extraction": {
+		"method": "sync",
+		"input_type": "file",
+		"config": {
+			"force_ocr_pages": [2],
+			"ocr": {
+				"backend": "tesseract",
+				"language": "eng"
+			}
+		}
+	},
+	"assertions": {
+		"expected_mime": "application/pdf",
+		"min_content_length": 1,
+		"extraction_method": {
+			"is": "mixed"
+		}
+	},
+	"skip": {
+		"requires_feature": ["ocr"]
+	}
+}

--- a/fixtures/schema.json
+++ b/fixtures/schema.json
@@ -323,6 +323,18 @@
 					},
 					"additionalProperties": false
 				},
+				"extraction_method": {
+					"type": "object",
+					"properties": {
+						"is": {
+							"type": "string",
+							"enum": ["native", "ocr", "mixed"],
+							"description": "Expected extraction method."
+						}
+					},
+					"required": ["is"],
+					"additionalProperties": false
+				},
 				"quality_score": {
 					"type": "object",
 					"properties": {

--- a/packages/php/src/Types/ExtractionResult.php
+++ b/packages/php/src/Types/ExtractionResult.php
@@ -22,7 +22,6 @@ namespace Kreuzberg\Types;
  * @property-read DocumentStructure|null $document Hierarchical document structure when include_document_structure=true
  * @property-read array<ExtractedKeyword>|null $extractedKeywords Extracted keywords with scores and algorithm metadata
  * @property-read float|null $qualityScore Quality score of the extraction (0.0 to 1.0)
- * @property-read 'native'|'ocr'|'mixed'|null $extractionMethod How text was extracted
  * @property-read array<ProcessingWarning>|null $processingWarnings Warnings generated during processing
  */
 readonly class ExtractionResult
@@ -40,7 +39,6 @@ readonly class ExtractionResult
      * @param DocumentStructure|null $document
      * @param array<ExtractedKeyword>|null $extractedKeywords
      * @param float|null $qualityScore
-     * @param 'native'|'ocr'|'mixed'|null $extractionMethod
      * @param array<ProcessingWarning>|null $processingWarnings
      */
     public function __construct(
@@ -59,7 +57,6 @@ readonly class ExtractionResult
         public ?DocumentStructure $document = null,
         public ?array $extractedKeywords = null,
         public ?float $qualityScore = null,
-        public ?string $extractionMethod = null,
         public ?array $processingWarnings = null,
         /** @var array<PdfAnnotation>|null */
         public ?array $annotations = null,
@@ -190,11 +187,6 @@ readonly class ExtractionResult
             }
         }
 
-        $extractionMethod = null;
-        if (isset($data['extraction_method']) && is_string($data['extraction_method'])) {
-            $extractionMethod = $data['extraction_method'];
-        }
-
         $processingWarnings = null;
         if (isset($data['processing_warnings'])) {
             /** @var array<array<string, mixed>> $processingWarningsData */
@@ -244,7 +236,6 @@ readonly class ExtractionResult
             document: $document,
             extractedKeywords: $extractedKeywords,
             qualityScore: $qualityScore,
-            extractionMethod: $extractionMethod,
             processingWarnings: $processingWarnings,
             annotations: $annotations,
             codeIntelligence: $codeIntelligence,

--- a/packages/php/src/Types/ExtractionResult.php
+++ b/packages/php/src/Types/ExtractionResult.php
@@ -23,6 +23,7 @@ namespace Kreuzberg\Types;
  * @property-read array<ExtractedKeyword>|null $extractedKeywords Extracted keywords with scores and algorithm metadata
  * @property-read float|null $qualityScore Quality score of the extraction (0.0 to 1.0)
  * @property-read array<ProcessingWarning>|null $processingWarnings Warnings generated during processing
+ * @property-read 'native'|'ocr'|'mixed'|null $extractionMethod Strategy used to extract content from the document
  */
 readonly class ExtractionResult
 {
@@ -40,6 +41,7 @@ readonly class ExtractionResult
      * @param array<ExtractedKeyword>|null $extractedKeywords
      * @param float|null $qualityScore
      * @param array<ProcessingWarning>|null $processingWarnings
+     * @param 'native'|'ocr'|'mixed'|null $extractionMethod
      */
     public function __construct(
         public string $content,
@@ -58,6 +60,7 @@ readonly class ExtractionResult
         public ?array $extractedKeywords = null,
         public ?float $qualityScore = null,
         public ?array $processingWarnings = null,
+        public ?string $extractionMethod = null,
         /** @var array<PdfAnnotation>|null */
         public ?array $annotations = null,
         public ?CodeProcessResult $codeIntelligence = null,
@@ -198,6 +201,9 @@ readonly class ExtractionResult
             );
         }
 
+        /** @var 'native'|'ocr'|'mixed'|null $extractionMethod */
+        $extractionMethod = $data['extraction_method'] ?? null;
+
         $annotations = null;
         if (isset($data['annotations'])) {
             /** @var array<array<string, mixed>> $annotationsData */
@@ -237,6 +243,7 @@ readonly class ExtractionResult
             extractedKeywords: $extractedKeywords,
             qualityScore: $qualityScore,
             processingWarnings: $processingWarnings,
+            extractionMethod: $extractionMethod,
             annotations: $annotations,
             codeIntelligence: $codeIntelligence,
         );

--- a/packages/php/src/Types/ExtractionResult.php
+++ b/packages/php/src/Types/ExtractionResult.php
@@ -22,6 +22,7 @@ namespace Kreuzberg\Types;
  * @property-read DocumentStructure|null $document Hierarchical document structure when include_document_structure=true
  * @property-read array<ExtractedKeyword>|null $extractedKeywords Extracted keywords with scores and algorithm metadata
  * @property-read float|null $qualityScore Quality score of the extraction (0.0 to 1.0)
+ * @property-read 'native'|'ocr'|'mixed'|null $extractionMethod How text was extracted
  * @property-read array<ProcessingWarning>|null $processingWarnings Warnings generated during processing
  */
 readonly class ExtractionResult
@@ -39,6 +40,7 @@ readonly class ExtractionResult
      * @param DocumentStructure|null $document
      * @param array<ExtractedKeyword>|null $extractedKeywords
      * @param float|null $qualityScore
+     * @param 'native'|'ocr'|'mixed'|null $extractionMethod
      * @param array<ProcessingWarning>|null $processingWarnings
      */
     public function __construct(
@@ -57,6 +59,7 @@ readonly class ExtractionResult
         public ?DocumentStructure $document = null,
         public ?array $extractedKeywords = null,
         public ?float $qualityScore = null,
+        public ?string $extractionMethod = null,
         public ?array $processingWarnings = null,
         /** @var array<PdfAnnotation>|null */
         public ?array $annotations = null,
@@ -187,6 +190,11 @@ readonly class ExtractionResult
             }
         }
 
+        $extractionMethod = null;
+        if (isset($data['extraction_method']) && is_string($data['extraction_method'])) {
+            $extractionMethod = $data['extraction_method'];
+        }
+
         $processingWarnings = null;
         if (isset($data['processing_warnings'])) {
             /** @var array<array<string, mixed>> $processingWarningsData */
@@ -236,6 +244,7 @@ readonly class ExtractionResult
             document: $document,
             extractedKeywords: $extractedKeywords,
             qualityScore: $qualityScore,
+            extractionMethod: $extractionMethod,
             processingWarnings: $processingWarnings,
             annotations: $annotations,
             codeIntelligence: $codeIntelligence,

--- a/packages/typescript/core/src/types/results.ts
+++ b/packages/typescript/core/src/types/results.ts
@@ -649,7 +649,6 @@ export interface ExtractionResult {
 	content: string;
 	mimeType: string;
 	metadata: Metadata;
-	extractionMethod?: "native" | "ocr" | "mixed";
 	tables: Table[];
 	detectedLanguages?: string[];
 	chunks?: Chunk[];

--- a/packages/typescript/core/src/types/results.ts
+++ b/packages/typescript/core/src/types/results.ts
@@ -650,6 +650,7 @@ export interface ExtractionResult {
 	mimeType: string;
 	metadata: Metadata;
 	tables: Table[];
+	extractionMethod?: "native" | "ocr" | "mixed";
 	detectedLanguages?: string[];
 	chunks?: Chunk[];
 	images?: ExtractedImage[];

--- a/packages/typescript/core/src/types/results.ts
+++ b/packages/typescript/core/src/types/results.ts
@@ -649,6 +649,7 @@ export interface ExtractionResult {
 	content: string;
 	mimeType: string;
 	metadata: Metadata;
+	extractionMethod?: "native" | "ocr" | "mixed";
 	tables: Table[];
 	detectedLanguages?: string[];
 	chunks?: Chunk[];

--- a/tools/e2e-generator/Cargo.toml
+++ b/tools/e2e-generator/Cargo.toml
@@ -7,13 +7,19 @@ authors.workspace = true
 license.workspace = true
 publish = false
 
+[features]
+default = ["formats"]
+formats = ["kreuzberg/formats"]
+layout-detection = ["kreuzberg/layout-detection"]
+tree-sitter = ["kreuzberg/tree-sitter"]
+
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }
 camino = "1.2"
 clap = { workspace = true }
 itertools = { workspace = true }
-kreuzberg = { path = "../../crates/kreuzberg", features = ["full"], default-features = false }
+kreuzberg = { path = "../../crates/kreuzberg", default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = "2.5"

--- a/tools/e2e-generator/src/c.rs
+++ b/tools/e2e-generator/src/c.rs
@@ -132,6 +132,9 @@ void assert_keywords(const CExtractionResult *result,
                      int has_min, size_t min_count,
                      int has_max, size_t max_count);
 
+void assert_extraction_method(const CExtractionResult *result,
+                              const char *expected);
+
 void assert_quality_score(const CExtractionResult *result,
                           int has_score, int score_present,
                           int has_min, double min_score,
@@ -815,6 +818,23 @@ void assert_keywords(const CExtractionResult *result,
     }
 }
 
+void assert_extraction_method(const CExtractionResult *result,
+                              const char *expected) {
+    const char *metadata_json = result->metadata_json ? result->metadata_json : "";
+    char needle[128];
+    char spaced_needle[128];
+    snprintf(needle, sizeof(needle), "\"extraction_method\":\"%s\"", expected);
+    snprintf(spaced_needle, sizeof(spaced_needle), "\"extraction_method\": \"%s\"", expected);
+    if (str_contains_ci(metadata_json, needle) || str_contains_ci(metadata_json, spaced_needle)) {
+        return;
+    }
+    fprintf(stderr,
+            "FAIL: expected extraction_method \"%s\" in metadata_json but got %s\n",
+            expected,
+            metadata_json[0] ? metadata_json : "(null)");
+    exit(1);
+}
+
 void assert_quality_score(const CExtractionResult *result,
                           int has_score, int score_present,
                           int has_min, double min_score,
@@ -1481,6 +1501,14 @@ fn render_assertions(assertions: &Assertions) -> String {
         )
         .unwrap();
     }
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        writeln!(
+            buf,
+            "    assert_extraction_method(result, {});",
+            render_string_literal(&extraction_method.is)
+        )
+        .unwrap();
+    }
     if let Some(qs) = assertions.quality_score.as_ref() {
         let has_score = qs.has_score.is_some() as u8;
         let score_present = qs.has_score.unwrap_or(false) as u8;
@@ -2064,6 +2092,10 @@ fn c_string_literal(s: &str) -> String {
     }
     out.push('"');
     out
+}
+
+fn render_string_literal(value: &str) -> String {
+    c_string_literal(value)
 }
 
 /// Convert a fixture id / category to a safe C identifier (snake_case).

--- a/tools/e2e-generator/src/csharp.rs
+++ b/tools/e2e-generator/src/csharp.rs
@@ -880,6 +880,15 @@ public static class TestHelpers
         }
     }
 
+    public static void AssertExtractionMethod(ExtractionResult result, string expected)
+    {
+        var actual = result.Metadata?.Additional?["extraction_method"]?.ToString();
+        if (!string.Equals(actual, expected, StringComparison.Ordinal))
+        {
+            throw new XunitException($"Expected extraction_method={expected} but got {actual ?? "null"}");
+        }
+    }
+
     public static void AssertContentNotEmpty(ExtractionResult result)
     {
         if (string.IsNullOrEmpty(result.Content))
@@ -1519,7 +1528,7 @@ fn render_assertions(buffer: &mut String, assertions: &Assertions) -> Result<()>
             .map(|v| v.to_string().to_lowercase())
             .unwrap_or_else(|| "null".into());
         buffer.push_str(&format!(
-            "        TestHelpers.AssertChunks(result, {min_count}, {max_count}, {each_has_content}, {each_has_embedding}, {each_has_heading_context}, {each_has_chunk_type}, {content_starts_with_heading});\n"
+            "            TestHelpers.AssertChunks(result, {min_count}, {max_count}, {each_has_content}, {each_has_embedding}, {each_has_heading_context}, {each_has_chunk_type}, {content_starts_with_heading});\n"
         ));
     }
 
@@ -1655,6 +1664,14 @@ fn render_assertions(buffer: &mut String, assertions: &Assertions) -> Result<()>
         )?;
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        writeln!(
+            buffer,
+            "            TestHelpers.AssertExtractionMethod(result, {});",
+            csharp_string_literal(&extraction_method.is)
+        )?;
+    }
+
     if assertions.content_not_empty == Some(true) {
         writeln!(buffer, "            TestHelpers.AssertContentNotEmpty(result);")?;
     }
@@ -1773,6 +1790,10 @@ fn render_string_array(values: &[String]) -> String {
         .map(|v| format!("\"{}\"", escape_csharp_string(v)))
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+fn csharp_string_literal(value: &str) -> String {
+    format!("\"{}\"", escape_csharp_string(value))
 }
 
 fn render_csharp_metadata_expectation(value: &Value) -> String {

--- a/tools/e2e-generator/src/elixir.rs
+++ b/tools/e2e-generator/src/elixir.rs
@@ -619,6 +619,17 @@ defmodule E2E.Helpers do
     result
   end
 
+  def assert_extraction_method(result, opts) do
+    metadata = Map.get(result, :metadata) || Map.get(result, "metadata") || %{}
+    additional = Map.get(metadata, :additional) || Map.get(metadata, "additional") || %{}
+    actual = Map.get(additional, "extraction_method") || Map.get(additional, :extraction_method)
+
+    assert actual == opts[:is],
+           "Expected extraction_method=#{opts[:is]} but got #{inspect(actual)}"
+
+    result
+  end
+
   def assert_content_not_empty(result) do
     content_len = String.length(result.content || "")
     if content_len > 0 do
@@ -1558,6 +1569,13 @@ fn render_assertions(assertions: &Assertions) -> String {
         }
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        pipes.push(format!(
+            "E2E.Helpers.assert_extraction_method(is: {})",
+            elixir_string_literal(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
         pipes.push("E2E.Helpers.assert_content_not_empty()".into());
     }
@@ -1704,6 +1722,10 @@ fn render_string_list(items: &[String]) -> String {
             .join(", ");
         format!("[{content}]")
     }
+}
+
+fn elixir_string_literal(value: &str) -> String {
+    render_elixir_string(value)
 }
 
 fn render_optional_string(value: Option<&String>) -> String {

--- a/tools/e2e-generator/src/fixtures.rs
+++ b/tools/e2e-generator/src/fixtures.rs
@@ -295,6 +295,9 @@ pub struct Assertions {
     /// Keyword extraction assertions
     #[serde(default)]
     pub keywords: Option<KeywordAssertion>,
+    /// Extraction method assertions
+    #[serde(default)]
+    pub extraction_method: Option<ExtractionMethodAssertion>,
     /// Whether content must be non-empty
     #[serde(default)]
     pub content_not_empty: Option<bool>,
@@ -429,6 +432,14 @@ pub struct KeywordAssertion {
     /// Maximum number of keywords expected
     #[serde(default)]
     pub max_count: Option<usize>,
+}
+
+/// Extraction method assertions.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExtractionMethodAssertion {
+    /// Expected extraction method (`native`, `ocr`, or `mixed`).
+    pub is: String,
 }
 
 /// Document structure assertions for hierarchical document tree validation

--- a/tools/e2e-generator/src/go.rs
+++ b/tools/e2e-generator/src/go.rs
@@ -614,6 +614,24 @@ func assertKeywords(t *testing.T, result *kreuzberg.ExtractionResult, hasKeyword
 	}
 }
 
+func assertExtractionMethod(t *testing.T, result *kreuzberg.ExtractionResult, expected string) {
+	t.Helper()
+	if result.Metadata.Additional == nil {
+		t.Fatalf("expected extraction_method=%q but metadata.additional was empty", expected)
+	}
+	raw, ok := result.Metadata.Additional["extraction_method"]
+	if !ok {
+		t.Fatalf("expected extraction_method=%q but metadata.additional had no extraction_method key", expected)
+	}
+	var actual string
+	if err := json.Unmarshal(raw, &actual); err != nil {
+		t.Fatalf("failed to decode extraction_method from metadata.additional: %v", err)
+	}
+	if actual != expected {
+		t.Fatalf("expected extraction_method=%q, got %q", expected, actual)
+	}
+}
+
 func assertContentNotEmpty(t *testing.T, result *kreuzberg.ExtractionResult) {
 	t.Helper()
 	if len(result.Content) == 0 {
@@ -1394,6 +1412,14 @@ fn render_assertions(assertions: &Assertions) -> String {
         )
         .unwrap();
     }
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        writeln!(
+            buffer,
+            "    assertExtractionMethod(t, result, {})",
+            render_string_literal(&extraction_method.is)
+        )
+        .unwrap();
+    }
     if assertions.content_not_empty == Some(true) {
         writeln!(buffer, "    assertContentNotEmpty(t, result)").unwrap();
     }
@@ -1533,6 +1559,10 @@ fn render_string_slice(values: &[String]) -> String {
 
 fn go_string_literal(value: &str) -> String {
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
+}
+
+fn render_string_literal(value: &str) -> String {
+    go_string_literal(value)
 }
 
 /// Convert a snake_case or UPPER_CASE identifier to PascalCase for Go test names

--- a/tools/e2e-generator/src/java.rs
+++ b/tools/e2e-generator/src/java.rs
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -767,6 +768,12 @@ public final class E2EHelpers {
                 assertTrue(count <= maxCount,
                         String.format("Expected at most %d processing warnings, got %d", maxCount, count));
             }
+        }
+
+        public static void assertExtractionMethod(ExtractionResult result, String expected) {
+            Object actual = result.getMetadata().getAdditional().get("extraction_method");
+            assertEquals(expected, actual,
+                    String.format("Expected extraction_method=%s, got %s", expected, actual));
         }
 
         public static void assertLlmUsage(ExtractionResult result, Integer maxCount, Boolean isEmpty) {
@@ -1982,6 +1989,13 @@ fn render_assertions(assertions: &Assertions) -> String {
         ));
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        buffer.push_str(&format!(
+            "                E2EHelpers.Assertions.assertExtractionMethod(result, {});\n",
+            java_string_literal(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
         buffer.push_str("                E2EHelpers.Assertions.assertContentNotEmpty(result);\n");
     }
@@ -2101,6 +2115,10 @@ fn render_string_list(items: &[String]) -> String {
             .join(", ");
         format!("Arrays.asList({})", content)
     }
+}
+
+fn java_string_literal(text: &str) -> String {
+    render_java_string(text)
 }
 
 fn render_optional_string(value: Option<&String>) -> String {

--- a/tools/e2e-generator/src/main.rs
+++ b/tools/e2e-generator/src/main.rs
@@ -410,7 +410,7 @@ fn run_styler_format(dir: &Utf8Path) {
 fn run_ruff_format(dir: &Utf8Path) {
     // Fix lint issues
     let status = std::process::Command::new("uv")
-        .args(["run", "ruff", "check", "--fix"])
+        .args(["run", "--no-project", "ruff", "check", "--fix"])
         .arg(dir.as_str())
         .status();
     match status {
@@ -423,7 +423,7 @@ fn run_ruff_format(dir: &Utf8Path) {
     }
     // Apply formatting
     let status = std::process::Command::new("uv")
-        .args(["run", "ruff", "format"])
+        .args(["run", "--no-project", "ruff", "format"])
         .arg(dir.as_str())
         .status();
     match status {

--- a/tools/e2e-generator/src/manifest.rs
+++ b/tools/e2e-generator/src/manifest.rs
@@ -417,6 +417,7 @@ fn sample_extraction_result() -> Value {
         content: "Hello world".to_string(),
         mime_type: Cow::Borrowed("text/plain"),
         metadata: kreuzberg::types::metadata::Metadata::default(),
+        extraction_method: Some(kreuzberg::ExtractionMethod::Native),
         tables: vec![table],
         detected_languages: Some(vec!["en".to_string()]),
         chunks: Some(vec![chunk]),
@@ -443,6 +444,7 @@ fn sample_extraction_result() -> Value {
         uris: Some(vec![uri]),
         llm_usage: None,
         formatted_content: None,
+        #[cfg(feature = "tree-sitter")]
         code_intelligence: None,
         ocr_internal_document: None,
         structured_output: None,
@@ -481,6 +483,7 @@ fn sample_extraction_config() -> Value {
         result_format: kreuzberg::types::OutputFormat::Unified,
         security_limits: Some(kreuzberg::extractors::security::SecurityLimits::default()),
         output_format: kreuzberg::core::config::OutputFormat::Plain,
+        #[cfg(feature = "layout-detection")]
         layout: Some(kreuzberg::LayoutDetectionConfig::default()),
         include_document_structure: true,
         acceleration: Some(kreuzberg::AccelerationConfig::default()),
@@ -489,6 +492,7 @@ fn sample_extraction_config() -> Value {
         email: Some(kreuzberg::EmailConfig::default()),
         concurrency: Some(kreuzberg::core::config::ConcurrencyConfig::default()),
         max_archive_depth: 3,
+        #[cfg(feature = "tree-sitter")]
         tree_sitter: Some(kreuzberg::TreeSitterConfig::default()),
         structured_extraction: None,
         html_output: None,

--- a/tools/e2e-generator/src/php.rs
+++ b/tools/e2e-generator/src/php.rs
@@ -728,6 +728,17 @@ class Helpers
         }
     }
 
+    public static function assertExtractionMethod(ExtractionResult $result, string $expected): void
+    {
+        $actual = $result->metadata->getCustom('extraction_method');
+
+        Assert::assertSame(
+            $expected,
+            $actual,
+            sprintf('Expected extraction_method=%s, got %s', $expected, var_export($actual, true))
+        );
+    }
+
     public static function assertContentNotEmpty(ExtractionResult $result): void
     {
         Assert::assertNotEmpty(
@@ -1571,6 +1582,15 @@ fn render_assertions(assertions: &Assertions) -> String {
             buffer,
             "        Helpers::assertKeywords($result, {}, {}, {});",
             has_keywords, min_count, max_count
+        )
+        .unwrap();
+    }
+
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        writeln!(
+            buffer,
+            "        Helpers::assertExtractionMethod($result, {});",
+            php_string_literal(&extraction_method.is)
         )
         .unwrap();
     }

--- a/tools/e2e-generator/src/php.rs
+++ b/tools/e2e-generator/src/php.rs
@@ -730,7 +730,7 @@ class Helpers
 
     public static function assertExtractionMethod(ExtractionResult $result, string $expected): void
     {
-        $actual = $result->metadata->getCustom('extraction_method');
+        $actual = $result->extractionMethod ?? $result->metadata->getCustom('extraction_method');
 
         Assert::assertSame(
             $expected,

--- a/tools/e2e-generator/src/python.rs
+++ b/tools/e2e-generator/src/python.rs
@@ -674,6 +674,24 @@ def assert_keywords(
             pytest.fail(f"Expected <= {max_count} keywords, found {len(keywords)}")
 
 
+def assert_extraction_method(result: Any, expected: str) -> None:
+    actual = getattr(result, "extraction_method", None)
+    if actual is None and isinstance(result, dict):
+        actual = result.get("extraction_method") or result.get("extractionMethod")
+
+    metadata = getattr(result, "metadata", None)
+    if isinstance(result, dict):
+        metadata = result.get("metadata")
+
+    if actual is None and isinstance(metadata, Mapping):
+        actual = metadata.get("extraction_method")
+        additional = metadata.get("additional")
+        if actual is None and isinstance(additional, Mapping):
+            actual = additional.get("extraction_method")
+
+    assert actual == expected, f"Expected extraction_method={expected!r}, got {actual!r}"
+
+
 def assert_content_not_empty(result: Any) -> None:
     content = getattr(result, "content", None)
     if content is None or len(content.strip()) == 0:
@@ -1477,6 +1495,15 @@ fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("max_count={max}"));
         }
         writeln!(buffer, "    helpers.assert_keywords(result, {})", args.join(", ")).unwrap();
+    }
+
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        writeln!(
+            buffer,
+            "    helpers.assert_extraction_method(result, {})",
+            python_string_literal(&extraction_method.is)
+        )
+        .unwrap();
     }
 
     if assertions.content_not_empty == Some(true) {

--- a/tools/e2e-generator/src/r/assertions.rs
+++ b/tools/e2e-generator/src/r/assertions.rs
@@ -7,42 +7,42 @@ pub fn render_assertions(assertions: &Assertions) -> String {
 
     if !assertions.expected_mime.is_empty() {
         buf.push_str(&format!(
-            "      assert_expected_mime(result, {})\n",
+            "  assert_expected_mime(result, {})\n",
             render_string_vector(&assertions.expected_mime)
         ));
     }
 
     if let Some(min) = assertions.min_content_length {
         buf.push_str(&format!(
-            "      assert_min_content_length(result, {})\n",
+            "  assert_min_content_length(result, {})\n",
             render_numeric_literal(min as u64)
         ));
     }
 
     if let Some(max) = assertions.max_content_length {
         buf.push_str(&format!(
-            "      assert_max_content_length(result, {})\n",
+            "  assert_max_content_length(result, {})\n",
             render_numeric_literal(max as u64)
         ));
     }
 
     if !assertions.content_contains_any.is_empty() {
         buf.push_str(&format!(
-            "      assert_content_contains_any(result, {})\n",
+            "  assert_content_contains_any(result, {})\n",
             render_string_vector(&assertions.content_contains_any)
         ));
     }
 
     if !assertions.content_contains_all.is_empty() {
         buf.push_str(&format!(
-            "      assert_content_contains_all(result, {})\n",
+            "  assert_content_contains_all(result, {})\n",
             render_string_vector(&assertions.content_contains_all)
         ));
     }
 
     if !assertions.content_contains_none.is_empty() {
         buf.push_str(&format!(
-            "      assert_content_contains_none(result, {})\n",
+            "  assert_content_contains_none(result, {})\n",
             render_string_vector(&assertions.content_contains_none)
         ));
     }
@@ -57,17 +57,17 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             .map(|v| render_numeric_literal(v as u64))
             .unwrap_or_else(|| "NULL".into());
         buf.push_str(&format!(
-            "      assert_table_count(result, minimum = {}, maximum = {})\n",
+            "  assert_table_count(result, minimum = {}, maximum = {})\n",
             min_lit, max_lit
         ));
         if tables.has_bounding_boxes == Some(true) {
-            buf.push_str("      assert_table_bounding_boxes(result)\n");
+            buf.push_str("  assert_table_bounding_boxes(result)\n");
         }
         if let Some(snippets) = tables.content_contains_any.as_ref()
             && !snippets.is_empty()
         {
             buf.push_str(&format!(
-                "      assert_table_content_contains_any(result, {})\n",
+                "  assert_table_content_contains_any(result, {})\n",
                 render_string_vector(snippets)
             ));
         }
@@ -80,7 +80,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             .map(|v| v.to_string())
             .unwrap_or_else(|| "NULL".into());
         buf.push_str(&format!(
-            "      assert_detected_languages(result, {}, {})\n",
+            "  assert_detected_languages(result, {}, {})\n",
             expected, min_conf
         ));
     }
@@ -88,7 +88,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
     if !assertions.metadata.is_empty() {
         for (path, expectation) in &assertions.metadata {
             buf.push_str(&format!(
-                "      assert_metadata_expectation(result, {}, {})\n",
+                "  assert_metadata_expectation(result, {}, {})\n",
                 render_r_string(path),
                 render_r_value(expectation)
             ));
@@ -134,7 +134,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             ));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_chunks(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_chunks(result, {})\n", args.join(", ")));
         }
     }
 
@@ -150,10 +150,10 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("formats_include = {}", render_string_vector(formats)));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_images(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_images(result, {})\n", args.join(", ")));
         }
         if images.has_bounding_boxes == Some(true) {
-            buf.push_str("      assert_image_bounding_boxes(result)\n");
+            buf.push_str("  assert_image_bounding_boxes(result)\n");
         }
     }
 
@@ -166,7 +166,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("exact_count = {}", render_numeric_literal(exact as u64)));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_pages(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_pages(result, {})\n", args.join(", ")));
         }
     }
 
@@ -179,7 +179,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("types_include = {}", render_string_vector(types)));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_elements(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_elements(result, {})\n", args.join(", ")));
         }
     }
 
@@ -207,7 +207,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("min_count = {}", render_numeric_literal(min as u64)));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_ocr_elements(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_ocr_elements(result, {})\n", args.join(", ")));
         }
     }
 
@@ -228,7 +228,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
         if let Some(has_groups) = document.has_groups {
             args.push(format!("has_groups = {}", if has_groups { "TRUE" } else { "FALSE" }));
         }
-        buf.push_str(&format!("      assert_document(result, {})\n", args.join(", ")));
+        buf.push_str(&format!("  assert_document(result, {})\n", args.join(", ")));
     }
 
     if let Some(keywords) = assertions.keywords.as_ref() {
@@ -246,12 +246,19 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("max_count = {}", render_numeric_literal(max as u64)));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_keywords(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_keywords(result, {})\n", args.join(", ")));
         }
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        buf.push_str(&format!(
+            "  assert_extraction_method(result, {})\n",
+            render_r_string(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
-        buf.push_str("      assert_content_not_empty(result)\n");
+        buf.push_str("  assert_content_not_empty(result)\n");
     }
 
     if let Some(qs) = assertions.quality_score.as_ref() {
@@ -266,7 +273,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("max_score = {}", max_score));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_quality_score(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_quality_score(result, {})\n", args.join(", ")));
         }
     }
 
@@ -279,10 +286,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("is_empty = {}", if is_empty { "TRUE" } else { "FALSE" }));
         }
         if !args.is_empty() {
-            buf.push_str(&format!(
-                "      assert_processing_warnings(result, {})\n",
-                args.join(", ")
-            ));
+            buf.push_str(&format!("  assert_processing_warnings(result, {})\n", args.join(", ")));
         }
     }
 
@@ -295,7 +299,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("is_empty = {}", if is_empty { "TRUE" } else { "FALSE" }));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_llm_usage(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_llm_usage(result, {})\n", args.join(", ")));
         }
     }
 
@@ -308,7 +312,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
             args.push(format!("min_blocks = {}", render_numeric_literal(min_blocks as u64)));
         }
         if !args.is_empty() {
-            buf.push_str(&format!("      assert_djot_content(result, {})\n", args.join(", ")));
+            buf.push_str(&format!("  assert_djot_content(result, {})\n", args.join(", ")));
         }
     }
 
@@ -320,7 +324,7 @@ pub fn render_assertions(assertions: &Assertions) -> String {
         if let Some(min_count) = annotations.min_count {
             args.push(format!("min_count = {}", render_numeric_literal(min_count as u64)));
         }
-        buf.push_str(&format!("      assert_annotations(result, {})\n", args.join(", ")));
+        buf.push_str(&format!("  assert_annotations(result, {})\n", args.join(", ")));
     }
 
     buf

--- a/tools/e2e-generator/src/r/helpers.rs
+++ b/tools/e2e-generator/src/r/helpers.rs
@@ -358,6 +358,18 @@ assert_keywords <- function(result, has_keywords = NULL, min_count = NULL, max_c
   }
 }
 
+assert_extraction_method <- function(result, expected) {
+  metadata <- result$metadata
+  actual <- NULL
+  if (!is.null(metadata$additional)) {
+    actual <- metadata$additional[["extraction_method"]]
+  }
+  if (is.null(actual)) {
+    actual <- metadata[["extraction_method"]]
+  }
+  testthat::expect_identical(actual, expected)
+}
+
 assert_content_not_empty <- function(result) {
   testthat::expect_false(is.null(result$content))
   testthat::expect_gt(nchar(result$content), 0)

--- a/tools/e2e-generator/src/ruby.rs
+++ b/tools/e2e-generator/src/ruby.rs
@@ -416,6 +416,14 @@ module E2ERuby
       expect(keywords.length).to be <= max_count if max_count
     end
 
+    def self.assert_extraction_method(result, expected)
+      metadata_value =
+        if result.respond_to?(:metadata) && result.metadata.respond_to?(:additional)
+          result.metadata.additional['extraction_method']
+        end
+      expect(metadata_value).to eq(expected)
+    end
+
     def self.assert_content_not_empty(result)
       expect(result.content).not_to be_nil
       expect(result.content).not_to be_empty
@@ -1153,6 +1161,13 @@ fn render_assertions(assertions: &Assertions) -> String {
         }
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        buffer.push_str(&format!(
+            "      E2ERuby::Assertions.assert_extraction_method(result, {})\n",
+            render_string_literal(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
         buffer.push_str("      E2ERuby::Assertions.assert_content_not_empty(result)\n");
     }
@@ -1313,6 +1328,10 @@ fn render_string_array(items: &[String]) -> String {
             .join(", ");
         format!("[{content}]")
     }
+}
+
+fn render_string_literal(text: &str) -> String {
+    render_ruby_string(text)
 }
 
 fn render_optional_string(value: Option<&String>) -> String {

--- a/tools/e2e-generator/src/rust.rs
+++ b/tools/e2e-generator/src/rust.rs
@@ -607,6 +607,13 @@ fn render_assertions(assertions: &Assertions) -> String {
         ));
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        buffer.push_str(&format!(
+            "    assertions::assert_extraction_method(&result, \"{}\");\n",
+            escape_rust_string(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
         buffer.push_str("    assertions::assert_content_not_empty(&result);\n");
     }

--- a/tools/e2e-generator/src/typescript.rs
+++ b/tools/e2e-generator/src/typescript.rs
@@ -590,6 +590,16 @@ export const assertions = {
         }
     },
 
+    assertExtractionMethod(result: ExtractionResult, expected: string): void {
+        const metadata = isPlainRecord(result.metadata) ? (result.metadata as PlainRecord) : null;
+        const additional = metadata && isPlainRecord(metadata.additional) ? (metadata.additional as PlainRecord) : null;
+        const actual = (result as unknown as PlainRecord).extractionMethod
+            ?? (result as unknown as PlainRecord).extraction_method
+            ?? metadata?.extraction_method
+            ?? additional?.extraction_method;
+        expect(actual).toBe(expected);
+    },
+
     assertContentNotEmpty(result: ExtractionResult): void {
         expect(result.content).toBeDefined();
         expect(result.content.trim().length).toBeGreaterThan(0);
@@ -1709,6 +1719,13 @@ fn render_assertions(assertions: &Assertions) -> String {
         ));
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        buffer.push_str(&format!(
+            "    assertions.assertExtractionMethod(result, {});\n",
+            render_string_literal(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
         buffer.push_str("    assertions.assertContentNotEmpty(result);\n");
     }
@@ -1822,6 +1839,10 @@ fn render_string_array(items: &[String]) -> String {
             .join(", ");
         format!("[{quoted}]")
     }
+}
+
+fn render_string_literal(value: &str) -> String {
+    format!("\"{}\"", escape_ts_string(value))
 }
 
 fn render_optional_string(value: Option<&String>) -> String {

--- a/tools/e2e-generator/src/wasm.rs
+++ b/tools/e2e-generator/src/wasm.rs
@@ -712,6 +712,16 @@ export const assertions = {
         }
     },
 
+    assertExtractionMethod(result: ExtractionResult, expected: string): void {
+        const metadata = isPlainRecord(result.metadata) ? (result.metadata as PlainRecord) : null;
+        const additional = metadata && isPlainRecord(metadata.additional) ? (metadata.additional as PlainRecord) : null;
+        const actual = (result as unknown as PlainRecord).extractionMethod
+            ?? (result as unknown as PlainRecord).extraction_method
+            ?? metadata?.extraction_method
+            ?? additional?.extraction_method;
+        expect(actual).toBe(expected);
+    },
+
     assertContentNotEmpty(result: ExtractionResult): void {
         expect(result.content.length > 0).toBe(true);
     },
@@ -1479,6 +1489,13 @@ fn render_assertions(assertions: &Assertions, _requirements: &[String]) -> Strin
         ));
     }
 
+    if let Some(extraction_method) = assertions.extraction_method.as_ref() {
+        buffer.push_str(&format!(
+            "    assertions.assertExtractionMethod(result, {});\n",
+            render_string_literal(&extraction_method.is)
+        ));
+    }
+
     if assertions.content_not_empty == Some(true) {
         buffer.push_str("    assertions.assertContentNotEmpty(result);\n");
     }
@@ -1594,6 +1611,10 @@ fn render_string_array(items: &[String]) -> String {
             .join(", ");
         format!("[{quoted}]")
     }
+}
+
+fn render_string_literal(value: &str) -> String {
+    format!("\"{}\"", escape_ts_string(value))
 }
 
 fn render_optional_string(value: Option<&String>) -> String {

--- a/tools/e2e-generator/templates/rust_lib.rs
+++ b/tools/e2e-generator/templates/rust_lib.rs
@@ -583,6 +583,22 @@ pub mod assertions {
         }
     }
 
+    /// Assert the reported extraction method.
+    pub fn assert_extraction_method(result: &ExtractionResult, expected: &str) {
+        let actual = result
+            .extraction_method
+            .map(|method| method.as_str())
+            .or_else(|| result.metadata.additional.get("extraction_method").and_then(Value::as_str));
+
+        assert_eq!(
+            actual,
+            Some(expected),
+            "Expected extraction_method {:?}, got {:?}",
+            expected,
+            actual
+        );
+    }
+
     /// Assert that content is not empty.
     pub fn assert_content_not_empty(result: &ExtractionResult) {
         assert!(!result.content.trim().is_empty(), "Expected non-empty content");


### PR DESCRIPTION
## Summary
- add a first-class `extraction_method` field to `ExtractionResult` with `native`, `ocr`, and `mixed` values
- propagate the existing PDF OCR/native decision into the public result while keeping the internal metadata handoff intact
- expose the new field through the Rust, Python, Node, PHP, and TypeScript result surfaces

Closes #751.

## Verification
- `cargo check -p kreuzberg --features 'pdf bundled-pdfium'`
- `cargo test -p kreuzberg --lib extraction_method --features 'pdf bundled-pdfium' -- --nocapture`

## Notes
- `cargo check -p kreuzberg-py -p kreuzberg-node` is blocked in this environment by the existing `kreuzberg-tesseract` arm64 build issue (`cpuid.h`/`simddetect.cpp` x86 SIMD detection)
- `cargo check -p kreuzberg-php` is also blocked locally because `ext-php-rs` requires a `php` executable on `PATH`
