### PR TITLE
chore(changelog): add missing release tag links for 4.10.0-rc versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3266,6 +3266,9 @@ See the [API Reference](https://docs.kreuzberg.dev/reference/api-python/) for de
 - [Format Support](https://docs.kreuzberg.dev/reference/formats/) - Supported file formats
 - [Extraction Guide](https://docs.kreuzberg.dev/guides/extraction/) - Extraction examples
 
+[4.10.0-rc.4]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.10.0-rc.4
+[4.10.0-rc.2]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.10.0-rc.2
+[4.10.0-rc.1]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.10.0-rc.1
 [4.9.5]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.5
 [4.9.4]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.4
 [4.9.3]: https://github.com/kreuzberg-dev/kreuzberg/releases/tag/v4.9.3


### PR DESCRIPTION
**Situation**: The CHANGELOG.md was missing reference link definitions for the 4.10.0-rc.1, 4.10.0-rc.2, and 4.10.0-rc.4 releases.

**Task**: Add the missing tag reference URLs so those version headers render as hyperlinks.

**Action**:
- Added `[4.10.0-rc.4]`, `[4.10.0-rc.2]`, and `[4.10.0-rc.1]` reference links pointing to their respective GitHub release tags in `CHANGELOG.md`

**Result**: All 4.10.0-rc version headers in the changelog now link to their GitHub releases consistently with other versions.

**Acceptance Criteria**:
- [x] Three missing reference links added
- [x] Linting passes