### PR TITLE
fix(cli): bail manifest_command when no model-providing feature is enabled

### DIFF
--- a/crates/kreuzberg-cli/src/commands/cache.rs
+++ b/crates/kreuzberg-cli/src/commands/cache.rs
@@ -134,6 +134,29 @@ pub fn clear_command(cache_dir: Option<PathBuf>, format: WireFormat) -> Result<(
 
 /// Execute cache manifest command - outputs expected model files with checksums.
 pub fn manifest_command(format: WireFormat) -> Result<()> {
+    // Without at least one model-providing feature, every `extend` call
+    // below is `#[cfg]`-stripped and `entries: Vec<_>` has no anchor for
+    // type inference — `e.size_bytes` on the closure further down then
+    // fails compilation with E0282. Bail with a clear error instead so
+    // the build with `--no-default-features --features "bundled-pdfium"`
+    // (or similar minimal configurations) succeeds.
+    #[cfg(not(any(feature = "paddle-ocr", feature = "layout-detection")))]
+    {
+        let _ = format;
+        anyhow::bail!(
+            "manifest command unavailable: build kreuzberg-cli with at least one of \
+             --features \"paddle-ocr\" or --features \"layout-detection\""
+        );
+    }
+
+    #[cfg(any(feature = "paddle-ocr", feature = "layout-detection"))]
+    {
+        manifest_command_inner(format)
+    }
+}
+
+#[cfg(any(feature = "paddle-ocr", feature = "layout-detection"))]
+fn manifest_command_inner(format: WireFormat) -> Result<()> {
     let mut entries = Vec::new();
 
     #[cfg(feature = "paddle-ocr")]


### PR DESCRIPTION
## Problem

`manifest_command` in `crates/kreuzberg-cli/src/commands/cache.rs` declares `let mut entries = Vec::new();` and only populates it inside `#[cfg(feature = "paddle-ocr")]` / `#[cfg(feature = "layout-detection")]` blocks. When kreuzberg-cli is built without either of those features (e.g. a minimal `--no-default-features --features "bundled-pdfium"` build for a small embedded image), all three `entries.extend(...)` calls are stripped at compile time. `entries: Vec<_>` then has no anchor for type inference, and the closure on the very next line fails to compile:

```
error[E0282]: type annotations needed for `&_`
   --> crates/kreuzberg-cli/src/commands/cache.rs:154:53
    |
154 |     let total_size_bytes: u64 = entries.iter().map(|e| e.size_bytes).sum();
    |                                                     ^  ------------ type must be known at this point

error: could not compile `kreuzberg-cli` (bin "kreuzberg") due to 1 previous error
error: failed to compile `kreuzberg-cli v4.8.5 ...`
```

This is invisible to anyone using the default feature set (which enables both `paddle-ocr` and `layout-detection`), but every `cargo install` invocation that picks a minimal feature combination — for example, when downstream callers only need `bundled-pdfium` for a small Docker image — fails deterministically after several minutes of compilation.

The same line is identical in v4.8.5, v4.8.6, and v4.9.5; this is a long-standing latent issue.

## Fix

Split the body into a feature-gated `manifest_command_inner` so the type-inference site only exists in compilations where at least one `extend` call survives the cfg pass. The outer wrapper bails with a clear, actionable error message when no model-providing feature is enabled, so end users learn how to configure the build instead of being confronted with a 30-line rustc message.

```rust
pub fn manifest_command(format: WireFormat) -> Result<()> {
    #[cfg(not(any(feature = "paddle-ocr", feature = "layout-detection")))]
    {
        let _ = format;
        anyhow::bail!(
            "manifest command unavailable: build kreuzberg-cli with at least one of \
             --features \"paddle-ocr\" or --features \"layout-detection\""
        );
    }

    #[cfg(any(feature = "paddle-ocr", feature = "layout-detection"))]
    {
        manifest_command_inner(format)
    }
}

#[cfg(any(feature = "paddle-ocr", feature = "layout-detection"))]
fn manifest_command_inner(format: WireFormat) -> Result<()> {
    /* original function body, unchanged */
}
```

The original function body is moved verbatim into `manifest_command_inner`. No semantic change for any feature combination that previously compiled; previously-broken combinations now compile and surface a runtime error if the user tries to invoke the manifest command.

## Test plan

- [ ] `cargo build -p kreuzberg-cli --no-default-features --features "bundled-pdfium"` — was failing with E0282, should now build clean.
- [ ] `cargo build -p kreuzberg-cli --no-default-features --features "bundled-pdfium,layout-detection"` — was already clean, should remain clean.
- [ ] `cargo build -p kreuzberg-cli` (default features) — was already clean, should remain clean.
- [ ] `kreuzberg cache manifest` invocation in a build with neither feature on — should print the bail message and exit non-zero, instead of panicking or silently misbehaving.

## Alternative considered

Annotating `entries` with the `Vec<ModelManifestEntry>` element type would be a one-line fix, but `ModelManifestEntry` itself lives inside the feature-gated `paddle_ocr` and `layout` modules. Without the features enabled, that type doesn't exist in the compiled output, so it can't be referenced at the declaration site. The early-return approach avoids this dependency entirely.