### PR TITLE
fix(mcp): fix file_configs JSON Schema for Moonshot AI compatibility

### DIFF
--- a/crates/kreuzberg/src/mcp/params.rs
+++ b/crates/kreuzberg/src/mcp/params.rs
@@ -55,7 +55,8 @@ pub struct BatchExtractFilesParams {
     pub pdf_password: Option<String>,
     /// Per-file extraction configuration overrides (parallel array to paths).
     /// Each entry is either null (use default) or a FileExtractionConfig JSON object.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "file_configs_schema")]
     pub file_configs: Option<Vec<Option<serde_json::Value>>>,
     /// Wire format for the response: "json" (default) or "toon"
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -164,6 +165,21 @@ pub struct ChunkTextParams {
     /// Topic threshold for semantic chunking (0.0-1.0, default: 0.75)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topic_threshold: Option<f32>,
+}
+
+// Emits `{"type":"array","items":{"anyOf":[{"type":"null"},{"type":"object"}]}}` instead
+// of the default `{"type":"array","items":true}` that schemars derives for Vec<Option<Value>>.
+// `items: true` is valid JSON Schema 2019-09+ but Moonshot AI rejects it (issue #877).
+fn file_configs_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "array",
+        "items": {
+            "anyOf": [
+                {"type": "null"},
+                {"type": "object"}
+            ]
+        }
+    })
 }
 
 // These param structs are constructed by the rmcp framework via serde deserialization,

--- a/crates/kreuzberg/tests/test_batch_extract_schema.rs
+++ b/crates/kreuzberg/tests/test_batch_extract_schema.rs
@@ -1,0 +1,56 @@
+use kreuzberg::mcp::BatchExtractFilesParams;
+use rmcp::schemars::schema_for;
+
+#[test]
+fn test_file_configs_items_is_object_not_boolean() {
+    // Regression test for https://github.com/kreuzberg-dev/kreuzberg/issues/877
+    // Moonshot AI (Kimi) rejects `"items": true` — items must be an object.
+    let schema = schema_for!(BatchExtractFilesParams);
+    let schema_value = serde_json::to_value(&schema).unwrap();
+
+    let items = &schema_value["properties"]["file_configs"]["items"];
+    assert!(
+        items.is_object(),
+        "file_configs items must be an object, got: {items} — \
+         Moonshot AI rejects boolean `items: true` (issue #877)"
+    );
+}
+
+#[test]
+fn test_file_configs_items_accepts_null_and_object() {
+    // items schema must accept both null (use default) and object (per-file config).
+    let schema = schema_for!(BatchExtractFilesParams);
+    let schema_value = serde_json::to_value(&schema).unwrap();
+
+    let items = &schema_value["properties"]["file_configs"]["items"];
+    let any_of = items["anyOf"].as_array().expect("items must have anyOf");
+
+    let types: Vec<&str> = any_of.iter().filter_map(|s| s["type"].as_str()).collect();
+
+    assert!(
+        types.contains(&"null"),
+        "file_configs items must accept null, got anyOf: {any_of:?}"
+    );
+    assert!(
+        types.contains(&"object"),
+        "file_configs items must accept object, got anyOf: {any_of:?}"
+    );
+}
+
+#[test]
+fn test_file_configs_is_not_required() {
+    // schema_with bypasses automatic Option<> handling — verify schemars still
+    // leaves file_configs out of `required` (the field is optional at the call site).
+    let schema = schema_for!(BatchExtractFilesParams);
+    let schema_value = serde_json::to_value(&schema).unwrap();
+
+    let is_required = schema_value["required"]
+        .as_array()
+        .map(|r| r.iter().any(|f| f.as_str() == Some("file_configs")))
+        .unwrap_or(false);
+
+    assert!(
+        !is_required,
+        "file_configs must be optional — outer Option<> must not appear in required"
+    );
+}


### PR DESCRIPTION
## Problem

Moonshot AI (Kimi) rejects `\"items\": true` in JSON Schema — it enforces a stricter subset requiring `items` to be an object. The `file_configs` field in `BatchExtractFilesParams` was deriving `Vec<Option<serde_json::Value>>`, which schemars emits as `\"items\": true` (valid JSON Schema 2019-09+ boolean schema, but rejected by Kimi).

Fixes #877.

## Fix

Added a `schema_with` custom schema function that emits:

```json
{
  \"type\": \"array\",
  \"items\": {
    \"anyOf\": [
      {\"type\": \"null\"},
      {\"type\": \"object\"}
    ]
  }
}
```

## Why `#[serde(default)]` is also required

In schemars v1, `schema_with` replaces the **entire** field schema — it bypasses schemars' own `Option<T>` detection that normally excludes the field from `required`. Without `#[serde(default)]`, `file_configs` would appear in the `required` array even though it's `Option<...>`. Adding `#[serde(default)]` signals to schemars that the field has a default value and must be omitted from `required`. The third test (`test_file_configs_is_not_required`) verifies this.

## Tests

Added `crates/kreuzberg/tests/test_batch_extract_schema.rs` with three integration tests:

1. `test_file_configs_items_is_object_not_boolean` — items must be an object, not boolean
2. `test_file_configs_items_accepts_null_and_object` — anyOf must include both null and object
3. `test_file_configs_is_not_required` — file_configs must not appear in the required array