### PR TITLE
fix(ffi): add forwarding features and cfg-gate embeddings/tree-sitter symbols so kreuzberg-ffi builds with any feature subset

### DIFF
--- a/crates/kreuzberg-ffi/src/config/loader.rs
+++ b/crates/kreuzberg-ffi/src/config/loader.rs
@@ -83,6 +83,7 @@ pub fn discover_config_as_json() -> Option<String> {
 /// # Returns
 ///
 /// JSON array of preset names, or error message.
+#[cfg(feature = "embeddings")]
 pub fn list_embedding_presets() -> Result<String, String> {
     let presets = kreuzberg::embeddings::list_presets();
     match serde_json::to_string(&presets) {
@@ -100,6 +101,7 @@ pub fn list_embedding_presets() -> Result<String, String> {
 /// # Returns
 ///
 /// JSON representation of the preset, or error message.
+#[cfg(feature = "embeddings")]
 pub fn get_embedding_preset(preset_name: &str) -> Result<String, String> {
     let preset = match kreuzberg::embeddings::get_preset(preset_name) {
         Some(preset) => preset,
@@ -128,6 +130,7 @@ pub fn get_embedding_preset(preset_name: &str) -> Result<String, String> {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "embeddings")]
     #[test]
     fn test_list_embedding_presets() {
         let result = list_embedding_presets();
@@ -137,12 +140,14 @@ mod tests {
         assert!(json.ends_with(']'));
     }
 
+    #[cfg(feature = "embeddings")]
     #[test]
     fn test_get_embedding_preset_unknown() {
         let result = get_embedding_preset("nonexistent_preset");
         assert!(result.is_err());
     }
 
+    #[cfg(feature = "embeddings")]
     #[test]
     fn test_get_embedding_preset_valid() {
         let result = get_embedding_preset("fast");

--- a/crates/kreuzberg-ffi/src/config/merge.rs
+++ b/crates/kreuzberg-ffi/src/config/merge.rs
@@ -66,6 +66,7 @@ pub fn merge_configs(base: &mut ExtractionConfig, override_config: &ExtractionCo
         base.extraction_timeout_secs = override_config.extraction_timeout_secs;
     }
 
+    #[cfg(feature = "tree-sitter")]
     if override_config.tree_sitter.is_some() {
         base.tree_sitter = override_config.tree_sitter.clone();
     }

--- a/crates/kreuzberg-ffi/src/config/mod.rs
+++ b/crates/kreuzberg-ffi/src/config/mod.rs
@@ -17,15 +17,17 @@ mod parse;
 mod serialize;
 
 // Re-export key functions for internal use
-pub use loader::{
-    discover_config_as_json, get_embedding_preset, list_embedding_presets, load_config_as_json, load_config_from_file,
-};
+pub use loader::{discover_config_as_json, load_config_as_json, load_config_from_file};
+#[cfg(feature = "embeddings")]
+pub use loader::{get_embedding_preset, list_embedding_presets};
 pub use merge::merge_configs;
 pub use parse::parse_extraction_config_from_json;
 pub use serialize::{config_to_json_string, get_field_as_json, json_to_c_string};
 
 use crate::ffi_panic_guard;
-use crate::helpers::{clear_last_error, set_last_error, string_to_c_string};
+use crate::helpers::{clear_last_error, set_last_error};
+#[cfg(feature = "embeddings")]
+use crate::helpers::string_to_c_string;
 use kreuzberg::core::config::ExtractionConfig;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
@@ -323,6 +325,7 @@ pub unsafe extern "C" fn kreuzberg_config_discover() -> *mut c_char {
 /// # Safety
 ///
 /// - Returned string is a JSON array and must be freed with `kreuzberg_free_string`
+#[cfg(feature = "embeddings")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kreuzberg_list_embedding_presets() -> *mut c_char {
     ffi_panic_guard!("kreuzberg_list_embedding_presets", {
@@ -350,6 +353,7 @@ pub unsafe extern "C" fn kreuzberg_list_embedding_presets() -> *mut c_char {
 ///
 /// - `name` must be a valid null-terminated C string
 /// - Returned string is JSON object and must be freed with `kreuzberg_free_string`
+#[cfg(feature = "embeddings")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kreuzberg_get_embedding_preset(name: *const c_char) -> *mut c_char {
     ffi_panic_guard!("kreuzberg_get_embedding_preset", {

--- a/crates/kreuzberg-ffi/src/config/serialize.rs
+++ b/crates/kreuzberg-ffi/src/config/serialize.rs
@@ -4,12 +4,14 @@
 
 use crate::helpers::set_last_error;
 use kreuzberg::core::config::ExtractionConfig;
+#[cfg(feature = "embeddings")]
 use serde::Serialize;
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
 
 /// SerializableEmbeddingPreset for FFI serialization.
+#[cfg(feature = "embeddings")]
 #[derive(Serialize)]
 pub struct SerializableEmbeddingPreset<'a> {
     pub name: &'a str,

--- a/crates/kreuzberg-ffi/src/config_builder.rs
+++ b/crates/kreuzberg-ffi/src/config_builder.rs
@@ -10,6 +10,7 @@ use crate::ffi_panic_guard;
 use crate::ffi_panic_guard_i32;
 use crate::helpers::{clear_last_error, set_last_error};
 use kreuzberg::core::config::LayoutDetectionConfig;
+#[cfg(feature = "tree-sitter")]
 use kreuzberg::core::config::TreeSitterConfig;
 use kreuzberg::core::config::{
     AccelerationConfig, ChunkingConfig, ContentFilterConfig, ExtractionConfig, HtmlOutputConfig, ImageExtractionConfig,
@@ -106,6 +107,7 @@ impl ConfigBuilder {
         Ok(())
     }
 
+    #[cfg(feature = "tree-sitter")]
     fn set_tree_sitter_from_json(&mut self, ts_json: &str) -> Result<(), String> {
         let ts_config: TreeSitterConfig =
             serde_json::from_str(ts_json).map_err(|e| format!("Failed to parse tree-sitter config JSON: {}", e))?;
@@ -714,6 +716,7 @@ pub unsafe extern "C" fn kreuzberg_config_builder_set_layout(
 /// - The pointer must be properly aligned and point to a valid ConfigBuilder instance
 /// - `ts_json` must be a valid, non-null pointer to a null-terminated UTF-8 string
 /// - The string pointer must remain valid for the duration of the function call
+#[cfg(feature = "tree-sitter")]
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn kreuzberg_config_builder_set_tree_sitter(
     builder: *mut ConfigBuilder,

--- a/crates/kreuzberg-ffi/src/lib.rs
+++ b/crates/kreuzberg-ffi/src/lib.rs
@@ -7,6 +7,7 @@ mod batch_streaming;
 mod cancellation;
 mod config;
 mod config_builder;
+#[cfg(feature = "embeddings")]
 mod embedding;
 mod error;
 mod extraction;
@@ -33,13 +34,16 @@ pub use cancellation::{
     CancellationToken as CFfiCancellationToken, kreuzberg_cancel_token_cancel, kreuzberg_cancel_token_free,
     kreuzberg_cancel_token_is_cancelled, kreuzberg_cancel_token_new,
 };
+#[cfg(feature = "embeddings")]
 pub use embedding::kreuzberg_embed;
 
 pub use config::{
     kreuzberg_config_discover, kreuzberg_config_free, kreuzberg_config_from_file, kreuzberg_config_from_json,
     kreuzberg_config_get_field, kreuzberg_config_is_valid, kreuzberg_config_merge, kreuzberg_config_to_json,
-    kreuzberg_get_embedding_preset, kreuzberg_list_embedding_presets, kreuzberg_load_extraction_config_from_file,
+    kreuzberg_load_extraction_config_from_file,
 };
+#[cfg(feature = "embeddings")]
+pub use config::{kreuzberg_get_embedding_preset, kreuzberg_list_embedding_presets};
 pub use config_builder::kreuzberg_config_builder_set_layout;
 pub use config_builder::{
     kreuzberg_config_builder_build, kreuzberg_config_builder_free, kreuzberg_config_builder_new,


### PR DESCRIPTION
## What

Make `kreuzberg-ffi` compilable against **any** feature subset of `kreuzberg`, not only `features = ["bundled-pdfium", "full"]`.

Two mechanical changes:

1. **Forwarding features** in `crates/kreuzberg-ffi/Cargo.toml`:
   - `embeddings  = ["kreuzberg/embeddings"]`
   - `tree-sitter = ["kreuzberg/tree-sitter"]`
   - `default = ["embeddings", "tree-sitter"]` - both are on by default, so `cargo build -p kreuzberg-ffi` behaves exactly as before; opt-out is via `--no-default-features`.

2. **`#[cfg(feature = "...")]`** guards on every FFI item that touches those optional symbols:
   - `mod embedding;` + `pub use embedding::kreuzberg_embed;`
   - `kreuzberg::embeddings::*` callers in `config/loader.rs` and their tests
   - `SerializableEmbeddingPreset`, `serde::Serialize` import, `string_to_c_string` import
   - `kreuzberg_list_embedding_presets` / `kreuzberg_get_embedding_preset` C entry points
   - `TreeSitterConfig` import, `set_tree_sitter_from_json`, `kreuzberg_config_builder_set_tree_sitter`
   - `ExtractionConfig::tree_sitter` merge in `config/merge.rs`

## Why

Today the FFI crate references `kreuzberg::embeddings::*`, `embed_texts`, and `TreeSitterConfig` unconditionally. Any consumer that tries to build with a trimmed `kreuzberg` feature set (e.g. without `embeddings` or `tree-sitter`) gets:

error[E0432]: unresolved import kreuzberg::core::config::TreeSitterConfig error[E0433]: failed to resolve: could not find embeddings in kreuzberg error[E0425]: cannot find function embed_texts in crate kreuzberg


This is a standard gap in Rust crates that expose optional-dependency symbols: downstream crates must gate those symbols with matching `#[cfg]` guards. This PR adopts the common forwarding-feature pattern so `kreuzberg-ffi` does the same - existing users are unaffected (the new features are on by default), and consumers who want a smaller FFI can now opt out with `--no-default-features` (or enable only a subset).