### PR TITLE
fix(pdf-structure): preserve tagged-block body text and stop mis-tagging numbered headings as lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#774**: Tagged-PDF structure tree dropped paragraph body text when a block had both own text and children, and wrapped numbered section headings in an invalid `List → Heading` AST (panics comrak in debug, emits malformed markdown in release). `flatten_blocks` now emits parent text alongside children; text-pattern list detection in `element_to_paragraph` is gated on `heading_level.is_none()`.
 - **Semantic chunker fallback path now respects `max_characters`** — previously the non-embedding fallback hardcoded a 4000-char ceiling and silently ignored the caller's `max_characters`. A warning is also emitted when `chunker_type='semantic'` is used without an `EmbeddingConfig` so the fallback mode is discoverable. The `ChunkerType::Semantic` docstring has been corrected to describe both paths accurately.
 - **OCR backend dispatch**: `OcrConfig(backend=...)` with a non-default backend no longer silently falls back to paddleocr when the chosen backend errors — auto-fallback is limited to the default tesseract backend; users who want multi-backend fallback configure it via `OcrConfig.pipeline` (unchanged).
 - **EasyOCR on PDFs**: `EasyOCRBackend.supports_document_processing()` returns `False` so Rust's `PdfRenderer` handles page rendering, removing the implicit `pdf2image`/`pymupdf` requirement that was never declared in the `[easyocr]` extra.

--- a/crates/kreuzberg/src/pdf/structure/adapters.rs
+++ b/crates/kreuzberg/src/pdf/structure/adapters.rs
@@ -19,11 +19,27 @@ pub(super) fn from_structure_tree(blocks: &[ExtractedBlock]) -> PageContent {
 }
 
 /// Recursively flatten `ExtractedBlock` hierarchy into `ContentElement`s.
+///
+/// A block is the author's logical unit (paragraph, list-item, table-cell).
+/// Either the block's own `text` OR its nested children can be non-empty — and
+/// in tagged PDFs both occur frequently: a `Paragraph`/`LBody` whose child span
+/// carries the bold lead-in while the continuation text lives on the parent.
+///
+/// For each block we emit:
+///   1. Its children's contents (recursive flatten), then
+///   2. Its own `text` as a separate element, if non-empty.
+///
+/// Emitting children first matches the reading order observed in tagged PDFs
+/// from word processors / presentation tools (Google Docs/Slides, Word), where
+/// nested child spans visually precede the parent's continuation MCIDs (e.g.
+/// a `Lbl`/`LBody` list structure or a `Paragraph` whose bold lead-in is a
+/// child span). Without this step, the parent's own text is silently dropped
+/// whenever it has children, truncating paragraph bodies and breaking list
+/// items across page boundaries.
 fn flatten_blocks(blocks: &[ExtractedBlock], elements: &mut Vec<ContentElement>) {
     for block in blocks {
         if !block.children.is_empty() {
             flatten_blocks(&block.children, elements);
-            continue;
         }
 
         if block.text.trim().is_empty() {
@@ -296,6 +312,29 @@ mod tests {
         let page = from_structure_tree(&blocks);
         assert_eq!(page.elements[0].semantic_role, Some(SemanticRole::ListItem));
         assert_eq!(page.elements[0].list_label, Some("1.".to_string()));
+    }
+
+    /// Regression: a block with both own `text` and nested children
+    /// (e.g. a tagged `LBody` whose bold lead-in is a child `P` while
+    /// the continuation text lives on the parent) must not silently drop
+    /// the parent text during flatten.
+    #[test]
+    fn test_from_structure_tree_preserves_parent_text_with_children() {
+        let blocks = vec![ExtractedBlock {
+            role: ContentRole::Other("LBody".to_string()),
+            text: " — continuation text on parent".to_string(),
+            bounds: None,
+            font_size: Some(12.0),
+            is_bold: false,
+            is_italic: false,
+            is_monospace: false,
+            children: vec![make_block(ContentRole::Paragraph, "Bold lead-in on child")],
+        }];
+        let page = from_structure_tree(&blocks);
+        assert_eq!(page.elements.len(), 2, "both child and parent texts must be emitted");
+        // Child first (reading order), parent own-text after.
+        assert_eq!(page.elements[0].text, "Bold lead-in on child");
+        assert_eq!(page.elements[1].text, " — continuation text on parent");
     }
 
     #[test]

--- a/crates/kreuzberg/src/pdf/structure/content_convert.rs
+++ b/crates/kreuzberg/src/pdf/structure/content_convert.rs
@@ -497,17 +497,22 @@ fn element_to_paragraph(elem: &ContentElement) -> Option<PdfParagraph> {
     let is_monospace = elem.is_monospace || is_code_block;
     let is_page_furniture = false;
 
-    // Detect list items from text content when not tagged.
-    // Use multi-token check to catch patterns like "(1)" or "[iv]" split across words.
-    if !is_list_item {
-        is_list_item = super::paragraphs::is_list_prefix_multi_token(&full_text);
-    }
-
     // Map heading level from semantic role, with word-count guard.
     let heading_level = match elem.semantic_role {
         Some(SemanticRole::Heading { level }) if word_count <= MAX_HEADING_WORD_COUNT => Some(level),
         _ => None,
     };
+
+    // Detect list items from text content when not tagged.
+    // Use multi-token check to catch patterns like "(1)" or "[iv]" split across words.
+    // Gate on `heading_level.is_none()`: a numbered section heading like
+    // "3. Conclusions" is a Heading, not a list item. Without this gate the
+    // element carries BOTH `heading_level=Some(3)` and `is_list_item=true`,
+    // which makes the assembly layer wrap the heading in a `ListStart`/`ListEnd`
+    // pair and produces an ill-formed AST (`List` → `Heading`).
+    if !is_list_item && heading_level.is_none() {
+        is_list_item = super::paragraphs::is_list_prefix_multi_token(&full_text);
+    }
 
     // Extract block_bbox as (left, bottom, right, top) tuple for PdfParagraph.
     let block_bbox = elem.bbox.map(|r| (r.left, r.y_min, r.right, r.y_max));
@@ -826,6 +831,26 @@ mod tests {
         let page = make_page(vec![make_element("• Bullet point", Some(SemanticRole::Paragraph))]);
         let paras = content_to_paragraphs(&page);
         assert!(paras[0].is_list_item);
+    }
+
+    /// Regression: a tagged Heading whose visible text happens to start
+    /// with a numeric prefix (e.g. `"3. Conclusions"`) must not also get
+    /// flagged as a list item. When both flags are set, assembly wraps
+    /// the heading in a `ListStart`/`ListEnd` pair around a `Heading`
+    /// node, which is an invalid CommonMark AST (`List` children may only
+    /// be `Item`/`TaskItem`) and trips comrak's debug validator.
+    #[test]
+    fn test_heading_with_numeric_prefix_not_marked_list_item() {
+        let page = make_page(vec![make_element(
+            "3. Conclusions",
+            Some(SemanticRole::Heading { level: 3 }),
+        )]);
+        let paras = content_to_paragraphs(&page);
+        assert_eq!(paras[0].heading_level, Some(3));
+        assert!(
+            !paras[0].is_list_item,
+            "tagged Heading must not also be flagged is_list_item from text pattern"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #774. Two compounding bugs in the tagged-PDF structure-tree path of markdown rendering. See the issue for before/after numbers and the full symptom list.

## The fix

**`adapters.rs::flatten_blocks`** — recurse into children AND emit parent's own `text`, instead of `continue`ing past it. Children are emitted first, parent text after — this matches the reading order observed for tagged list items (`LBody` child carries the lead-in, parent text carries the continuation). Inline emphasis spans inside a parent paragraph end up emitted in reverse visual order, but all text is preserved. A bbox-aware merge that reconstructs a single paragraph with inline annotations is a possible follow-up.

**`content_convert.rs::element_to_paragraph`** — gate the text-pattern `is_list_item` detection (`is_list_prefix_multi_token`) on `heading_level.is_none()`. An element explicitly tagged `Heading` by the author beats a text-pattern heuristic.

+28 / −7 behavior change across 2 files.

## Scope

Grepped every recursive block walker in the codebase for the same "recurse on children, skip parent" shape:

- `html.rs::walk_nodes` — pushes `ListItem` text before recursing; safe.
- `docx.rs` / `pptx.rs` / `email.rs` / `pst.rs` embedded-children handling — unrelated attachment logic, not text flattening.
- `bridge.rs::filter_blocks_recursive` — preserves parent structure when filtering sidebar blocks; doesn't drop text.

Only `adapters.rs::flatten_blocks` has this bug.

## Testing

Two synthetic unit tests — no binary fixture, no external-tool dependency:

- `adapters.rs::tests::test_from_structure_tree_preserves_parent_text_with_children` — constructs `LBody(text + child P)` and asserts both texts are emitted.
- `content_convert.rs::tests::test_heading_with_numeric_prefix_not_marked_list_item` — asserts a `Heading { level: 3 }` with text `"3. Conclusions"` keeps `is_list_item=false`.

Verified fail-before (both panic / assert-fail with the production fix temporarily reverted) and pass-after.

```
cargo test -p kreuzberg --lib --features pdf
# → 1569 passed (1567 existing + 2 new), 0 failed

cargo test -p kreuzberg --features pdf \
    --test pdf_output_quality \
    --test pdf_hierarchy_quality \
    --test pdf_table_ground_truth \
    --test markdown_lint_quality \
    --test issue_359_list_whitespace_test
# → 20 passed, 1 ignored (pre-existing), 0 failed
```

Release-mode `pdf_markdown_regression` (F1-score quality gate on 23 PDFs) is also running — result will be posted as a comment once it completes.