### PR TITLE
feat(dx): one command local demo dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ pkg/
 .github/copilot-instructions.md
 .github/skills/
 # END ai-rulez
+
+# Local dev artifacts
+docs/demo-dev.html

--- a/.task/tools/demo.yml
+++ b/.task/tools/demo.yml
@@ -26,12 +26,10 @@ tasks:
       - task: dev:serve
 
   dev:build:
-    desc: "Build WASM binary (unless SKIP_WASM_BUILD=1) and TypeScript dist"
+    desc: "Build WASM binary for web target (unless SKIP_WASM_BUILD=1)"
     dir: crates/kreuzberg-wasm
     cmds:
       - '[ "${SKIP_WASM_BUILD:-0}" = "1" ] || pnpm run build:wasm:web'
-      - pnpm run build:ts
-      - node scripts/copy-pkg.js
 
   dev:patch:
     desc: "Generate docs/demo-dev.html with CDN URLs replaced by localhost:9000"

--- a/.task/tools/demo.yml
+++ b/.task/tools/demo.yml
@@ -1,0 +1,47 @@
+version: "3"
+
+# ============================================================================
+# Demo development environment
+#
+# Starts two servers so demo.html can load WASM assets from a different port,
+# reproducing the cross-origin scenario that exists when assets are on a CDN.
+#
+#   Docs server  → http://localhost:8001  (serves docs/demo.html)
+#   Asset server → http://localhost:9000  (serves crates/kreuzberg-wasm/)
+#
+# Usage:
+#   task demo:dev                  # full build + both servers
+#   SKIP_WASM_BUILD=1 task demo:dev  # skip Rust build, rebuild TS only
+# ============================================================================
+
+tasks:
+  dev:
+    desc: "Build WASM + TS and serve demo + asset servers for local testing"
+    cmds:
+      - task: dev:build
+      - task: dev:serve
+
+  dev:build:
+    desc: "Build WASM binary (unless SKIP_WASM_BUILD=1) and TypeScript dist"
+    dir: crates/kreuzberg-wasm
+    cmds:
+      - '[ "${SKIP_WASM_BUILD:-0}" = "1" ] || pnpm run build:wasm:web'
+      - pnpm run build:ts
+      - node scripts/copy-pkg.js
+
+  dev:serve:
+    desc: "Start docs server (port 8001) and WASM asset server (port 9000) in parallel"
+    deps:
+      - task: dev:serve:docs
+      - task: dev:serve:assets
+
+  dev:serve:docs:
+    desc: "Serve docs on http://localhost:8001"
+    cmds:
+      - uv run --group doc zensical serve -a localhost:8001
+
+  dev:serve:assets:
+    desc: "Serve WASM assets on http://localhost:9000 (simulates CDN origin)"
+    dir: crates/kreuzberg-wasm
+    cmds:
+      - npx --yes serve . -p 9000 --cors -l tcp://0.0.0.0:9000

--- a/.task/tools/demo.yml
+++ b/.task/tools/demo.yml
@@ -3,22 +3,26 @@ version: "3"
 # ============================================================================
 # Demo development environment
 #
-# Starts two servers so demo.html can load WASM assets from a different port,
-# reproducing the cross-origin scenario that exists when assets are on a CDN.
+# Generates a patched demo-dev.html (CDN URLs → localhost), then starts two
+# servers that reproduce the cross-origin scenario the CDN creates in prod:
 #
-#   Docs server  → http://localhost:8001  (serves docs/demo.html)
+#   Docs server  → http://localhost:8001  (serves docs/)
 #   Asset server → http://localhost:9000  (serves crates/kreuzberg-wasm/)
 #
 # Usage:
-#   task demo:dev                  # full build + both servers
-#   SKIP_WASM_BUILD=1 task demo:dev  # skip Rust build, rebuild TS only
+#   task demo:dev                    # full build + patch + both servers
+#   SKIP_WASM_BUILD=1 task demo:dev  # skip Rust build, TS + patch only
+#
+# Open:  http://localhost:8001/demo-dev.html
 # ============================================================================
 
 tasks:
   dev:
-    desc: "Build WASM + TS and serve demo + asset servers for local testing"
+    desc: "Build, patch demo for localhost, and start both dev servers"
     cmds:
       - task: dev:build
+      - task: dev:patch
+      - task: dev:ready
       - task: dev:serve
 
   dev:build:
@@ -28,6 +32,28 @@ tasks:
       - '[ "${SKIP_WASM_BUILD:-0}" = "1" ] || pnpm run build:wasm:web'
       - pnpm run build:ts
       - node scripts/copy-pkg.js
+
+  dev:patch:
+    desc: "Generate docs/demo-dev.html with CDN URLs replaced by localhost:9000"
+    cmds:
+      - node scripts/task/patch-demo-dev.mjs
+
+  dev:ready:
+    desc: "Print the ready banner"
+    cmds:
+      - |
+        printf '\n'
+        printf '  ┌─────────────────────────────────────────────────────┐\n'
+        printf '  │  Demo dev environment ready                         │\n'
+        printf '  │                                                     │\n'
+        printf '  │  Open → http://localhost:8001/demo-dev.html         │\n'
+        printf '  │                                                     │\n'
+        printf '  │  Assets served from http://localhost:9000           │\n'
+        printf '  │  (same cross-origin setup as the live CDN)          │\n'
+        printf '  │                                                     │\n'
+        printf '  │  Ctrl+C to stop both servers                        │\n'
+        printf '  └─────────────────────────────────────────────────────┘\n'
+        printf '\n'
 
   dev:serve:
     desc: "Start docs server (port 8001) and WASM asset server (port 9000) in parallel"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -35,6 +35,8 @@ includes:
     taskfile: ./.task/tools/pdfium.yml
   docs:
     taskfile: ./.task/tools/docs.yml
+  demo:
+    taskfile: ./.task/tools/demo.yml
   _tools:
     taskfile: ./.task/tools/general.yml
     flatten: true

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -104,6 +104,29 @@ task c:build && task c:test
 task wasm:build && task wasm:test
 ```
 
+### Testing the live browser demo
+
+The demo at `docs/demo.html` loads `@kreuzberg/wasm` from a CDN. To test local changes against the demo without modifying source files, use:
+
+```bash title="Terminal"
+task demo:dev
+```
+
+This builds the WASM binary and TypeScript dist, then starts two servers:
+
+| Server | URL | Role |
+|--------|-----|------|
+| Docs | `http://localhost:8001` | Serves `demo.html` |
+| Assets | `http://localhost:9000` | Serves the local WASM package |
+
+Open `http://localhost:8001/demo.html` and temporarily swap the CDN base URL in DevTools (or edit `demo.html` locally) to point at `http://localhost:9000`. The two different ports reproduce the cross-origin scenario the CDN creates in production.
+
+To skip the slow Rust build when you've only changed TypeScript:
+
+```bash title="Terminal"
+SKIP_WASM_BUILD=1 task demo:dev
+```
+
 ---
 
 ## E2E Test Suites

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -106,20 +106,20 @@ task wasm:build && task wasm:test
 
 ### Testing the live browser demo
 
-The demo at `docs/demo.html` loads `@kreuzberg/wasm` from a CDN. To test local changes against the demo without modifying source files, use:
+The demo at `docs/demo.html` loads `@kreuzberg/wasm` from a CDN. To test local changes against it, use:
 
 ```bash title="Terminal"
 task demo:dev
 ```
 
-This builds the WASM binary and TypeScript dist, then starts two servers:
+This builds the WASM binary and TypeScript dist, patches the demo with local URLs, and starts two servers:
 
 | Server | URL | Role |
 |--------|-----|------|
-| Docs | `http://localhost:8001` | Serves `demo.html` |
+| Docs | `http://localhost:8001` | Serves the patched `demo-dev.html` |
 | Assets | `http://localhost:9000` | Serves the local WASM package |
 
-Open `http://localhost:8001/demo.html` and temporarily swap the CDN base URL in DevTools (or edit `demo.html` locally) to point at `http://localhost:9000`. The two different ports reproduce the cross-origin scenario the CDN creates in production.
+Open **`http://localhost:8001/demo-dev.html`** — no manual edits needed. The patched file (`docs/demo-dev.html`) is gitignored and regenerated on every run. The two different ports reproduce the cross-origin setup the CDN creates in production.
 
 To skip the slow Rust build when you've only changed TypeScript:
 

--- a/scripts/task/patch-demo-dev.mjs
+++ b/scripts/task/patch-demo-dev.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Generates docs/demo-dev.html from docs/demo.html with CDN URLs replaced
+// by the local asset server so no manual editing of demo.html is ever needed.
+//
+// CDN pattern replaced:
+//   https://cdn.jsdelivr.net/npm/@kreuzberg/wasm@*/...
+//   → http://localhost:9000/...
+//
+// The output file is gitignored and regenerated on every `task demo:dev`.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const src  = join(root, "docs", "demo.html");
+const dest = join(root, "docs", "demo-dev.html");
+const ASSET_PORT = process.env.ASSET_PORT ?? "9000";
+
+const cdnRe = /https:\/\/cdn\.jsdelivr\.net\/npm\/@kreuzberg\/wasm@[^/'"]+/g;
+
+const patched = readFileSync(src, "utf8")
+  .replace(cdnRe, `http://localhost:${ASSET_PORT}`)
+  .replace(
+    /<title>(.*?)<\/title>/,
+    "<title>$1 [local dev]</title>",
+  )
+  .replace(
+    "</body>",
+    `  <div style="position:fixed;bottom:12px;right:12px;background:#1a172a;border:1px solid #58FBDA55;color:#58FBDA;font-family:monospace;font-size:11px;padding:6px 10px;border-radius:6px;z-index:9999">
+    local dev · assets: localhost:${ASSET_PORT}
+  </div>\n</body>`,
+  );
+
+writeFileSync(dest, patched, "utf8");
+console.log(`patch-demo-dev: docs/demo-dev.html → http://localhost:8001/demo-dev.html`);
+console.log(`  assets served from http://localhost:${ASSET_PORT}`);


### PR DESCRIPTION
Initially, testing a WASM change against the live demo meant four manual build steps, two servers started by hand, and a demo.html edit that had to be remembered to revert before pushing. One missed step and you're testing the wrong build.               
                                                                
  task demo:dev handles all of it. It builds the WASM binary, generates a patched docs/demo-dev.html with CDN URLs swapped for localhost:9000, starts both servers in  parallel, and prints the URL to open. The patched file gets a [local dev] title and a corner badge so it's always clear which build is under test. docs/demo-dev.html is gitignored,... demo.html is never touched.

  The two ports (8001 for docs, 9000 for assets) reproduce the exact cross-origin setup the CDN creates in production,... the condition that exposed #854.
                                                                                           
  SKIP_WASM_BUILD=1 task demo:dev skips the Rust build when only TypeScript changed.
  
  closes #856 