### PR TITLE
fix: PDF image links silently dropped from markdown output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
 
   # Shell scripts: formatting and linting
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.14.2-1
+    rev: v3.13.1-1
     hooks:
       - id: shfmt
         args: ["-w", "-i", "2"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken wasm-deno/wasm-workers e2e tasks** — removed non-functional deno and workers e2e generate/lint/test tasks that referenced invalid generator lang values.
 - **oxlint path in node e2e lint** — `oxlint --fix typescript` changed to `oxlint --fix .` (was looking for nonexistent `typescript/` directory).
 - **Clippy warnings in benchmark-harness** — `sort_by` replaced with `sort_by_key` + `Reverse`.
+- **#762**: PDF image links are no longer silently dropped from markdown output. Image extraction now correctly preserves correspondence between pdfium objects and lopdf data, and respects the `inject_placeholders` configuration.
+- **#769**: Downgraded `pre-commit-shfmt` to `v3.13.1-1` (fixes broken CI due to non-existent version in `main`).
 - **#766**: PDF extraction with large numbers of image fragments no longer hangs indefinitely — added `ImageExtractionConfig.max_images_per_page` (default `None`) to cap images processed per page. Batch-level `extraction_timeout_secs` now interrupts blocking pdfium threads at the next inter-page checkpoint via a `CancellationToken`, preventing the timeout from being silently bypassed.
 - **#764**: PST extractor now populates email attachments — `attachments` was hardcoded to an empty list and never read from the message; now reads attachment name, filename, MIME type, size, and binary data via the attachment table. PST entry IDs are now formatted as proper 48-char MAPI hex strings instead of Rust Debug output.
 

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -121,7 +121,13 @@ pub(crate) fn extract_all_from_document(
             .map(|cf| (cf.strip_repeating_text, cf.include_headers, cf.include_footers))
             .unwrap_or((true, false, false)); // defaults match current behavior
 
-        tracing::debug!(k_clusters = k, "PDF structure path: calling extract_document_structure");
+        let inject_placeholders = config
+            .images
+            .as_ref()
+            .map(|c| c.inject_placeholders)
+            .unwrap_or(true);
+
+        tracing::debug!(k_clusters = k, inject_placeholders, "PDF structure path: calling extract_document_structure");
         match crate::pdf::structure::extract_document_structure(
             document,
             k,
@@ -151,6 +157,7 @@ pub(crate) fn extract_all_from_document(
             include_footers,
             config.images.as_ref().and_then(|i| i.max_images_per_page),
             config.cancel_token.as_ref(),
+            inject_placeholders,
         ) {
             Ok((doc, has_encoding_issues)) if !doc.elements.is_empty() => {
                 tracing::debug!(
@@ -503,6 +510,12 @@ pub(crate) fn extract_all_from_oxide_document(
                 "oxide structure: extracted segments for heading detection"
             );
 
+            let inject_placeholders = config
+                .images
+                .as_ref()
+                .map(|c| c.inject_placeholders)
+                .unwrap_or(true);
+
             match crate::pdf::structure::extract_document_structure_from_segments(
                 segments,
                 crate::pdf::structure::SegmentStructureConfig {
@@ -513,6 +526,7 @@ pub(crate) fn extract_all_from_oxide_document(
                     include_footers,
                     used_structure_tree,
                     image_positions: &image_positions,
+                    inject_placeholders,
                     layout_hints,
                     allow_single_column,
                     cancel_token: config.cancel_token.as_ref(),

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -121,13 +121,13 @@ pub(crate) fn extract_all_from_document(
             .map(|cf| (cf.strip_repeating_text, cf.include_headers, cf.include_footers))
             .unwrap_or((true, false, false)); // defaults match current behavior
 
-        let inject_placeholders = config
-            .images
-            .as_ref()
-            .map(|c| c.inject_placeholders)
-            .unwrap_or(true);
+        let inject_placeholders = config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(true);
 
-        tracing::debug!(k_clusters = k, inject_placeholders, "PDF structure path: calling extract_document_structure");
+        tracing::debug!(
+            k_clusters = k,
+            inject_placeholders,
+            "PDF structure path: calling extract_document_structure"
+        );
         match crate::pdf::structure::extract_document_structure(
             document,
             k,
@@ -510,11 +510,7 @@ pub(crate) fn extract_all_from_oxide_document(
                 "oxide structure: extracted segments for heading detection"
             );
 
-            let inject_placeholders = config
-                .images
-                .as_ref()
-                .map(|c| c.inject_placeholders)
-                .unwrap_or(true);
+            let inject_placeholders = config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(true);
 
             match crate::pdf::structure::extract_document_structure_from_segments(
                 segments,

--- a/crates/kreuzberg/src/extractors/pdf/mod.rs
+++ b/crates/kreuzberg/src/extractors/pdf/mod.rs
@@ -960,9 +960,11 @@ impl PdfExtractor {
                         pre_doc.tables.push(table);
                     }
                 }
-                if let Some(imgs) = images {
-                    pre_doc.images = imgs;
-                }
+                // Do NOT overwrite pre_doc.images here. The structure pipeline already
+                // populated it via populate_images_from_pdfium with images indexed to match
+                // the ElementKind::Image { image_index } values in pre_doc.elements. Overwriting
+                // with the lopdf-extracted images (indexed 0, 1, 2...) would break that
+                // correspondence and cause image links to silently disappear from markdown output.
                 if let Some(warning) = image_fallback_warning.clone() {
                     pre_doc.processing_warnings.push(warning);
                 }

--- a/crates/kreuzberg/src/pdf/structure/assembly.rs
+++ b/crates/kreuzberg/src/pdf/structure/assembly.rs
@@ -865,6 +865,38 @@ mod tests {
     }
 
     #[test]
+    fn test_image_elements_injected_with_positions() {
+        let pages = vec![vec![make_paragraph("Page with image", None)]];
+        // Image at page 1 (1-indexed), image_index = 0
+        let image_positions = vec![(1usize, 0usize)];
+        let doc = assemble_internal_document(pages, &[], &image_positions);
+
+        let image_elems: Vec<_> = doc
+            .elements
+            .iter()
+            .filter(|e| matches!(e.kind, ElementKind::Image { .. }))
+            .collect();
+        assert_eq!(image_elems.len(), 1, "one image element should be injected");
+        assert!(
+            matches!(image_elems[0].kind, ElementKind::Image { image_index: 0 }),
+            "image_index must match the position provided"
+        );
+    }
+
+    #[test]
+    fn test_no_image_elements_with_empty_positions() {
+        let pages = vec![vec![make_paragraph("No images here", None)]];
+        let doc = assemble_internal_document(pages, &[], &[]);
+
+        let image_count = doc
+            .elements
+            .iter()
+            .filter(|e| matches!(e.kind, ElementKind::Image { .. }))
+            .count();
+        assert_eq!(image_count, 0, "no image elements when positions is empty");
+    }
+
+    #[test]
     fn test_caption_skipped_in_main_flow() {
         let para1 = make_paragraph("Main text", None);
         let mut caption = make_paragraph("Caption text", None);

--- a/crates/kreuzberg/src/pdf/structure/pipeline.rs
+++ b/crates/kreuzberg/src/pdf/structure/pipeline.rs
@@ -549,6 +549,7 @@ pub fn extract_document_structure(
     include_footers: bool,
     max_images_per_page: Option<u32>,
     cancel_token: Option<&crate::cancellation::CancellationToken>,
+    inject_placeholders: bool,
 ) -> Result<(crate::types::internal::InternalDocument, bool)> {
     let pages = document.pages();
     let page_count = pages.len();
@@ -1330,11 +1331,16 @@ pub fn extract_document_structure(
     let mut combined_tables: Vec<crate::types::Table> = tables.iter().cloned().chain(layout_tables).collect();
     deduplicate_overlapping_tables(&mut combined_tables);
 
-    // Convert image positions to (page_idx, image_index) pairs for the assembler
-    let image_pos_pairs: Vec<(usize, usize)> = all_image_positions
-        .iter()
-        .map(|img| (img.page_number, img.image_index))
-        .collect();
+    // Convert image positions to (page_idx, image_index) pairs for the assembler.
+    // Skip when inject_placeholders=false: the caller does not want image links in output.
+    let image_pos_pairs: Vec<(usize, usize)> = if inject_placeholders {
+        all_image_positions
+            .iter()
+            .map(|img| (img.page_number, img.image_index))
+            .collect()
+    } else {
+        Vec::new()
+    };
 
     tracing::debug!(
         combined_tables = combined_tables.len(),
@@ -1348,7 +1354,10 @@ pub fn extract_document_structure(
     // Stage 4b: Populate doc.images with actual image data from pdfium.
     // Image elements reference indices into doc.images, which must be populated
     // for markdown/HTML rendering to produce `![desc](image_N.png)` instead of `![]()`.
-    populate_images_from_pdfium(document, &all_image_positions, &mut doc, cancel_token);
+    // Skip when inject_placeholders=false to avoid unnecessary rendering work.
+    if inject_placeholders {
+        populate_images_from_pdfium(document, &all_image_positions, &mut doc, cancel_token);
+    }
 
     let element_count = doc.elements.len();
     tracing::debug!(element_count, "PDF structure pipeline: assembly complete");
@@ -1397,6 +1406,7 @@ pub(crate) struct SegmentStructureConfig<'a> {
     pub include_footers: bool,
     pub used_structure_tree: bool,
     pub image_positions: &'a [(usize, usize)],
+    pub inject_placeholders: bool,
     pub layout_hints: Option<&'a [Vec<LayoutHint>]>,
     pub allow_single_column: bool,
     pub cancel_token: Option<&'a crate::cancellation::CancellationToken>,
@@ -1423,6 +1433,7 @@ pub(crate) fn extract_document_structure_from_segments(
         include_footers,
         used_structure_tree,
         image_positions,
+        inject_placeholders,
         layout_hints,
         allow_single_column,
         cancel_token,
@@ -2096,7 +2107,8 @@ pub(crate) fn extract_document_structure_from_segments(
     // overlapping tables on the same page (same pattern as the pdfium path).
     let mut combined_tables: Vec<crate::types::Table> = tables.iter().cloned().chain(layout_tables).collect();
     deduplicate_overlapping_tables(&mut combined_tables);
-    let mut doc = assemble_internal_document(all_page_paragraphs, &combined_tables, image_positions);
+    let effective_image_positions = if inject_placeholders { image_positions } else { &[] };
+    let mut doc = assemble_internal_document(all_page_paragraphs, &combined_tables, effective_image_positions);
 
     // Stage 5: Element-level text normalization.
     for elem in &mut doc.elements {

--- a/crates/kreuzberg/src/rendering/comrak_bridge.rs
+++ b/crates/kreuzberg/src/rendering/comrak_bridge.rs
@@ -675,21 +675,29 @@ pub fn build_comrak_ast<'a>(doc: &InternalDocument, arena: &'a comrak::Arena<'a>
             ElementKind::Image { image_index } => {
                 let image = doc.images.get(image_index as usize);
                 let desc = image.and_then(|img| img.description.as_deref()).unwrap_or("");
-                let url = image
-                    .and_then(|img| {
-                        if !img.data.is_empty() {
-                            Some(format!("image_{}.{}", image_index, img.format))
-                        } else {
-                            img.source_path.clone()
+                let url = match image {
+                    None => {
+                        // image_index is out-of-bounds — no corresponding entry in doc.images.
+                        // Skip to avoid emitting a broken link with no context.
+                        if desc.is_empty() {
+                            continue;
                         }
-                    })
-                    .unwrap_or_default();
-
-                // Skip images with no URL and no description — they produce
-                // empty `![]()` nodes that add noise to the output.
-                if url.is_empty() && desc.is_empty() {
-                    continue;
-                }
+                        String::new()
+                    }
+                    Some(img) => {
+                        if !img.data.is_empty() {
+                            format!("image_{}.{}", image_index, img.format)
+                        } else if let Some(ref path) = img.source_path {
+                            path.clone()
+                        } else {
+                            // The image is known to exist in the document (pdfium detected it)
+                            // but its pixel data could not be extracted (too small, encoding
+                            // failure, etc.). Emit a stable placeholder filename so the link
+                            // appears in markdown output rather than being silently dropped.
+                            format!("image_{}.bin", image_index)
+                        }
+                    }
+                };
 
                 let para = mk(arena, NodeValue::Paragraph);
                 let img_node = mk(
@@ -1216,5 +1224,95 @@ mod tests {
         let doc = b.build();
         let out = render(&doc);
         assert!(out.contains("footnote"), "should contain footnote marker, got: {}", out);
+    }
+
+    /// Regression test for issue #762: image links must appear in markdown when image
+    /// data is available via pdfium extraction (non-empty `data` field).
+    #[test]
+    fn test_image_with_data_renders_link() {
+        use crate::types::internal::ElementKind;
+        use crate::types::ExtractedImage;
+
+        let mut b = InternalDocumentBuilder::new("test");
+        b.push_paragraph("Before image.", vec![], None, None);
+        b.push_element(crate::types::internal::InternalElement::text(
+            ElementKind::Image { image_index: 0 },
+            "",
+            0,
+        ));
+        let mut doc = b.build();
+        doc.images.push(ExtractedImage {
+            data: bytes::Bytes::from_static(b"\x89PNG"),
+            format: std::borrow::Cow::Borrowed("png"),
+            image_index: 0,
+            page_number: Some(1),
+            width: Some(100),
+            height: Some(100),
+            colorspace: None,
+            bits_per_component: None,
+            is_mask: false,
+            description: None,
+            ocr_result: None,
+            bounding_box: None,
+            source_path: None,
+        });
+        let out = render(&doc);
+        assert!(out.contains("image_0.png"), "image link must appear; got: {}", out);
+        assert!(out.contains("!["), "must use image markdown syntax; got: {}", out);
+    }
+
+    /// Regression test for issue #762: image with no data but known to exist (placeholder)
+    /// must still emit a link with a `.bin` fallback URL rather than being silently dropped.
+    #[test]
+    fn test_image_placeholder_with_empty_data_renders_fallback_link() {
+        use crate::types::internal::ElementKind;
+        use crate::types::ExtractedImage;
+
+        let mut b = InternalDocumentBuilder::new("test");
+        b.push_element(crate::types::internal::InternalElement::text(
+            ElementKind::Image { image_index: 0 },
+            "",
+            0,
+        ));
+        let mut doc = b.build();
+        doc.images.push(ExtractedImage {
+            data: bytes::Bytes::new(), // empty — extraction failed
+            format: std::borrow::Cow::Borrowed("unknown"),
+            image_index: 0,
+            page_number: Some(1),
+            width: None,
+            height: None,
+            colorspace: None,
+            bits_per_component: None,
+            is_mask: false,
+            description: None,
+            ocr_result: None,
+            bounding_box: None,
+            source_path: None,
+        });
+        let out = render(&doc);
+        assert!(
+            out.contains("image_0.bin"),
+            "empty-data image must emit placeholder link; got: {:?}",
+            out
+        );
+    }
+
+    /// Image element with out-of-bounds index and no description must be silently dropped.
+    #[test]
+    fn test_image_out_of_bounds_index_dropped() {
+        use crate::types::internal::ElementKind;
+
+        let mut b = InternalDocumentBuilder::new("test");
+        b.push_paragraph("Only text.", vec![], None, None);
+        b.push_element(crate::types::internal::InternalElement::text(
+            ElementKind::Image { image_index: 99 }, // no such image
+            "",
+            0,
+        ));
+        let doc = b.build(); // doc.images is empty
+        let out = render(&doc);
+        assert!(!out.contains("image_99"), "out-of-bounds image must be dropped; got: {}", out);
+        assert!(out.contains("Only text."), "paragraph must still render; got: {}", out);
     }
 }

--- a/crates/kreuzberg/src/rendering/comrak_bridge.rs
+++ b/crates/kreuzberg/src/rendering/comrak_bridge.rs
@@ -1230,8 +1230,8 @@ mod tests {
     /// data is available via pdfium extraction (non-empty `data` field).
     #[test]
     fn test_image_with_data_renders_link() {
-        use crate::types::internal::ElementKind;
         use crate::types::ExtractedImage;
+        use crate::types::internal::ElementKind;
 
         let mut b = InternalDocumentBuilder::new("test");
         b.push_paragraph("Before image.", vec![], None, None);
@@ -1265,8 +1265,8 @@ mod tests {
     /// must still emit a link with a `.bin` fallback URL rather than being silently dropped.
     #[test]
     fn test_image_placeholder_with_empty_data_renders_fallback_link() {
-        use crate::types::internal::ElementKind;
         use crate::types::ExtractedImage;
+        use crate::types::internal::ElementKind;
 
         let mut b = InternalDocumentBuilder::new("test");
         b.push_element(crate::types::internal::InternalElement::text(
@@ -1312,7 +1312,11 @@ mod tests {
         ));
         let doc = b.build(); // doc.images is empty
         let out = render(&doc);
-        assert!(!out.contains("image_99"), "out-of-bounds image must be dropped; got: {}", out);
+        assert!(
+            !out.contains("image_99"),
+            "out-of-bounds image must be dropped; got: {}",
+            out
+        );
         assert!(out.contains("Only text."), "paragraph must still render; got: {}", out);
     }
 }


### PR DESCRIPTION
Summary                                                                                  
                                                                                           
  - Root cause: extractors/pdf/mod.rs unconditionally overwrote pre_doc.images (indexed by pdfium's page-object scan order) with lopdf-extracted images (indexed 0, 1, 2...). Since ElementKind::Image { image_index } values in the document elements use pdfium indices, the overwrite broke the correspondence and every image link silently disappeared.
  - Secondary: comrak_bridge.rs silently dropped image elements when pdfium detected an image but couldn't extract pixel data (tiny images, encoding failure). Now emits a stable image_N.bin fallback URL instead.
  - Feature: ImageExtractionConfig.inject_placeholders was documented but never read. Now  wired through extract_document_structure and SegmentStructureConfig so setting it to  false actually suppresses image links.
                                                                                           
                                                                                        
  Test plan                                                 

  - 3 new unit tests in comrak_bridge: image with data renders link, empty-data image  renders fallback link, out-of-bounds index dropped cleanly
  - 2 new unit tests in assembly: image elements injected from positions, no elements when positions empty                                                                          
  - Manual: extract a PDF with images using ImageExtractionConfig(extract_images=True) and  confirm ![](image_N.png) links appear in markdown                                        
  - Manual: set inject_placeholders=False and confirm no image links in markdown output
                                                                                           
  fixes #762  