### PR TITLE
fix(docs): repair empty TOC anchors and dedupe repo facts list

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
     paths:
+      - 'CHANGELOG.md'
       - 'docs/**'
       - 'pyproject.toml'
       - 'zensical.toml'
@@ -16,6 +17,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'CHANGELOG.md'
       - 'docs/**'
       - 'pyproject.toml'
       - 'zensical.toml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,54 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [4.9.2] - 2026-04-19
-
-### Fixed
-
-- Fix cancellation token not checked in WASM (non-tokio) path for Excel, DOC, PPT, Pages, Keynote, and Numbers extractors — cancellation was silently ignored in WASM builds
-- Propagate `Cancelled` error code (9) to all bindings — Go, C FFI, Python, TypeScript, and C API docs now include the new code
-- Fix PHP e2e embed tests calling instance methods statically — use procedural `\Kreuzberg\embed()` functions
-- Fix TypeScript e2e embed tests using wrong field names (`type`/`name` → `modelType`/`value`) for embedding model config
-- Fix Elixir e2e embed tests calling non-existent `embed_async/2` — use sync `embed/2`
-- Fix TypeScript e2e generator missing `html_output` config mapping for styled HTML tests
-- Fix `ORT_DYLIB_PATH` on Windows CI pointing to `lib/` instead of the actual DLL location
-- Fix C# CI build conditional to require successful FFI build
-- Add `libuv1-dev` to Linux CI system dependencies for R package builds
-
----
-
-## [4.9.1] - 2026-04-19
-
-### Fixed
-
-- **#754**: Preserve `_internal_bindings.pyi` type stub during wheel artifact cleanup — published wheels now include inline type information for the core binding module
-- Add missing `Default` impl for `PyCancellationToken` to satisfy clippy `new_without_default` lint
-- Improve download resilience for `eng.traineddata` in build script — increase retries from 3 to 5, add fallback URL via `raw.githubusercontent.com`, and increase timeout to 300s
-- Increase Task installer retry resilience in CI — 5 attempts with `--retry-all-errors` curl flag
-
----
-
-## [4.9.0] - 2026-04-18
-
-### Fixed
-
-- **#588**: Suppress C23 glibc symbols (`__isoc23_strtoll` etc.) in manylinux wheels — added CMake flag propagation and CI verification step to prevent incompatible symbols on glibc < 2.38 (Debian 12, Ubuntu 22.04)
-- **#748**: Remove `kreuzberg-cli` from Python wheel to fix `libonnxruntime.so.1` loading failure — CLI is available as standalone release
-- **#749**: Add cancellation token support — cancelled extractions no longer block subsequent calls via `PDFIUM_OPERATION_LOCK`; wired across Python, Node.js, Ruby, WASM, and C FFI bindings
-- **#750**: Fix `kreuzberg[easyocr]` extra silently installing nothing on Python 3.14+; clean up stale `[paddleocr]` references in docs
-- **#752**: Fix ~1000x slowdown on Ghostscript-produced PDFs with structured output — replace O(N²) `Vec::contains` with O(1) `AHashSet` lookup, add minimum dimension filter for tiny inline images
-- **#753**: Fix `llm_usage` returning `None` when using VLM-based OCR — propagate usage through PDF OCR, image OCR, and `force_ocr_pages` paths
-
-### Added
-
-- Cancellation token API available in all language bindings (`CancellationToken` in Python/Node/Ruby/WASM/FFI)
-
-### Changed
-
-- **Breaking**: `kreuzberg-cli` binary is no longer bundled in the Python wheel — install the standalone CLI from GitHub releases
-
----
-
 ## [4.9.4] - 2026-04-22
 
 ### Fixed
@@ -134,6 +86,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Removed redundant `.task/workflows/e2e.yml` — e2e tasks consolidated in top-level `Taskfile.yml`.
+
+---
+
+## [4.9.2] - 2026-04-19
+
+### Fixed
+
+- Fix cancellation token not checked in WASM (non-tokio) path for Excel, DOC, PPT, Pages, Keynote, and Numbers extractors — cancellation was silently ignored in WASM builds
+- Propagate `Cancelled` error code (9) to all bindings — Go, C FFI, Python, TypeScript, and C API docs now include the new code
+- Fix PHP e2e embed tests calling instance methods statically — use procedural `\Kreuzberg\embed()` functions
+- Fix TypeScript e2e embed tests using wrong field names (`type`/`name` → `modelType`/`value`) for embedding model config
+- Fix Elixir e2e embed tests calling non-existent `embed_async/2` — use sync `embed/2`
+- Fix TypeScript e2e generator missing `html_output` config mapping for styled HTML tests
+- Fix `ORT_DYLIB_PATH` on Windows CI pointing to `lib/` instead of the actual DLL location
+- Fix C# CI build conditional to require successful FFI build
+- Add `libuv1-dev` to Linux CI system dependencies for R package builds
+
+---
+
+## [4.9.1] - 2026-04-19
+
+### Fixed
+
+- **#754**: Preserve `_internal_bindings.pyi` type stub during wheel artifact cleanup — published wheels now include inline type information for the core binding module
+- Add missing `Default` impl for `PyCancellationToken` to satisfy clippy `new_without_default` lint
+- Improve download resilience for `eng.traineddata` in build script — increase retries from 3 to 5, add fallback URL via `raw.githubusercontent.com`, and increase timeout to 300s
+- Increase Task installer retry resilience in CI — 5 attempts with `--retry-all-errors` curl flag
+
+---
+
+## [4.9.0] - 2026-04-18
+
+### Fixed
+
+- **#588**: Suppress C23 glibc symbols (`__isoc23_strtoll` etc.) in manylinux wheels — added CMake flag propagation and CI verification step to prevent incompatible symbols on glibc < 2.38 (Debian 12, Ubuntu 22.04)
+- **#748**: Remove `kreuzberg-cli` from Python wheel to fix `libonnxruntime.so.1` loading failure — CLI is available as standalone release
+- **#749**: Add cancellation token support — cancelled extractions no longer block subsequent calls via `PDFIUM_OPERATION_LOCK`; wired across Python, Node.js, Ruby, WASM, and C FFI bindings
+- **#750**: Fix `kreuzberg[easyocr]` extra silently installing nothing on Python 3.14+; clean up stale `[paddleocr]` references in docs
+- **#752**: Fix ~1000x slowdown on Ghostscript-produced PDFs with structured output — replace O(N²) `Vec::contains` with O(1) `AHashSet` lookup, add minimum dimension filter for tiny inline images
+- **#753**: Fix `llm_usage` returning `None` when using VLM-based OCR — propagate usage through PDF OCR, image OCR, and `force_ocr_pages` paths
+
+### Added
+
+- Cancellation token API available in all language bindings (`CancellationToken` in Python/Node/Ruby/WASM/FFI)
+
+### Changed
+
+- **Breaking**: `kreuzberg-cli` binary is no longer bundled in the Python wheel — install the standalone CLI from GitHub releases
 
 ---
 
@@ -3190,6 +3190,13 @@ See the [API Reference](https://docs.kreuzberg.dev/reference/api-python/) for de
 - [Format Support](https://docs.kreuzberg.dev/reference/formats/) - Supported file formats
 - [Extraction Guide](https://docs.kreuzberg.dev/guides/extraction/) - Extraction examples
 
+[4.9.5]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.5
+[4.9.4]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.4
+[4.9.3]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.3
+[4.9.2]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.2
+[4.9.1]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.1
+[4.9.0]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.0
+[4.8.6]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.6
 [4.8.5]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.5
 [4.8.4]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.4
 [4.8.3]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.8.3

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -1129,8 +1129,8 @@ strong {
 }
 
 [data-md-color-scheme="slate"] .md-nav__link:not(.md-nav__link--active):hover {
-	background: rgba(88, 251, 218, 0.08);
-	color: #58fbda;
+	background: rgba(88, 251, 218, 0.08) !important;
+	color: #58fbda !important;
 }
 
 .md-nav--lifted > .md-nav__list > .md-nav__item--active {

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -15,6 +15,7 @@ Kreuzberg integrates with AI frameworks, databases, and search engines — bring
 | CrewAI | [CrewAI](https://www.crewai.com/) | [`kreuzberg-crewai`](https://pypi.org/project/kreuzberg-crewai/) | [GitHub](https://github.com/kreuzberg-dev/kreuzberg-crewai) |
 | txtAI | [txtAI](https://neuml.github.io/txtai/) | [`kreuzberg-txtai`](https://pypi.org/project/kreuzberg-txtai/) | [GitHub](https://github.com/kreuzberg-dev/kreuzberg-txtai) |
 | SurrealDB | [SurrealDB](https://surrealdb.com/) | [`kreuzberg-surrealdb`](https://pypi.org/project/kreuzberg-surrealdb/) | [SurrealDB](surrealdb.md) |
+| Spring AI | [Spring AI](https://spring.io/projects/spring-ai) | [`kreuzberg-spring-ai-document-reader`](https://central.sonatype.com/artifact/dev.kreuzberg/kreuzberg-spring-ai-document-reader) | [GitHub](https://github.com/kreuzberg-dev/kreuzberg-spring-ai) |
 
 !!! Tip "Building a new integration?"
     Explore existing integrations on [GitHub](https://github.com/kreuzberg-dev) for reference.

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,49 @@
 {% extends "base.html" %}
 
+{% block scripts %}
+  {{ super() }}
+  <script>
+    // Changelog headings use [ver] link-reference syntax, which renders a nested <a> inside
+    // the outer .md-nav__link anchor. Browsers break nested anchors apart (HTML5 adoption
+    // agency algorithm), leaving the TOC anchor empty and the version text as orphaned nodes.
+    // This repairs those empty anchors by reading the text from the sibling nav's aria-label.
+    document$.subscribe(function () {
+      document.querySelectorAll("li.md-nav__item").forEach(function (item) {
+        var link = item.querySelector(":scope > a.md-nav__link");
+        var subNav = item.querySelector(":scope > nav.md-nav[aria-label]");
+        var label = subNav && subNav.getAttribute("aria-label");
+        if (link && label && !link.textContent.trim()) {
+          link.textContent = label;
+          var toRemove = [];
+          for (var node = link.nextSibling; node && node !== subNav; node = node.nextSibling) {
+            toRemove.push(node);
+          }
+          toRemove.forEach(function (n) { n.parentNode && n.parentNode.removeChild(n); });
+        }
+      });
+
+      // Workaround: zensical's repo source observable re-emits on each instant
+      // navigation, appending another <ul class="md-source__facts"> without
+      // removing the previous one. Keep only the most recent list. The GitHub
+      // stars fetch is async, so an immediate sweep isn't enough — also attach
+      // a MutationObserver so late appends get collapsed too.
+      document.querySelectorAll(".md-source__repository").forEach(function (repo) {
+        var dedupe = function () {
+          var lists = repo.querySelectorAll(":scope > ul.md-source__facts");
+          for (var i = 0; i < lists.length - 1; i++) {
+            lists[i].remove();
+          }
+        };
+        dedupe();
+        if (!repo.__factsObserver) {
+          repo.__factsObserver = new MutationObserver(dedupe);
+          repo.__factsObserver.observe(repo, { childList: true });
+        }
+      });
+    });
+  </script>
+{% endblock %}
+
 {% block extrahead %}
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-8G4NQW55PF"></script>
   <script>


### PR DESCRIPTION
Changelog `[ver]` link-reference syntax produced nested anchors the HTML5 parser split, leaving sidebar TOC entries blank; a small script in `docs/overrides/main.html` restores the text from the sibling nav's `aria-label`. The same script collapses zensical's duplicated `md-source__facts` lists that piled up on instant navigation.

Also reorders the 4.9.x CHANGELOG entries, appends missing version link references, lists the new Spring AI integration, and adds `CHANGELOG.md` to the docs CI trigger paths.