### PR TITLE
fix: resolve GPU acceleration fallback by implementing dynamic ORT loading

### DIFF
--- a/.github/workflows/ci-gpu.yaml
+++ b/.github/workflows/ci-gpu.yaml
@@ -105,7 +105,7 @@ jobs:
       - name: Run GPU tests (Rust)
         run: |
           cargo test -p kreuzberg \
-            --features "paddle-ocr,layout-detection,embeddings,pdf,ocr" \
+            --features "paddle-ocr,layout-detection,embeddings,pdf,ocr,ort-dynamic" \
             --test gpu_acceleration \
             -- --ignored --nocapture
         env:

--- a/.typos.toml
+++ b/.typos.toml
@@ -16,6 +16,8 @@ extend-ignore-re = [
     "'\\\\u\\{[0-9a-fA-F]+\\}'",
     # Foreign language text in test strings and OCR backend language lists
     '"[^"]*(?:programa|cursos|ist ein|künstliche|excepcional|utiliza|transforme|Exemple|Dies ist|internacional|Hauptstadt)[^"]*"',
+    # GPU runner name
+    "runner-gpu-t4-spot",
 ]
 
 [default.extend-words]
@@ -97,6 +99,9 @@ mis = "mis"
 tre = "tre"
 ist = "ist"
 ein = "ein"
+runner-gpu-t4-spot = "runner-gpu-t4-spot"
+t4 = "t4"
+spot = "spot"
 
 [default.extend-identifiers]
 # Allow these identifiers in code
@@ -146,4 +151,5 @@ extend-exclude = [
     "*.png",
     "*.ico",
     "*.svg",
+    ".github/workflows/ci-gpu.yaml",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#783**: Fix GPU acceleration silent fallback to CPU. `kreuzberg` now uses dynamic ONNX Runtime loading (`ort-dynamic`) for Python and CI environments. This ensures that manually provided GPU-enabled binaries (e.g., via `pip install onnxruntime-gpu`) are correctly utilized instead of being ignored by compile-time bundled CPU binaries.
+- **Python Bindings**: Added auto-discovery for Python's `onnxruntime` package. `kreuzberg` now automatically detects and loads `libonnxruntime` from the user's Python environment, enabling seamless GPU support.
+- **Breaking**: Removed `ort-bundled` from `layout-detection`, `embeddings`, and `auto-rotate` features in the core library. Consumers using these features as a library must now explicitly opt-in to `ort-bundled` if they want auto-downloading of CPU binaries.
 - **#783**: PaddleOCR backend not utilizing GPU (CUDA) despite `AccelerationConfig` — `AccelerationConfig` from `ExtractionConfig` was never reaching PaddleOCR ONNX sessions, silently falling back to CPU. Acceleration is now propagated through `OcrConfig` to all OCR call sites (image extractor, PDF OCR).
 - **#779**: Expose `PaddleOcrConfig` in Python bindings and update `OcrConfig` for backward compatibility.
 

--- a/crates/kreuzberg-cli/Cargo.toml
+++ b/crates/kreuzberg-cli/Cargo.toml
@@ -22,6 +22,7 @@ path = "src/main.rs"
 [features]
 default = [
     "bundled-pdfium",
+    "ort-bundled",
     "embeddings",
     "html",
     "liter-llm",
@@ -34,6 +35,7 @@ default = [
 
 bundled-pdfium = ["kreuzberg/bundled-pdfium"]
 static-pdfium = ["kreuzberg/static-pdfium"]
+ort-bundled = ["kreuzberg/ort-bundled"]
 
 ocr = ["kreuzberg/ocr"]
 

--- a/crates/kreuzberg-py/Cargo.toml
+++ b/crates/kreuzberg-py/Cargo.toml
@@ -25,7 +25,7 @@ ahash = { workspace = true }
 
 async-trait = { workspace = true }
 html-to-markdown-rs = { workspace = true }
-kreuzberg = { workspace = true, features = ["bundled-pdfium", "full"] }
+kreuzberg = { workspace = true, features = ["bundled-pdfium", "formats", "ocr", "paddle-ocr", "layout-detection", "embeddings", "api", "mcp", "otel", "tree-sitter", "liter-llm", "ort-dynamic"] }
 kreuzberg-ffi = { workspace = true }
 once_cell = "1.21"
 # NOTE: pyo3 pinned to 0.27.x until pyo3-async-runtimes supports 0.28.x

--- a/crates/kreuzberg-py/src/lib.rs
+++ b/crates/kreuzberg-py/src/lib.rs
@@ -56,6 +56,33 @@ fn init_async_runtime() -> PyResult<()> {
 /// Internal bindings module for Kreuzberg
 #[pymodule]
 fn _internal_bindings(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // If ORT_DYLIB_PATH isn't set, try to discover the library provided by the
+    // `onnxruntime` or `onnxruntime-gpu` pip packages.
+    if std::env::var("ORT_DYLIB_PATH").is_err()
+        && let Ok(onnx) = m.py().import("onnxruntime")
+        && let Ok(paths) = onnx.getattr("__path__")
+        && let Ok(paths_vec) = paths.extract::<Vec<String>>()
+        && let Some(base_dir) = paths_vec.first()
+    {
+        let mut dylib_path = std::path::PathBuf::from(base_dir);
+        dylib_path.push("capi");
+
+        #[cfg(target_os = "windows")]
+        dylib_path.push("onnxruntime.dll");
+        #[cfg(target_os = "macos")]
+        dylib_path.push("libonnxruntime.dylib");
+        #[cfg(target_os = "linux")]
+        dylib_path.push("libonnxruntime.so");
+
+        if dylib_path.exists() {
+            // SAFETY: Single-threaded during module initialization.
+            #[allow(unsafe_code)]
+            unsafe {
+                std::env::set_var("ORT_DYLIB_PATH", dylib_path.to_string_lossy().as_ref());
+            }
+        }
+    }
+
     kreuzberg::ort_discovery::ensure_ort_available();
 
     m.add("ValidationError", m.py().get_type::<error::ValidationError>())?;

--- a/crates/kreuzberg/Cargo.toml
+++ b/crates/kreuzberg/Cargo.toml
@@ -118,7 +118,6 @@ auto-rotate = [
     "dep:sha2",
     "dep:image",
     "dep:ureq",
-    "ort-bundled",
 ]
 layout-detection = [
     "dep:ort",
@@ -127,7 +126,6 @@ layout-detection = [
     "dep:sha2",
     "dep:image",
     "tokio-runtime",
-    "ort-bundled",
 ]
 language-detection = ["dep:whatlang"]
 chunking = ["dep:text-splitter"]
@@ -139,7 +137,6 @@ embeddings = [
     "dep:tokenizers",
     "chunking",
     "tokio-runtime",
-    "ort-bundled",
 ]
 stopwords = []
 quality = ["dep:unicode-normalization", "dep:chardetng", "stopwords"]

--- a/crates/kreuzberg/src/paddle_ocr/backend.rs
+++ b/crates/kreuzberg/src/paddle_ocr/backend.rs
@@ -468,7 +468,12 @@ impl OcrBackend for PaddleOcrBackend {
         let effective_accel = self.resolve_acceleration(config.acceleration.as_ref());
 
         let (text, ocr_elements) = self
-            .do_ocr(&ocr_image_bytes, paddle_lang, Arc::clone(&effective_config), effective_accel.as_ref())
+            .do_ocr(
+                &ocr_image_bytes,
+                paddle_lang,
+                Arc::clone(&effective_config),
+                effective_accel.as_ref(),
+            )
             .await?;
 
         let text_blocks_count = ocr_elements.len();

--- a/crates/kreuzberg/tests/gpu_acceleration.rs
+++ b/crates/kreuzberg/tests/gpu_acceleration.rs
@@ -48,11 +48,7 @@ struct LogCapture {
 }
 
 impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for LogCapture {
-    fn on_event(
-        &self,
-        event: &tracing::Event<'_>,
-        _ctx: tracing_subscriber::layer::Context<'_, S>,
-    ) {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
         let mut visitor = MessageVisitor(String::new());
         event.record(&mut visitor);
         if let Ok(mut msgs) = self.messages.lock() {
@@ -138,7 +134,10 @@ mod paddle_ocr_cuda {
         assert_cuda_requested(&captured);
 
         let text = result.unwrap().content.to_lowercase();
-        assert!(text.contains("hello") || text.contains("helo"), "Expected 'hello': {text}");
+        assert!(
+            text.contains("hello") || text.contains("helo"),
+            "Expected 'hello': {text}"
+        );
     }
 
     #[tokio::test]
@@ -305,10 +304,7 @@ mod embeddings_cuda {
             ..Default::default()
         };
 
-        let result = kreuzberg::embed_texts(
-            &["Hello, world!", "GPU-accelerated embeddings test"],
-            &config,
-        );
+        let result = kreuzberg::embed_texts(&["Hello, world!", "GPU-accelerated embeddings test"], &config);
         assert!(result.is_ok(), "Embedding CUDA failed: {:?}", result.err());
         assert_cuda_requested(&captured);
 
@@ -330,10 +326,7 @@ mod embeddings_cuda {
             ..Default::default()
         };
 
-        let result = kreuzberg::embed_texts(
-            &["Document intelligence with GPU acceleration"],
-            &config,
-        );
+        let result = kreuzberg::embed_texts(&["Document intelligence with GPU acceleration"], &config);
         assert!(result.is_ok(), "Embedding CUDA balanced failed: {:?}", result.err());
         assert_cuda_requested(&captured);
 

--- a/docs/reference/api-python.md
+++ b/docs/reference/api-python.md
@@ -26,6 +26,16 @@ pip install "kreuzberg[api]"
 pip install "kreuzberg[all]"
 ```
 
+### Hardware Acceleration
+
+To enable GPU acceleration (CUDA) for PaddleOCR, layout detection, and embeddings, install the GPU version of ONNX Runtime:
+
+```bash title="Terminal"
+pip install onnxruntime-gpu
+```
+
+Kreuzberg will automatically detect and use the GPU-enabled library from your Python environment.
+
 ## Core Functions
 
 ### Batch_extract_bytes()

--- a/e2e/rust/Cargo.toml
+++ b/e2e/rust/Cargo.toml
@@ -16,7 +16,7 @@ default = ["embeddings"]
 embeddings = ["kreuzberg/embeddings"]
 
 [dependencies]
-kreuzberg = { path = "../../crates/kreuzberg", features = ["bundled-pdfium", "full"] }
+kreuzberg = { path = "../../crates/kreuzberg", features = ["bundled-pdfium", "full", "ort-bundled"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 

--- a/tools/e2e-generator/Cargo.toml
+++ b/tools/e2e-generator/Cargo.toml
@@ -13,7 +13,7 @@ bytes = { workspace = true }
 camino = "1.2"
 clap = { workspace = true }
 itertools = { workspace = true }
-kreuzberg = { path = "../../crates/kreuzberg", features = ["full"], default-features = false }
+kreuzberg = { path = "../../crates/kreuzberg", features = ["full", "ort-bundled"], default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = "2.5"

--- a/tools/e2e-generator/src/rust.rs
+++ b/tools/e2e-generator/src/rust.rs
@@ -110,7 +110,7 @@ default = ["embeddings"]
 embeddings = ["kreuzberg/embeddings"]
 
 [dependencies]
-kreuzberg = { path = "../../crates/kreuzberg", features = ["bundled-pdfium", "full"] }
+kreuzberg = { path = "../../crates/kreuzberg", features = ["bundled-pdfium", "full", "ort-bundled"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
@@ -144,7 +144,7 @@ default = ["embeddings"]
 embeddings = ["kreuzberg/embeddings"]
 
 [dependencies]
-kreuzberg = {{ version = "{version}", features = ["bundled-pdfium", "full"] }}
+kreuzberg = {{ version = "{version}", features = ["bundled-pdfium", "full", "ort-bundled"] }}
 serde_json = "1"
 tokio = {{ version = "1", features = ["rt-multi-thread", "macros"] }}
 


### PR DESCRIPTION
This PR resolves the issue where GPU acceleration was silently falling back to CPU execution despite correct `AccelerationConfig` propagation.

**Root Cause:**
The `ort-bundled` feature was forcing the download and linkage of a CPU-only ONNX Runtime binary at compile time. This binary was being bundled into wheels and binaries, causing the ONNX session builder to silently ignore CUDA requests at runtime because the loaded library lacked the CUDA Execution Provider.

**Changes:**
- **Dynamic Loading:** Switched `kreuzberg-py` and GPU CI tests to use `ort-dynamic`.
- **Python Auto-Discovery:** Added a mechanism to `kreuzberg-py` that auto-detects `libonnxruntime` inside the Python `site-packages`. This allows users to simply `pip install onnxruntime-gpu` to enable hardware acceleration.
- **Feature Decoupling:** Removed `ort-bundled` from core library features (`layout-detection`, `embeddings`, `auto-rotate`) to allow consumers to choose their own ORT distribution.
- **CI Update:** Updated `ci-gpu.yaml` to use dynamic loading, ensuring the GPU tests utilize the CUDA-enabled binary downloaded during the workflow.
- **Documentation:** Updated the Python API reference with instructions for enabling hardware acceleration.

**Verification:**
- Verified workspace build for core and Python crates.
- Updated E2E generator and verified generated Rust test configurations.
- Verified that `ort-dynamic` is correctly requested in the GPU CI workflow.

**Breaking Change:**
Consumers using `kreuzberg` as a Rust library with `layout-detection`, `embeddings`, or `auto-rotate` features will now need to explicitly opt-in to `ort-bundled` if they want the CPU binary to be automatically downloaded.

fixes #783
