### PR TITLE
fix(ruby-gem): remove staged libpdfium from lib/ after native extension build

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1383,6 +1383,16 @@ jobs:
           echo "=== Native libraries ==="
           find lib -name '*.so' -o -name '*.bundle' -o -name '*.dylib' 2>/dev/null | head -20
 
+      - name: Remove staged PDFium runtime artifacts
+        shell: bash
+        working-directory: packages/ruby
+        run: |
+          # libpdfium.dylib/.so/.dll was staged into lib/ for the Rust build to embed via
+          # include_bytes!. Now that compilation is done it is baked into kreuzberg_rb.bundle
+          # and the original file in lib/ is redundant. Remove it so it is not packaged into
+          # the gem, saving ~5 MB per install.
+          rm -f lib/libpdfium.dylib lib/libpdfium.so lib/pdfium.dll
+
       - name: Build platform gem
         shell: bash
         working-directory: packages/ruby

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1383,16 +1383,6 @@ jobs:
           echo "=== Native libraries ==="
           find lib -name '*.so' -o -name '*.bundle' -o -name '*.dylib' 2>/dev/null | head -20
 
-      - name: Remove staged PDFium runtime artifacts
-        shell: bash
-        working-directory: packages/ruby
-        run: |
-          # libpdfium.dylib/.so/.dll was staged into lib/ for the Rust build to embed via
-          # include_bytes!. Now that compilation is done it is baked into kreuzberg_rb.bundle
-          # and the original file in lib/ is redundant. Remove it so it is not packaged into
-          # the gem, saving ~5 MB per install.
-          rm -f lib/libpdfium.dylib lib/libpdfium.so lib/pdfium.dll
-
       - name: Build platform gem
         shell: bash
         working-directory: packages/ruby

--- a/packages/ruby/kreuzberg.gemspec
+++ b/packages/ruby/kreuzberg.gemspec
@@ -139,12 +139,7 @@ files = if vendor_files.any?
         end
 
 native_artifacts = Dir.chdir(__dir__) do
-  Dir.glob(%w[
-             lib/**/*.bundle
-             lib/**/*.so
-             lib/**/*.dll
-             lib/**/*.dylib
-           ])
+  Dir.glob('lib/**/kreuzberg_rb.*')
 end
 files.concat(native_artifacts)
 


### PR DESCRIPTION
## Problem

When building the Ruby gem, `libpdfium.dylib` (and `.so`/`.dll` on other platforms) is staged into `packages/ruby/lib/` so the Rust compiler can embed it via `include_bytes!` ([bundled.rs#L160](https://github.com/kreuzberg-dev/kreuzberg/blob/main/crates/kreuzberg/src/pdf/bundled.rs#L160)).

Once `rake compile` finishes, the library is fully baked into `kreuzberg_rb.bundle`. The original file in `lib/` is no longer needed — but the gemspec's `lib/**/*.dylib` glob ([kreuzberg.gemspec#L141-L149](https://github.com/kreuzberg-dev/kreuzberg/blob/main/packages/ruby/kreuzberg.gemspec#L141-L149)) picks it up and ships it in every gem install as ~5 MB of dead weight.

This can be verified locally:

```bash
mv $(gem contents kreuzberg | grep libpdfium) /tmp/
ruby -e "require 'kreuzberg'; puts Kreuzberg.extract_bytes_sync(data: File.binread('some.pdf'), mime_type: 'application/pdf').class"
# => Kreuzberg::Result  (works fine without it)
```

## Fix

Include only the bundle file in `gemspec`

## Impact

~5 MB saved per gem install (per platform).