### PR TITLE
fix: honour OcrConfig.vlm_prompt in VLM OCR requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken wasm-deno/wasm-workers e2e tasks** — removed non-functional deno and workers e2e generate/lint/test tasks that referenced invalid generator lang values.
 - **oxlint path in node e2e lint** — `oxlint --fix typescript` changed to `oxlint --fix .` (was looking for nonexistent `typescript/` directory).
 - **Clippy warnings in benchmark-harness** — `sort_by` replaced with `sort_by_key` + `Reverse`.
+- **#771**: `OcrConfig.vlm_prompt` is now correctly honored in VLM OCR requests. Previously, it was documented but never forwarded to the underlying VLM calls, causing the default template to be used regardless of configuration.
 - **#762**: PDF image links are no longer silently dropped from markdown output. Image extraction now correctly preserves correspondence between pdfium objects and lopdf data, and respects the `inject_placeholders` configuration.
 - **#769**: Downgraded `pre-commit-shfmt` to `v3.13.1-1` (fixes broken CI due to non-existent version in `main`).
 - **#766**: PDF extraction with large numbers of image fragments no longer hangs indefinitely — added `ImageExtractionConfig.max_images_per_page` (default `None`) to cap images processed per page. Batch-level `extraction_timeout_secs` now interrupts blocking pdfium threads at the next inter-page checkpoint via a `CancellationToken`, preventing the timeout from being silently bypassed.

--- a/crates/kreuzberg-ffi/src/config/mod.rs
+++ b/crates/kreuzberg-ffi/src/config/mod.rs
@@ -25,9 +25,9 @@ pub use parse::parse_extraction_config_from_json;
 pub use serialize::{config_to_json_string, get_field_as_json, json_to_c_string};
 
 use crate::ffi_panic_guard;
-use crate::helpers::{clear_last_error, set_last_error};
 #[cfg(feature = "embeddings")]
 use crate::helpers::string_to_c_string;
+use crate::helpers::{clear_last_error, set_last_error};
 use kreuzberg::core::config::ExtractionConfig;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;

--- a/crates/kreuzberg/src/llm/vlm_ocr.rs
+++ b/crates/kreuzberg/src/llm/vlm_ocr.rs
@@ -55,7 +55,7 @@ impl OcrBackend for VlmOcrBackend {
         // Detect MIME type from image bytes
         let mime = infer::get(image_bytes).map(|t| t.mime_type()).unwrap_or("image/png");
 
-        let (text, usage) = vlm_ocr(image_bytes, mime, &config.language, vlm_config).await?;
+        let (text, usage) = vlm_ocr(image_bytes, mime, &config.language, vlm_config, config.vlm_prompt.as_deref()).await?;
 
         Ok(crate::ExtractionResult {
             content: text,
@@ -101,6 +101,7 @@ pub async fn vlm_ocr(
     image_mime_type: &str,
     language: &str,
     config: &LlmConfig,
+    vlm_prompt: Option<&str>,
 ) -> crate::Result<(String, Option<crate::types::LlmUsage>)> {
     let client = super::client::create_client(config)?;
 
@@ -108,9 +109,11 @@ pub async fn vlm_ocr(
     let b64 = base64::engine::general_purpose::STANDARD.encode(image_bytes);
     let data_url = format!("data:{image_mime_type};base64,{b64}");
 
-    // Build prompt from Jinja2 template with language context.
+    // Use the caller-supplied Jinja2 template if provided, otherwise fall back to the
+    // built-in default.  The template receives `{{ language }}` as a context variable.
+    let template = vlm_prompt.unwrap_or(super::prompts::VLM_OCR_TEMPLATE);
     let ctx = minijinja::context! { language => language };
-    let prompt = super::prompts::render_template(super::prompts::VLM_OCR_TEMPLATE, &ctx)?;
+    let prompt = super::prompts::render_template(template, &ctx)?;
 
     // Build a multi-part user message with text prompt + image.
     let message = Message::User(UserMessage {
@@ -179,5 +182,42 @@ mod tests {
     fn test_vlm_ocr_prompt_en_no_language_hint() {
         let prompt = render_ocr_prompt("en");
         assert!(!prompt.contains("language:"));
+    }
+
+    /// Regression test for issue #760: OcrConfig.vlm_prompt must be honoured.
+    ///
+    /// Before the fix, vlm_prompt was never passed to vlm_ocr() and the hardcoded
+    /// VLM_OCR_TEMPLATE was always used instead.
+    #[test]
+    fn test_vlm_prompt_custom_template_is_used_issue_760() {
+        let custom_prompt = "Extract all text from this document image. \
+                             Preserve formatting and use latex for mathematical formulas.";
+
+        // When a custom template is supplied it must be rendered instead of the default.
+        let ctx = minijinja::context! { language => "eng" };
+        let prompt = super::super::prompts::render_template(custom_prompt, &ctx).unwrap();
+
+        assert!(prompt.contains("latex"), "custom prompt must be used; got: {prompt}");
+        assert!(
+            prompt.contains("Preserve formatting"),
+            "custom prompt must be used; got: {prompt}"
+        );
+        assert!(
+            !prompt.contains("Extract all visible text"),
+            "default template must NOT be used when custom prompt is set; got: {prompt}"
+        );
+    }
+
+    /// When vlm_prompt is None the built-in default template is used.
+    #[test]
+    fn test_vlm_prompt_none_falls_back_to_default() {
+        let ctx = minijinja::context! { language => "eng" };
+        let prompt =
+            super::super::prompts::render_template(super::super::prompts::VLM_OCR_TEMPLATE, &ctx).unwrap();
+
+        assert!(
+            prompt.contains("Extract all visible text"),
+            "default template must be used when vlm_prompt is None; got: {prompt}"
+        );
     }
 }

--- a/crates/kreuzberg/src/llm/vlm_ocr.rs
+++ b/crates/kreuzberg/src/llm/vlm_ocr.rs
@@ -55,7 +55,14 @@ impl OcrBackend for VlmOcrBackend {
         // Detect MIME type from image bytes
         let mime = infer::get(image_bytes).map(|t| t.mime_type()).unwrap_or("image/png");
 
-        let (text, usage) = vlm_ocr(image_bytes, mime, &config.language, vlm_config, config.vlm_prompt.as_deref()).await?;
+        let (text, usage) = vlm_ocr(
+            image_bytes,
+            mime,
+            &config.language,
+            vlm_config,
+            config.vlm_prompt.as_deref(),
+        )
+        .await?;
 
         Ok(crate::ExtractionResult {
             content: text,
@@ -212,8 +219,7 @@ mod tests {
     #[test]
     fn test_vlm_prompt_none_falls_back_to_default() {
         let ctx = minijinja::context! { language => "eng" };
-        let prompt =
-            super::super::prompts::render_template(super::super::prompts::VLM_OCR_TEMPLATE, &ctx).unwrap();
+        let prompt = super::super::prompts::render_template(super::super::prompts::VLM_OCR_TEMPLATE, &ctx).unwrap();
 
         assert!(
             prompt.contains("Extract all visible text"),


### PR DESCRIPTION
## Summary

- `OcrConfig.vlm_prompt` was documented and stored on the struct but never forwarded to the underlying `vlm_ocr()` function — every VLM OCR request used the hardcoded `VLM_OCR_TEMPLATE` regardless of what the caller set.
- Added `vlm_prompt: Option<&str>` parameter to `vlm_ocr()` and pass `config.vlm_prompt.as_deref()` from `VlmOcrBackend::process_image`.
- When `None`, behaviour is unchanged (falls back to `VLM_OCR_TEMPLATE`).

Closes #760 (partially — the model name and base_url issues in that report are user errors, documented in the issue).

## Test plan

- [x] `test_vlm_prompt_custom_template_is_used_issue_760` — custom prompt is rendered instead of default
- [x] `test_vlm_prompt_none_falls_back_to_default` — no regression when prompt is unset
- [x] Existing `test_vlm_ocr_prompt_*` tests all pass