### PR TITLE
chore: bump alef pre-commit hook v0.13.6 → v0.14.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -239,7 +239,7 @@ repos:
 
   # Alef: verify bindings and sync versions
   - repo: https://github.com/kreuzberg-dev/alef
-    rev: v0.13.6
+    rev: v0.14.6
     hooks:
       - id: alef-verify
       - id: alef-sync-versions


### PR DESCRIPTION
The alef hook uses `language: system`, so it invokes the local `alef` binary. `alef.toml` was migrated to the v0.14.x workspace format in 512f1b766 but the pre-commit pin was not bumped at the same time. Any commit on main since that change fails with `TOML parse error: missing field 'crate'` because v0.13.x expected the old flat `[crate]` format.