### PR TITLE
fix(ocr): default PSM to SINGLE_BLOCK (6) on WASM target

### DIFF
--- a/crates/kreuzberg/src/ocr/types.rs
+++ b/crates/kreuzberg/src/ocr/types.rs
@@ -87,6 +87,11 @@ impl Default for TesseractConfig {
     fn default() -> Self {
         Self {
             language: "eng".to_string(),
+            // PSM_AUTO (3) triggers full layout analysis which hangs 60-90s on sparse/no-text
+            // images in WASM (issue #855). PSM_SINGLE_BLOCK (6) skips layout analysis entirely.
+            #[cfg(target_arch = "wasm32")]
+            psm: 6,
+            #[cfg(not(target_arch = "wasm32"))]
             psm: 3,
             output_format: "markdown".to_string(),
             oem: 3,
@@ -233,13 +238,18 @@ mod tests {
         let config = TesseractConfig::default();
 
         assert_eq!(config.language, "eng");
-        assert_eq!(config.psm, 3);
         assert_eq!(config.output_format, "markdown");
         assert!(config.enable_table_detection);
         assert_eq!(config.table_min_confidence, 0.0);
         assert_eq!(config.table_column_threshold, 50);
         assert_eq!(config.table_row_threshold_ratio, 0.5);
         assert!(config.use_cache);
+
+        // PSM default is target-specific: WASM avoids layout-analysis hang (issue #855)
+        #[cfg(target_arch = "wasm32")]
+        assert_eq!(config.psm, 6, "WASM default must be PSM_SINGLE_BLOCK (6)");
+        #[cfg(not(target_arch = "wasm32"))]
+        assert_eq!(config.psm, 3, "native default must be PSM_AUTO (3)");
     }
 
     #[test]

--- a/crates/kreuzberg/src/types/formats.rs
+++ b/crates/kreuzberg/src/types/formats.rs
@@ -286,8 +286,8 @@ pub struct TesseractConfig {
     /// Page Segmentation Mode (0-13).
     ///
     /// Common values:
-    /// - 3: Fully automatic page segmentation (default)
-    /// - 6: Assume a single uniform block of text
+    /// - 3: Fully automatic page segmentation (native default)
+    /// - 6: Assume a single uniform block of text (WASM default — avoids layout-analysis hang)
     /// - 11: Sparse text with no particular order
     pub psm: i32,
 
@@ -364,6 +364,10 @@ impl Default for TesseractConfig {
     fn default() -> Self {
         Self {
             language: "eng".to_string(),
+            // PSM_AUTO (3) hangs 60-90s on sparse/no-text images in WASM (issue #855)
+            #[cfg(target_arch = "wasm32")]
+            psm: 6,
+            #[cfg(not(target_arch = "wasm32"))]
             psm: 3,
             output_format: "markdown".to_string(),
             oem: 3,


### PR DESCRIPTION
PSM_AUTO (3) enters a degenerate layout-analysis loop on sparse or no-text images (screenshots, gradients, icons) inside the WASM worker, hanging for 60–90 s. PSM_SINGLE_BLOCK (6) skips that phase entirely. The fix is applied in both `Default` impls (public `TesseractConfig` in `types/formats.rs` and internal in `ocr/types.rs`). Native default (PSM_AUTO = 3) is unchanged. Users who need PSM_AUTO on WASM can override `psm` explicitly.

Fixes #855