### PR TITLE
fix(ci): verify required FFI symbols in go-ffi artifact

### DIFF
--- a/scripts/ci/go/verify-ffi-artifact.sh
+++ b/scripts/ci/go/verify-ffi-artifact.sh
@@ -78,4 +78,34 @@ if [ $PLATFORM_LIBS_FOUND -eq 0 ]; then
 fi
 
 echo ""
+echo "=== Checking required FFI symbols ==="
+# These symbols are declared in packages/go/v4/binding.go and must be exported
+# by the compiled library. A missing symbol causes linker errors at Go build
+# time (regression: v4.8.0–v4.9.4, tracked in issue #871).
+REQUIRED_SYMBOLS=(
+  "kreuzberg_embed_texts"
+  "kreuzberg_get_embedding_preset"
+  "kreuzberg_list_embedding_presets"
+)
+
+if command -v nm >/dev/null 2>&1; then
+  SYMBOL_ERRORS=0
+  for sym in "${REQUIRED_SYMBOLS[@]}"; do
+    if nm "$STATIC_LIB" 2>/dev/null | grep -qF "$sym"; then
+      echo "✓ Symbol present: $sym"
+    else
+      echo "✗ Missing symbol: $sym"
+      SYMBOL_ERRORS=$((SYMBOL_ERRORS + 1))
+    fi
+  done
+  if [ $SYMBOL_ERRORS -gt 0 ]; then
+    echo ""
+    echo "✗ $SYMBOL_ERRORS required symbol(s) missing from libkreuzberg_ffi.a"
+    exit 1
+  fi
+else
+  echo "  (nm not available — skipping symbol check)"
+fi
+
+echo ""
 echo "✓ Artifact verification passed"

--- a/scripts/ci/go/verify-ffi-artifact.sh
+++ b/scripts/ci/go/verify-ffi-artifact.sh
@@ -79,32 +79,37 @@ fi
 
 echo ""
 echo "=== Checking required FFI symbols ==="
-# These symbols are declared in packages/go/v4/binding.go and must be exported
-# by the compiled library. A missing symbol causes linker errors at Go build
-# time (regression: v4.8.0–v4.9.4, tracked in issue #871).
-REQUIRED_SYMBOLS=(
-  "kreuzberg_embed_texts"
-  "kreuzberg_get_embedding_preset"
-  "kreuzberg_list_embedding_presets"
-)
-
-if command -v nm >/dev/null 2>&1; then
-  SYMBOL_ERRORS=0
-  for sym in "${REQUIRED_SYMBOLS[@]}"; do
-    if nm "$STATIC_LIB" 2>/dev/null | grep -qF "$sym"; then
-      echo "✓ Symbol present: $sym"
-    else
-      echo "✗ Missing symbol: $sym"
-      SYMBOL_ERRORS=$((SYMBOL_ERRORS + 1))
-    fi
-  done
-  if [ $SYMBOL_ERRORS -gt 0 ]; then
-    echo ""
-    echo "✗ $SYMBOL_ERRORS required symbol(s) missing from libkreuzberg_ffi.a"
-    exit 1
-  fi
-else
+# Derive required symbols dynamically from the Go binding so this check stays
+# in sync automatically as the API surface grows. Any C.kreuzberg_* call in
+# binding.go must resolve to a compiled symbol — the root cause of issue #871
+# was three embedding symbols compiled out by a stale feature flag, which this
+# check would have caught.
+BINDING_FILE="packages/go/v4/binding.go"
+if [ ! -f "$BINDING_FILE" ]; then
+  echo "  (binding file not found at $BINDING_FILE — skipping symbol check)"
+elif ! command -v nm >/dev/null 2>&1; then
   echo "  (nm not available — skipping symbol check)"
+else
+  REQUIRED_SYMBOLS=$(grep -o 'C\.kreuzberg_[a-zA-Z0-9_]*' "$BINDING_FILE" | sed 's/C\.//' | sort -u)
+  if [ -z "$REQUIRED_SYMBOLS" ]; then
+    echo "  (no kreuzberg_ symbols found in $BINDING_FILE — skipping)"
+  else
+    NM_OUTPUT=$(nm "$STATIC_LIB" 2>/dev/null)
+    SYMBOL_ERRORS=0
+    while IFS= read -r sym; do
+      if echo "$NM_OUTPUT" | grep -qF "$sym"; then
+        echo "✓ $sym"
+      else
+        echo "✗ Missing: $sym"
+        SYMBOL_ERRORS=$((SYMBOL_ERRORS + 1))
+      fi
+    done <<< "$REQUIRED_SYMBOLS"
+    if [ $SYMBOL_ERRORS -gt 0 ]; then
+      echo ""
+      echo "✗ $SYMBOL_ERRORS symbol(s) referenced in $BINDING_FILE missing from libkreuzberg_ffi.a"
+      exit 1
+    fi
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## Root cause

Commit c9bd09d3b added `#[cfg(feature = "embeddings")]` guards in `kreuzberg-ffi/src/lib.rs` without adding `embeddings` to the crate's `default` features. The build command (`cargo build --release -p kreuzberg-ffi`) uses default features only, so the three embedding symbols were compiled out of every release from v4.8.0 onward.

The confusion: `kreuzberg-ffi/Cargo.toml` had `kreuzberg = { ..., features = ["full"] }` which activates `kreuzberg/embeddings` inside the core crate — but that does **not** activate `kreuzberg-ffi`'s own crate-level `embeddings` feature. The `#[cfg]` gate checks the latter.

## Fix

The code regression is already gone on main: the alef-generated monolithic `lib.rs` has no crate-level feature gating, so all symbols are compiled unconditionally.

This PR adds a symbol-presence check to `verify-ffi-artifact.sh` so any future reintroduction of feature gating that drops a Go-declared symbol fails the publish job before the artifact is uploaded.

Closes #871