### PR TITLE
fix(demo): fix task demo:dev server startup failures

### DIFF
--- a/.task/tools/demo.yml
+++ b/.task/tools/demo.yml
@@ -62,10 +62,10 @@ tasks:
   dev:serve:docs:
     desc: "Serve docs on http://localhost:8001"
     cmds:
-      - uv run --group doc zensical serve -a localhost:8001
+      - uv run --group docs zensical serve -a localhost:8001
 
   dev:serve:assets:
     desc: "Serve WASM assets on http://localhost:9000 (simulates CDN origin)"
     dir: crates/kreuzberg-wasm
     cmds:
-      - npx --yes serve . -p 9000 --cors -l tcp://0.0.0.0:9000
+      - npx --yes serve . --cors -l tcp://0.0.0.0:9000


### PR DESCRIPTION
Fixes two bugs that prevent `task demo:dev` from starting.

- `--group doc` → `--group docs` (typo; group is `docs` in pyproject.toml). Fixes #901.
- Drop `-p 9000` from `npx serve`; when `-l` is also passed it takes precedence and binds a random port, breaking the `localhost:9000` asset URL. Fixes #902.