### PR TITLE
fix(pdf): prevent image data leak when extraction is disabled in structured output

### DIFF
--- a/crates/kreuzberg-ffi/README.md
+++ b/crates/kreuzberg-ffi/README.md
@@ -73,6 +73,10 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
+
+
 ### System Requirements
 
 - See [Installation Guide](https://kreuzberg.dev/getting-started/installation/) for requirements
@@ -93,13 +97,20 @@ Extract text, metadata, and structure from any supported document format:
 Most use cases benefit from configuration to control extraction behavior:
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
 
 
+
 #### Processing Multiple Files
+
+
+
+
+
 
 
 ### Next Steps
@@ -108,6 +119,7 @@ See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) f
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -209,14 +221,18 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
 
 
+
 ### OCR Configuration Example
 
 <!-- snippet not found:  -->
+
+
 
 
 ## Async Support
@@ -226,6 +242,8 @@ This binding provides full async/await support for non-blocking document process
 <!-- snippet not found:  -->
 
 
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
@@ -233,11 +251,16 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Configuration

--- a/crates/kreuzberg-node/README.md
+++ b/crates/kreuzberg-node/README.md
@@ -76,10 +76,13 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 Install via one of the supported package managers:
 
 
+
 **npm:**
 ```bash
 npm install @kreuzberg/node
 ```
+
+
 
 
 **pnpm:**
@@ -88,10 +91,15 @@ pnpm add @kreuzberg/node
 ```
 
 
+
+
 **yarn:**
 ```bash
 yarn add @kreuzberg/node
 ```
+
+
+
 
 
 ### System Requirements
@@ -106,6 +114,7 @@ Pre-built binaries available for:
 - macOS (arm64, x64)
 - Linux (x64)
 - Windows (x64)
+
 
 
 ## Quick Start
@@ -155,6 +164,7 @@ console.log(result.content);
 ```
 
 
+
 #### Table Extraction
 
 
@@ -169,6 +179,7 @@ for (const table of result.tables) {
 	console.log(table.markdown);
 }
 ```
+
 
 
 #### Processing Multiple Files
@@ -186,6 +197,8 @@ results.forEach((result, i) => {
 ```
 
 
+
+
 #### Async Processing
 
 For non-blocking document processing:
@@ -196,6 +209,8 @@ import { extractFile } from '@kreuzberg/node';
 const result = await extractFile('document.pdf');
 console.log(result.content);
 ```
+
+
 
 
 #### Configuration Discovery
@@ -214,6 +229,8 @@ if (config) {
   console.log(result.content);
 }
 ```
+
+
 
 
 #### Worker Thread Pool
@@ -259,6 +276,7 @@ try {
 - Reuse pools across multiple batch operations for efficiency
 
 
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
@@ -291,6 +309,7 @@ This binding uses NAPI-RS to provide native Node.js bindings with:
 - Temporary files are created in system temp directory for extraction
 - Memory is automatically released after extraction completion
 - ONNX models are cached in memory for repeated embeddings operations
+
 
 
 ## Features
@@ -392,9 +411,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -423,6 +444,8 @@ console.log(result.content);
 ```
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
@@ -435,6 +458,8 @@ console.log(result.content);
 ```
 
 
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
@@ -442,11 +467,16 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Batch Processing
@@ -463,6 +493,7 @@ results.forEach((result, i) => {
 	console.log(`File ${i + 1}: ${result.content.length} characters`);
 });
 ```
+
 
 
 ## Configuration

--- a/crates/kreuzberg-wasm/README.md
+++ b/crates/kreuzberg-wasm/README.md
@@ -76,10 +76,13 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 Install via one of the supported package managers:
 
 
+
 **npm:**
 ```bash
 npm install @kreuzberg/wasm
 ```
+
+
 
 
 **pnpm:**
@@ -88,10 +91,15 @@ pnpm add @kreuzberg/wasm
 ```
 
 
+
+
 **yarn:**
 ```bash
 yarn add @kreuzberg/wasm
 ```
+
+
+
 
 
 ### System Requirements
@@ -166,10 +174,12 @@ extractWithOcr().catch(console.error);
 ```
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
+
 
 
 #### Processing Multiple Files
@@ -212,6 +222,8 @@ async function _processBatch(documents: DocumentJob[], concurrency: number = 3) 
 ```
 
 
+
+
 #### Async Processing
 
 For non-blocking document processing:
@@ -244,12 +256,16 @@ extractDocuments(fileBytes, mimes)
 ```
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -349,9 +365,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract-Wasm**
@@ -390,6 +408,8 @@ extractWithOcr().catch(console.error);
 ```
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
@@ -422,11 +442,18 @@ extractDocuments(fileBytes, mimes)
 ```
 
 
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
 
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
+
+
+
+
+
 
 
 ## Batch Processing
@@ -468,6 +495,7 @@ async function _processBatch(documents: DocumentJob[], concurrency: number = 3) 
 	return results;
 }
 ```
+
 
 
 ## Configuration

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -121,7 +121,15 @@ pub(crate) fn extract_all_from_document(
             .map(|cf| (cf.strip_repeating_text, cf.include_headers, cf.include_footers))
             .unwrap_or((true, false, false)); // defaults match current behavior
 
-        let inject_placeholders = config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(true);
+        // Image extraction must be explicitly enabled before we inject placeholders.
+        // Checking both config paths so that either flag (`images.extract_images` or
+        // `pdf_options.extract_images`) correctly suppresses image rendering in the
+        // structure pipeline. When disabled, `populate_images_from_pdfium` is skipped
+        // entirely, preventing base64 image data from leaking into the result.
+        let images_extraction_enabled = config.images.as_ref().map(|c| c.extract_images).unwrap_or(false)
+            || config.pdf_options.as_ref().map(|p| p.extract_images).unwrap_or(false);
+        let inject_placeholders =
+            images_extraction_enabled && config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(true);
 
         tracing::debug!(
             k_clusters = k,
@@ -510,7 +518,13 @@ pub(crate) fn extract_all_from_oxide_document(
                 "oxide structure: extracted segments for heading detection"
             );
 
-            let inject_placeholders = config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(true);
+            // Same gate as the pdfium path: only inject placeholders when image extraction
+            // is explicitly enabled. Prevents base64 data from leaking into results when
+            // the caller sets extract_images=false (fixes #796).
+            let images_extraction_enabled = config.images.as_ref().map(|c| c.extract_images).unwrap_or(false)
+                || config.pdf_options.as_ref().map(|p| p.extract_images).unwrap_or(false);
+            let inject_placeholders =
+                images_extraction_enabled && config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(true);
 
             match crate::pdf::structure::extract_document_structure_from_segments(
                 segments,

--- a/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
+++ b/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
@@ -153,3 +153,132 @@ fn test_ghostscript_inline_images_completes_in_reasonable_time() {
     // The file has no text — content may be empty or minimal; that is expected.
     let _ = result;
 }
+
+// ─── Regression tests for issue #796 ────────────────────────────────────────
+//
+// Before the fix, setting `images.extract_images = false` (or
+// `pdf_options.extract_images = false`) still caused full base64 image data to
+// appear in `ExtractionResult.images` when `output_format` was `Markdown` or
+// `Djot`. The root cause was that `inject_placeholders` in `extraction.rs`
+// defaulted to `true` without checking `extract_images`, allowing the structure
+// pipeline to call `populate_images_from_pdfium` unconditionally.
+
+/// Helper: extract with a specific output format and images explicitly disabled
+/// via `ImageExtractionConfig.extract_images = false`.
+fn extract_no_images(relative_path: &str, fmt: OutputFormat) -> kreuzberg::types::ExtractionResult {
+    use kreuzberg::core::config::ImageExtractionConfig;
+    let path = test_documents_dir().join(relative_path);
+    let config = ExtractionConfig {
+        output_format: fmt,
+        images: Some(ImageExtractionConfig {
+            extract_images: false,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(kreuzberg::core::extractor::extract_file(&path, None, &config))
+        .unwrap()
+}
+
+/// Helper: extract with a specific output format and images disabled via
+/// `PdfConfig.extract_images = false`.
+fn extract_no_images_via_pdf_options(relative_path: &str, fmt: OutputFormat) -> kreuzberg::types::ExtractionResult {
+    use kreuzberg::core::config::pdf::PdfConfig;
+    let path = test_documents_dir().join(relative_path);
+    let config = ExtractionConfig {
+        output_format: fmt,
+        pdf_options: Some(PdfConfig {
+            extract_images: false,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(kreuzberg::core::extractor::extract_file(&path, None, &config))
+        .unwrap()
+}
+
+/// Regression #796: images must be absent when extract_images=false, output_format=Markdown.
+///
+/// Uses `embedded_images_tables.pdf` — a known-image PDF. Before the fix, this
+/// returned `ExtractionResult.images` with full base64 data despite the flag.
+#[test]
+fn test_regression_796_markdown_no_images_when_disabled_via_images_config() {
+    let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Markdown);
+    assert!(
+        result.images.as_ref().map(|v| v.is_empty()).unwrap_or(true),
+        "images.extract_images=false must produce an empty images list even for \
+         output_format=Markdown. Got {} image(s).",
+        result.images.as_ref().map(|v| v.len()).unwrap_or(0)
+    );
+    // Confirm the text content was still extracted (no regression on content).
+    assert!(
+        !result.content.is_empty(),
+        "Content must still be extracted when images are disabled"
+    );
+}
+
+/// Regression #796: same assertion for Djot output format.
+#[test]
+fn test_regression_796_djot_no_images_when_disabled_via_images_config() {
+    let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Djot);
+    assert!(
+        result.images.as_ref().map(|v| v.is_empty()).unwrap_or(true),
+        "images.extract_images=false must produce an empty images list even for \
+         output_format=Djot. Got {} image(s).",
+        result.images.as_ref().map(|v| v.len()).unwrap_or(0)
+    );
+}
+
+/// Regression #796: the pdf_options.extract_images path must also be respected
+/// when output_format=Markdown.
+#[test]
+fn test_regression_796_markdown_no_images_when_disabled_via_pdf_options() {
+    let result = extract_no_images_via_pdf_options("pdf/embedded_images_tables.pdf", OutputFormat::Markdown);
+    assert!(
+        result.images.as_ref().map(|v| v.is_empty()).unwrap_or(true),
+        "pdf_options.extract_images=false must produce an empty images list even for \
+         output_format=Markdown. Got {} image(s).",
+        result.images.as_ref().map(|v| v.len()).unwrap_or(0)
+    );
+}
+
+/// Sanity check: images must still appear when extract_images=true (no regression).
+#[test]
+fn test_regression_796_markdown_images_present_when_enabled() {
+    use kreuzberg::core::config::ImageExtractionConfig;
+    let path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        images: Some(ImageExtractionConfig {
+            extract_images: true,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt
+        .block_on(kreuzberg::core::extractor::extract_file(&path, None, &config))
+        .unwrap();
+    let images = result
+        .images
+        .as_ref()
+        .expect("images must be Some when extract_images=true");
+    assert!(
+        !images.is_empty(),
+        "images list must be non-empty when extract_images=true and the PDF contains images"
+    );
+}
+
+/// Plain-text baseline: images must never appear for plain output (already passing
+/// before the fix; kept as a safety net).
+#[test]
+fn test_regression_796_plain_no_images_when_disabled() {
+    let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Plain);
+    assert!(
+        result.images.as_ref().map(|v| v.is_empty()).unwrap_or(true),
+        "Plain output with extract_images=false must have no images. Got {} image(s).",
+        result.images.as_ref().map(|v| v.len()).unwrap_or(0)
+    );
+}

--- a/packages/csharp/README.md
+++ b/packages/csharp/README.md
@@ -73,6 +73,8 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
 Install via NuGet:
 
 ```bash
@@ -84,6 +86,8 @@ Or via NuGet Package Manager:
 ```
 Install-Package Kreuzberg
 ```
+
+
 
 
 ### System Requirements
@@ -144,10 +148,12 @@ Console.WriteLine(result.Content);
 ```
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
+
 
 
 #### Processing Multiple Files
@@ -203,6 +209,8 @@ class Program
 ```
 
 
+
+
 #### Async Processing
 
 For non-blocking document processing:
@@ -244,12 +252,16 @@ class Program
 ```
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -351,9 +363,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -383,6 +397,8 @@ var config = new ExtractionConfig
 var result = KreuzbergClient.ExtractFileSync("document.pdf", config);
 Console.WriteLine(result.Content);
 ```
+
+
 
 
 ## Async Support
@@ -426,6 +442,8 @@ class Program
 ```
 
 
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
@@ -433,11 +451,16 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Batch Processing
@@ -492,6 +515,7 @@ class Program
     }
 }
 ```
+
 
 
 ## Configuration

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -73,6 +73,10 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
+
+
 ### System Requirements
 
 - See [Installation Guide](https://kreuzberg.dev/getting-started/installation/) for requirements
@@ -98,16 +102,20 @@ Most use cases benefit from configuration to control extraction behavior:
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
 
 
+
 #### Processing Multiple Files
 
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
+
 
 
 #### Async Processing
@@ -117,12 +125,16 @@ For non-blocking document processing:
 <!-- snippet not found: api/extract_file_async.md -->
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -224,9 +236,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -240,11 +254,15 @@ Kreuzberg supports multiple OCR backends for extracting text from scanned docume
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
 
 <!-- snippet not found: api/extract_file_async.md -->
+
+
 
 
 ## Plugin System
@@ -254,6 +272,9 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
@@ -261,11 +282,14 @@ Generate vector embeddings for extracted text using the built-in ONNX Runtime su
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
 
 
+
+
 ## Batch Processing
 
 Process multiple documents efficiently:
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
 
 
 ## Configuration

--- a/packages/elixir/README.md
+++ b/packages/elixir/README.md
@@ -73,6 +73,8 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
 Add to your `mix.exs` dependencies:
 
 ```elixir
@@ -88,6 +90,8 @@ Then run:
 ```bash
 mix deps.get
 ```
+
+
 
 
 ### System Requirements
@@ -146,10 +150,12 @@ IO.puts("Metadata: #{inspect(result.metadata)}")
 ```
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
+
 
 
 #### Processing Multiple Files
@@ -173,6 +179,8 @@ IO.puts("Total files processed: #{length(results)}")
 ```
 
 
+
+
 #### Async Processing
 
 For non-blocking document processing:
@@ -194,12 +202,16 @@ end
 ```
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -301,9 +313,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -332,6 +346,8 @@ IO.puts("Metadata: #{inspect(result.metadata)}")
 ```
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
@@ -353,11 +369,14 @@ end
 ```
 
 
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
 
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
+
 
 
 ### Plugin Example
@@ -443,11 +462,16 @@ IO.inspect(processors, label: "Registered Post-Processors")
 ```
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Batch Processing
@@ -470,6 +494,7 @@ end)
 IO.puts("Total files processed: #{length(results)}")
 ```
 ```
+
 
 
 ## Configuration

--- a/packages/gleam/README.md
+++ b/packages/gleam/README.md
@@ -76,6 +76,12 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 Install via one of the supported package managers:
 
 
+
+
+
+
+
+
 ### System Requirements
 
 - See [Installation Guide](https://kreuzberg.dev/getting-started/installation/) for requirements
@@ -101,16 +107,20 @@ Most use cases benefit from configuration to control extraction behavior:
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
 
 
+
 #### Processing Multiple Files
 
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
+
 
 
 #### Async Processing
@@ -120,12 +130,16 @@ For non-blocking document processing:
 <!-- snippet not found: api/extract_file_async.md -->
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -225,9 +239,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -241,11 +257,17 @@ Kreuzberg supports multiple OCR backends for extracting text from scanned docume
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
 
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
+
+
+
 
 
 ## Embeddings Support
@@ -255,11 +277,14 @@ Generate vector embeddings for extracted text using the built-in ONNX Runtime su
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
 
 
+
+
 ## Batch Processing
 
 Process multiple documents efficiently:
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
 
 
 ## Configuration

--- a/packages/java/README.md
+++ b/packages/java/README.md
@@ -76,6 +76,7 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 Install via one of the supported package managers:
 
 
+
 **Maven:**
 ```xml
 <dependency>
@@ -86,10 +87,15 @@ Install via one of the supported package managers:
 ```
 
 
+
+
 **Gradle:**
 ```gradle
 implementation 'dev.kreuzberg:kreuzberg:4.0.0'
 ```
+
+
+
 
 
 ### System Requirements
@@ -168,10 +174,12 @@ public class Main {
 ```
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
+
 
 
 #### Processing Multiple Files
@@ -200,6 +208,8 @@ try {
 ```
 
 
+
+
 #### Async Processing
 
 For non-blocking document processing:
@@ -224,12 +234,16 @@ public class Example {
 ```
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -331,9 +345,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -372,6 +388,8 @@ public class Main {
 ```
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
@@ -396,6 +414,8 @@ public class Example {
 ```
 
 
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
@@ -403,11 +423,16 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Batch Processing
@@ -435,6 +460,7 @@ try {
     e.printStackTrace();
 }
 ```
+
 
 
 ## Configuration

--- a/packages/kotlin/README.md
+++ b/packages/kotlin/README.md
@@ -76,10 +76,13 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 Install via one of the supported package managers:
 
 
+
 **Gradle:**
 ```gradle
 implementation 'dev.kreuzberg:kreuzberg:4.0.0'
 ```
+
+
 
 
 **Maven:**
@@ -90,6 +93,9 @@ implementation 'dev.kreuzberg:kreuzberg:4.0.0'
     <version>4.0.0</version>
 </dependency>
 ```
+
+
+
 
 
 ### System Requirements
@@ -117,16 +123,20 @@ Most use cases benefit from configuration to control extraction behavior:
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
 
 
+
 #### Processing Multiple Files
 
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
+
 
 
 #### Async Processing
@@ -136,12 +146,16 @@ For non-blocking document processing:
 <!-- snippet not found: api/extract_file_async.md -->
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -243,9 +257,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -259,11 +275,15 @@ Kreuzberg supports multiple OCR backends for extracting text from scanned docume
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
 
 <!-- snippet not found: api/extract_file_async.md -->
+
+
 
 
 ## Plugin System
@@ -273,6 +293,9 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
@@ -280,11 +303,14 @@ Generate vector embeddings for extracted text using the built-in ONNX Runtime su
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
 
 
+
+
 ## Batch Processing
 
 Process multiple documents efficiently:
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
 
 
 ## Configuration

--- a/packages/php/README.md
+++ b/packages/php/README.md
@@ -73,11 +73,15 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
 Install via Composer:
 
 ```bash
 composer require kreuzberg/kreuzberg
 ```
+
+
 
 
 ### System Requirements
@@ -179,7 +183,7 @@ echo $result->content . "\n\n";
 $multilingualConfig = new ExtractionConfig(
     ocr: new OcrConfig(
         backend: 'tesseract',
-        language: 'eng+fra+deu'
+        language: 'eng+fra+deu'  
     )
 );
 
@@ -275,10 +279,12 @@ if ($avgCharsPerPage < 100) {
 ```
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
+
 
 
 #### Processing Multiple Files
@@ -334,7 +340,7 @@ if (!empty($files)) {
 
 $config = new ExtractionConfig(
     extractTables: true,
-    extractImages: false
+    extractImages: false  
 );
 
 $kreuzberg = new Kreuzberg($config);
@@ -442,12 +448,18 @@ echo "\n\nCompleted! Processed $totalProcessed files.\n";
 ```
 
 
+
+
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -547,9 +559,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -595,7 +609,7 @@ echo $result->content . "\n\n";
 $multilingualConfig = new ExtractionConfig(
     ocr: new OcrConfig(
         backend: 'tesseract',
-        language: 'eng+fra+deu'
+        language: 'eng+fra+deu'  
     )
 );
 
@@ -691,6 +705,9 @@ if ($avgCharsPerPage < 100) {
 ```
 
 
+
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
@@ -698,11 +715,16 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Batch Processing
@@ -759,7 +781,7 @@ if (!empty($files)) {
 
 $config = new ExtractionConfig(
     extractTables: true,
-    extractImages: false
+    extractImages: false  
 );
 
 $kreuzberg = new Kreuzberg($config);
@@ -865,6 +887,7 @@ foreach ($batches as $index => $batch) {
 echo "\n\nCompleted! Processed $totalProcessed files.\n";
 ```
 ```
+
 
 
 ## Configuration

--- a/packages/r/README.md
+++ b/packages/r/README.md
@@ -73,6 +73,10 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
+
+
 ### System Requirements
 
 - See [Installation Guide](https://kreuzberg.dev/getting-started/installation/) for requirements
@@ -118,10 +122,12 @@ cat(substr(result$content, 1, 200))
 ```
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
+
 
 
 #### Processing Multiple Files
@@ -144,6 +150,8 @@ cat(sprintf("\n\nDetected language: %s\n", detected_language(result)))
 ```
 
 
+
+
 #### Async Processing
 
 For non-blocking document processing:
@@ -164,12 +172,16 @@ cat(sprintf("Detected language: %s\n", detected_language(result)))
 ```
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -269,9 +281,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -299,6 +313,9 @@ cat(substr(result$content, 1, 200))
 ```
 
 
+
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
@@ -306,11 +323,16 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
 
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
+
+
 
 
 ## Batch Processing
@@ -332,6 +354,7 @@ cat(sprintf("Extracted text from image:\n"))
 cat(content(result))
 cat(sprintf("\n\nDetected language: %s\n", detected_language(result)))
 ```
+
 
 
 ## Configuration

--- a/packages/swift/README.md
+++ b/packages/swift/README.md
@@ -73,6 +73,10 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
+
+
 ### System Requirements
 
 - See [Installation Guide](https://kreuzberg.dev/getting-started/installation/) for requirements
@@ -98,16 +102,20 @@ Most use cases benefit from configuration to control extraction behavior:
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
 
 
+
 #### Processing Multiple Files
 
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
+
 
 
 #### Async Processing
@@ -117,12 +125,16 @@ For non-blocking document processing:
 <!-- snippet not found: api/extract_file_async.md -->
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -224,9 +236,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -240,11 +254,15 @@ Kreuzberg supports multiple OCR backends for extracting text from scanned docume
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
+
 ## Async Support
 
 This binding provides full async/await support for non-blocking document processing:
 
 <!-- snippet not found: api/extract_file_async.md -->
+
+
 
 
 ## Plugin System
@@ -254,6 +272,9 @@ Kreuzberg supports extensible post-processing plugins for custom text transforma
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
 
 
+
+
+
 ## Embeddings Support
 
 Generate vector embeddings for extracted text using the built-in ONNX Runtime support. Requires ONNX Runtime installation.
@@ -261,11 +282,14 @@ Generate vector embeddings for extracted text using the built-in ONNX Runtime su
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
 
 
+
+
 ## Batch Processing
 
 Process multiple documents efficiently:
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
 
 
 ## Configuration

--- a/packages/zig/README.md
+++ b/packages/zig/README.md
@@ -73,6 +73,10 @@ Extract text, tables, images, and metadata from 91+ file formats and 248 program
 ### Package Installation
 
 
+
+
+
+
 ### System Requirements
 
 - See [Installation Guide](https://kreuzberg.dev/getting-started/installation/) for requirements
@@ -98,16 +102,20 @@ Most use cases benefit from configuration to control extraction behavior:
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
 #### Table Extraction
 
 
 See [Table Extraction Guide](https://kreuzberg.dev/features/table-extraction/) for detailed examples.
 
 
+
 #### Processing Multiple Files
 
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
+
 
 
 #### Async Processing
@@ -117,12 +125,16 @@ For non-blocking document processing:
 <!-- snippet not found: api/extract_file_async.md -->
 
 
+
+
+
 ### Next Steps
 
 - **[Installation Guide](https://kreuzberg.dev/getting-started/installation/)** - Platform-specific setup
 - **[API Documentation](https://kreuzberg.dev/api/)** - Complete API reference
 - **[Examples & Guides](https://kreuzberg.dev/guides/)** - Full code examples and usage guides
 - **[Configuration Guide](https://kreuzberg.dev/guides/configuration/)** - Advanced configuration options
+
 
 
 ## Features
@@ -222,9 +234,11 @@ Powered by [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sit
 | **Web formats** | 50-200 MB/s | Streaming | HTML, XML, JSON |
 
 
+
 ## OCR Support
 
 Kreuzberg supports multiple OCR backends for extracting text from scanned documents and images:
+
 
 
 - **Tesseract**
@@ -238,11 +252,17 @@ Kreuzberg supports multiple OCR backends for extracting text from scanned docume
 <!-- snippet not found: ocr/ocr_extraction.md -->
 
 
+
+
+
 ## Plugin System
 
 Kreuzberg supports extensible post-processing plugins for custom text transformation and filtering.
 
 For detailed plugin documentation, visit [Plugin System Guide](https://kreuzberg.dev/guides/plugins/).
+
+
+
 
 
 ## Embeddings Support
@@ -252,11 +272,14 @@ Generate vector embeddings for extracted text using the built-in ONNX Runtime su
 **[Embeddings Guide](https://kreuzberg.dev/features/#embeddings)**
 
 
+
+
 ## Batch Processing
 
 Process multiple documents efficiently:
 
 <!-- snippet not found: api/batch_extract_files_sync.md -->
+
 
 
 ## Configuration


### PR DESCRIPTION
fixes #796 a critical bug where base64 image data was included in the `ExtractionResult` despite `extract_images=false` being set in the configuration. 

The issue occurred only when `output_format` was set to `Markdown`, `Djot`, or `Html`. In these cases, the PDF extractor activates the "structured document" pipeline, which was computing the `inject_placeholders` flag based solely on the user's placeholder preference, ignoring whether image extraction was actually enabled. This caused the pipeline to render and embed full image data even when the caller explicitly disabled it.

### changes
- Updated `extraction.rs` (both `pdfium` and `oxide` backends) to gate `inject_placeholders` on the `extract_images` config flags.
- Ensured that if image extraction is disabled, the structure pipeline skips `populate_images_from_pdfium` entirely, improving performance for non-image extractions.
- Added regression tests in `pdf_image_extraction_tests.rs` covering both `Markdown` and `Djot` formats.

### verification results

#### automated tests
- Added 5 new regression tests in `crates/kreuzberg/tests/pdf_image_extraction_tests.rs` which verify:
    - `images.extract_images = false` suppresses image data in Markdown.
    - `pdf_options.extract_images = false` suppresses image data in Markdown.
    - Parity for Djot output format.
    - Sanity check that images *are* still present when explicitly enabled.

#### quality checks
- Ran `cargo fmt` and `cargo clippy`.
- Ran `prek run --all-files` to ensure project-wide consistency.