### PR TITLE
fix(table-guard): decouple SecurityLimits from OCR table limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Table extraction complexity guard**: Introduced `max_table_cells` configuration to `OcrConfig`, `TesseractConfig`, `PaddleOcrConfig`, and `LayoutDetectionConfig`. This allows setting a hard limit on the number of cells reconstructed during table extraction (default: 5000), preventing Out-Of-Memory (OOM) errors on extremely large or degenerate tables.
 - **InternalDocument is serde-bridgeable**: `InternalDocument` and its four
   previously-non-serde sub-types (`InternalElement`, `ElementKind`,
   `Relationship`, `RelationshipTarget`) gained `Serialize` + `Deserialize`

--- a/crates/kreuzberg/src/core/config/layout.rs
+++ b/crates/kreuzberg/src/core/config/layout.rs
@@ -87,6 +87,15 @@ pub struct LayoutDetectionConfig {
     /// is used for inference. Defaults to `None` (auto-select per platform).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub acceleration: Option<super::acceleration::AccelerationConfig>,
+
+    /// Maximum number of table cells allowed before a table is deemed too complex
+    /// and rendered as plain text. Default is 5000.
+    #[serde(default = "default_max_table_cells")]
+    pub max_table_cells: Option<usize>,
+}
+
+fn default_max_table_cells() -> Option<usize> {
+    Some(5000)
 }
 
 impl Default for LayoutDetectionConfig {
@@ -96,6 +105,7 @@ impl Default for LayoutDetectionConfig {
             apply_heuristics: true,
             table_model: TableModel::default(),
             acceleration: None,
+            max_table_cells: default_max_table_cells(),
         }
     }
 }
@@ -114,6 +124,7 @@ mod tests {
         assert_eq!(config.table_model, TableModel::Tatr);
         assert!(config.apply_heuristics);
         assert!(config.confidence_threshold.is_none());
+        assert_eq!(config.max_table_cells, Some(5000));
     }
 
     #[test]

--- a/crates/kreuzberg/src/core/config/ocr.rs
+++ b/crates/kreuzberg/src/core/config/ocr.rs
@@ -293,6 +293,15 @@ pub struct OcrConfig {
     /// at runtime.
     #[serde(skip)]
     pub tessdata_bytes: Option<std::collections::HashMap<String, Vec<u8>>>,
+
+    /// Maximum number of cells allowed in a reconstructed table (default: 5000).
+    /// Prevents memory exhaustion from massive or degenerate tables.
+    #[serde(default = "default_max_table_cells")]
+    pub max_table_cells: Option<usize>,
+}
+
+fn default_max_table_cells() -> Option<usize> {
+    Some(5000)
 }
 
 impl Default for OcrConfig {
@@ -312,6 +321,7 @@ impl Default for OcrConfig {
             vlm_prompt: None,
             acceleration: None,
             tessdata_bytes: None,
+            max_table_cells: default_max_table_cells(),
         }
     }
 }

--- a/crates/kreuzberg/src/extractors/dbf.rs
+++ b/crates/kreuzberg/src/extractors/dbf.rs
@@ -2,7 +2,6 @@
 //!
 //! Reads records from dBASE files and formats them as a markdown table.
 
-
 use crate::Result;
 use crate::core::config::ExtractionConfig;
 use crate::plugins::{DocumentExtractor, Plugin};

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -154,6 +154,8 @@ pub(crate) fn extract_all_from_oxide_document(
                     #[cfg(feature = "layout-detection")]
                     table_model: config.layout.as_ref().map(|l| l.table_model).unwrap_or_default(),
                     #[cfg(feature = "layout-detection")]
+                    max_table_cells: config.layout.as_ref().and_then(|l| l.max_table_cells),
+                    #[cfg(feature = "layout-detection")]
                     acceleration: config.acceleration.as_ref(),
                 },
             ) {

--- a/crates/kreuzberg/src/extractors/pdf/layout_hints.rs
+++ b/crates/kreuzberg/src/extractors/pdf/layout_hints.rs
@@ -207,11 +207,7 @@ mod tests {
     /// this case but the function must return cleanly.
     #[test]
     fn pixel_to_pdf_zero_dim_does_not_panic() {
-        let det = DetectionResult::new(
-            0,
-            0,
-            vec![detection_at(LayoutClass::Text, 0.0, 0.0, 10.0, 10.0)],
-        );
+        let det = DetectionResult::new(0, 0, vec![detection_at(LayoutClass::Text, 0.0, 0.0, 10.0, 10.0)]);
         let _ = pixel_detection_to_layout_hints_pdf_space(&det, 0, 0, 595.0, 842.0);
     }
 }

--- a/crates/kreuzberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/kreuzberg/src/extractors/pdf/layout_runner.rs
@@ -164,10 +164,7 @@ type LayoutForMarkdownOptional = (
 );
 
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
-pub(super) fn maybe_run_layout_for_markdown(
-    content: &[u8],
-    config: &ExtractionConfig,
-) -> LayoutForMarkdownOptional {
+pub(super) fn maybe_run_layout_for_markdown(content: &[u8], config: &ExtractionConfig) -> LayoutForMarkdownOptional {
     if !config.use_layout_for_markdown {
         return (None, None, None);
     }

--- a/crates/kreuzberg/src/extractors/security.rs
+++ b/crates/kreuzberg/src/extractors/security.rs
@@ -45,7 +45,7 @@ pub struct SecurityLimits {
     /// Maximum XML depth (100 levels)
     pub max_xml_depth: usize,
 
-    /// Maximum cells per table (100,000)
+    /// Maximum cells per table (5,000)
     pub max_table_cells: usize,
 }
 
@@ -68,7 +68,7 @@ impl Default for SecurityLimits {
             max_content_size: 100 * 1024 * 1024,
             max_iterations: 10_000_000,
             max_xml_depth: 1024,
-            max_table_cells: 100_000,
+            max_table_cells: 5000,
         }
     }
 }

--- a/crates/kreuzberg/src/ocr/processor/execution.rs
+++ b/crates/kreuzberg/src/ocr/processor/execution.rs
@@ -1081,7 +1081,12 @@ pub(super) fn perform_ocr(
         let words = extract_words_from_tsv(tsv_data, config.table_min_confidence)?;
 
         if words.len() >= 6 {
-            let table = reconstruct_table(&words, config.table_column_threshold, config.table_row_threshold_ratio);
+            let table = reconstruct_table(
+                &words,
+                config.table_column_threshold,
+                config.table_row_threshold_ratio,
+                config.max_table_cells,
+            );
             if !table.is_empty() && !table[0].is_empty() {
                 // Apply full post-processing validation to reject false positives.
                 // post_process_table is only available with the pdf feature; without it, use table as-is.

--- a/crates/kreuzberg/src/ocr/tesseract_backend.rs
+++ b/crates/kreuzberg/src/ocr/tesseract_backend.rs
@@ -74,6 +74,7 @@ impl TesseractBackend {
                 .as_ref()
                 .map(|p| p.auto_rotate)
                 .unwrap_or(false),
+            max_table_cells: public_config.max_table_cells,
         }
     }
 
@@ -86,9 +87,11 @@ impl TesseractBackend {
             Some(tess_config) => Self::convert_config(tess_config),
             None => InternalTesseractConfig {
                 language: config.language.clone(),
+                max_table_cells: config.max_table_cells,
                 ..Default::default()
             },
         };
+        internal.max_table_cells = config.max_table_cells;
         // Propagate top-level OcrConfig.auto_rotate (OR with any preprocessing setting)
         if config.auto_rotate {
             internal.auto_rotate = true;
@@ -544,5 +547,17 @@ mod tests {
         assert_eq!(internal_config.psm, 6u8);
         assert_eq!(internal_config.oem, 3u8);
         assert_eq!(internal_config.table_column_threshold, 100u32);
+    }
+
+    #[test]
+    fn test_config_to_tesseract_max_table_cells_propagation() {
+        let backend = TesseractBackend::new().expect("Tesseract should be available for test");
+        let ocr_config = OcrConfig {
+            max_table_cells: Some(9999),
+            ..Default::default()
+        };
+
+        let internal = backend.config_to_tesseract(&ocr_config);
+        assert_eq!(internal.max_table_cells, Some(9999));
     }
 }

--- a/crates/kreuzberg/src/ocr/types.rs
+++ b/crates/kreuzberg/src/ocr/types.rs
@@ -81,6 +81,10 @@ pub struct TesseractConfig {
     /// page orientation (0/90/180/270 degrees) before OCR. If the page is
     /// rotated with high confidence, the image is corrected before recognition.
     pub auto_rotate: bool,
+
+    /// Maximum number of cells allowed in a reconstructed table (default: 5000).
+    /// Prevents memory exhaustion from massive or degenerate tables.
+    pub max_table_cells: Option<usize>,
 }
 
 impl Default for TesseractConfig {
@@ -113,6 +117,7 @@ impl Default for TesseractConfig {
             textord_space_size_is_variable: true,
             thresholding_method: false,
             auto_rotate: false,
+            max_table_cells: Some(5000),
         }
     }
 }
@@ -160,6 +165,7 @@ impl From<&crate::types::TesseractConfig> for TesseractConfig {
             textord_space_size_is_variable: config.textord_space_size_is_variable,
             thresholding_method: config.thresholding_method,
             auto_rotate: config.preprocessing.as_ref().map(|p| p.auto_rotate).unwrap_or(false),
+            max_table_cells: config.max_table_cells,
         }
     }
 }
@@ -388,6 +394,7 @@ mod tests {
             tessedit_use_primary_params_model: false,
             textord_space_size_is_variable: false,
             thresholding_method: true,
+            max_table_cells: Some(1000),
         };
 
         let internal_config: TesseractConfig = (&public_config).into();
@@ -413,5 +420,6 @@ mod tests {
         assert!(!internal_config.tessedit_use_primary_params_model);
         assert!(!internal_config.textord_space_size_is_variable);
         assert!(internal_config.thresholding_method);
+        assert_eq!(internal_config.max_table_cells, Some(1000));
     }
 }

--- a/crates/kreuzberg/src/paddle_ocr/backend.rs
+++ b/crates/kreuzberg/src/paddle_ocr/backend.rs
@@ -527,7 +527,7 @@ impl OcrBackend for PaddleOcrBackend {
             let words = elements_to_hocr_words(&ocr_elements, 0.3);
 
             if !words.is_empty() {
-                let cells = reconstruct_table(&words, 20, 0.5);
+                let cells = reconstruct_table(&words, 20, 0.5, effective_config.max_table_cells);
 
                 if !cells.is_empty() {
                     table_count = 1;

--- a/crates/kreuzberg/src/paddle_ocr/config.rs
+++ b/crates/kreuzberg/src/paddle_ocr/config.rs
@@ -78,6 +78,10 @@ pub struct PaddleOcrConfig {
     /// - `"mobile"` (default): Lightweight models (~4.5MB detection, ~16.5MB recognition), fast download and inference
     /// - `"server"`: Large, high-accuracy models (~88MB detection, ~84MB recognition), best for GPU or complex documents
     pub model_tier: String,
+
+    /// Maximum number of cells allowed in a reconstructed table (default: 5000).
+    /// Prevents memory exhaustion from massive or degenerate tables.
+    pub max_table_cells: Option<usize>,
 }
 
 impl PaddleOcrConfig {
@@ -108,6 +112,7 @@ impl PaddleOcrConfig {
             padding: 10,
             drop_score: 0.5,
             model_tier: "mobile".to_string(), // mobile is the default: fast, ~13MB total download
+            max_table_cells: Some(5000),
         }
     }
 
@@ -266,6 +271,16 @@ impl PaddleOcrConfig {
     /// * `tier` - `"mobile"` (default, lightweight, faster) or `"server"` (high accuracy, GPU/complex documents)
     pub fn with_model_tier(mut self, tier: impl Into<String>) -> Self {
         self.model_tier = tier.into();
+        self
+    }
+
+    /// Sets the maximum number of cells allowed in a reconstructed table.
+    ///
+    /// # Arguments
+    ///
+    /// * `limit` - Maximum number of cells
+    pub fn with_max_table_cells(mut self, limit: Option<usize>) -> Self {
+        self.max_table_cells = limit;
         self
     }
 }
@@ -526,6 +541,15 @@ mod tests {
         assert_eq!(config.det_db_thresh, 0.25);
         assert_eq!(config.det_db_box_thresh, 0.6);
         assert_eq!(config.det_db_unclip_ratio, 1.8);
+    }
+
+    #[test]
+    fn test_max_table_cells_builder() {
+        let config = PaddleOcrConfig::new("en").with_max_table_cells(Some(2000));
+        assert_eq!(config.max_table_cells, Some(2000));
+
+        let config = PaddleOcrConfig::new("en").with_max_table_cells(None);
+        assert_eq!(config.max_table_cells, None);
     }
 
     #[test]

--- a/crates/kreuzberg/src/pdf/oxide/table.rs
+++ b/crates/kreuzberg/src/pdf/oxide/table.rs
@@ -309,7 +309,12 @@ mod tests {
     fn make_span(text: &str, x: f32, y: f32) -> pdf_oxide::layout::TextSpan {
         pdf_oxide::layout::TextSpan {
             text: text.to_string(),
-            bbox: pdf_oxide::geometry::Rect { x, y, width: 50.0, height: 10.0 },
+            bbox: pdf_oxide::geometry::Rect {
+                x,
+                y,
+                width: 50.0,
+                height: 10.0,
+            },
             font_name: "Helvetica".to_string(),
             font_size: 10.0,
             font_weight: pdf_oxide::layout::FontWeight::Normal,
@@ -367,10 +372,7 @@ mod tests {
             rowspan: 1,
             mcids: vec![],
             // Same Y — right column (x=200) delivered before left column (x=10).
-            spans: vec![
-                make_span("right", 200.0, 150.0),
-                make_span("left", 10.0, 150.0),
-            ],
+            spans: vec![make_span("right", 200.0, 150.0), make_span("left", 10.0, 150.0)],
             bbox: None,
             is_header: false,
         };
@@ -398,6 +400,9 @@ mod tests {
         };
 
         let text = cell_text_in_reading_order(&cell);
-        assert_eq!(text, "hello world", "fallback must trim and collapse newlines; got: {text:?}");
+        assert_eq!(
+            text, "hello world",
+            "fallback must trim and collapse newlines; got: {text:?}"
+        );
     }
 }

--- a/crates/kreuzberg/src/pdf/structure/layout_classify.rs
+++ b/crates/kreuzberg/src/pdf/structure/layout_classify.rs
@@ -40,9 +40,7 @@ pub(crate) fn apply_layout_overrides(
         // font-size classification is more reliable than proportional position matching.
         // Proportional matching can misalign paragraphs that reorder between
         // font-clustering and RT-DETR detection. Skip applying layout hints here.
-        tracing::debug!(
-            "Skipping proportional layout overrides: structure tree pages use font-size classification"
-        );
+        tracing::debug!("Skipping proportional layout overrides: structure tree pages use font-size classification");
     }
 
     tracing::debug!(
@@ -142,7 +140,7 @@ fn matches_hint_text(hint: &LayoutHint, para_text: &str) -> bool {
                 || trimmed.starts_with('*')
                 || trimmed.starts_with('·')
         }
-        _ => true,  // no text constraint
+        _ => true, // no text constraint
     }
 }
 

--- a/crates/kreuzberg/src/pdf/structure/pipeline.rs
+++ b/crates/kreuzberg/src/pdf/structure/pipeline.rs
@@ -114,11 +114,7 @@ fn build_heading_map(
                 // Compute median font size of all blocks.
                 let mut sizes: Vec<f32> = all_blocks.iter().map(|b| b.font_size).collect();
                 sizes.sort_by(|a, b| a.total_cmp(b));
-                let median = if sizes.is_empty() {
-                    0.0
-                } else {
-                    sizes[sizes.len() / 2]
-                };
+                let median = if sizes.is_empty() { 0.0 } else { sizes[sizes.len() / 2] };
 
                 if median > 0.0 && first_font >= median * 1.2 {
                     // Promote the largest-font entry to heading_level=1.
@@ -802,6 +798,8 @@ pub(crate) struct SegmentStructureConfig<'a> {
     #[cfg(feature = "layout-detection")]
     pub table_model: crate::core::config::layout::TableModel,
     #[cfg(feature = "layout-detection")]
+    pub max_table_cells: Option<usize>,
+    #[cfg(feature = "layout-detection")]
     pub acceleration: Option<&'a crate::core::config::acceleration::AccelerationConfig>,
 }
 
@@ -827,6 +825,8 @@ pub(crate) fn extract_document_structure_from_segments(
         layout_results,
         #[cfg(feature = "layout-detection")]
         table_model,
+        #[cfg(feature = "layout-detection")]
+        max_table_cells,
         #[cfg(feature = "layout-detection")]
         acceleration,
     } = config;
@@ -1082,6 +1082,7 @@ pub(crate) fn extract_document_structure_from_segments(
                                         tp.page_height,
                                         0.5,
                                         allow_single_column,
+                                        max_table_cells,
                                     )
                                 })
                             } else {
@@ -1122,6 +1123,7 @@ pub(crate) fn extract_document_structure_from_segments(
                                         tp.page_height,
                                         0.5,
                                         allow_single_column,
+                                        max_table_cells,
                                     )
                                 })
                             }
@@ -1162,6 +1164,7 @@ pub(crate) fn extract_document_structure_from_segments(
                                         tp.page_height,
                                         0.5,
                                         allow_single_column,
+                                        max_table_cells,
                                     )
                                 })
                             } else {
@@ -1185,6 +1188,7 @@ pub(crate) fn extract_document_structure_from_segments(
                             tp.page_height,
                             0.5,
                             allow_single_column,
+                            max_table_cells,
                         ));
                     }
                 }
@@ -1203,6 +1207,7 @@ pub(crate) fn extract_document_structure_from_segments(
                         tp.page_height,
                         0.5,
                         allow_single_column,
+                        max_table_cells,
                     ));
                 }
             }
@@ -1223,6 +1228,7 @@ pub(crate) fn extract_document_structure_from_segments(
                 tp.page_height,
                 0.5,
                 allow_single_column,
+                None,
             ));
         }
     }
@@ -2395,8 +2401,9 @@ mod tests {
     #[test]
     fn test_build_heading_map_fallback_title_when_k_equals_1() {
         let title_seg = seg_with_font("Document Title", 14.0);
-        let body_segs: Vec<SegmentData> =
-            (0..4).map(|i| seg_with_font(&format!("Body paragraph {i}."), 11.0)).collect();
+        let body_segs: Vec<SegmentData> = (0..4)
+            .map(|i| seg_with_font(&format!("Body paragraph {i}."), 11.0))
+            .collect();
 
         let mut segs = vec![title_seg];
         segs.extend(body_segs);

--- a/crates/kreuzberg/src/pdf/structure/regions/tables.rs
+++ b/crates/kreuzberg/src/pdf/structure/regions/tables.rs
@@ -20,6 +20,7 @@ pub(in crate::pdf::structure) fn extract_tables_from_layout_hints(
     page_height: f32,
     min_confidence: f32,
     allow_single_column: bool,
+    max_table_cells: Option<usize>,
 ) -> Vec<Table> {
     use crate::pdf::table_reconstruct::HocrWord;
 
@@ -87,7 +88,7 @@ pub(in crate::pdf::structure) fn extract_tables_from_layout_hints(
         // Falls back to width-based scaling when not enough data.
         let table_width = hint.right - hint.left;
         let col_gap = compute_adaptive_column_gap(&table_words, table_width);
-        let table_cells = reconstruct_table(&table_words, col_gap, 0.5);
+        let table_cells = reconstruct_table(&table_words, col_gap, 0.5, max_table_cells);
 
         if table_cells.is_empty() || table_cells[0].is_empty() {
             continue;
@@ -221,6 +222,20 @@ pub(in crate::pdf::structure) fn extract_tables_from_layout_hints(
                 "table failed quality validation — skipping as prose"
             );
             continue;
+        }
+
+        // Check max_table_cells limit. If the table is too massive, skip it
+        // so it falls back to unassigned text segments (plain text).
+        if let Some(max_cells) = max_table_cells {
+            if total_cells > max_cells {
+                tracing::debug!(
+                    page = page_index,
+                    total_cells,
+                    max_cells,
+                    "table complexity threshold exceeded — skipping table hint to fallback to plain text"
+                );
+                continue;
+            }
         }
 
         // Repair broken word spacing per-cell before rendering to markdown
@@ -365,7 +380,7 @@ mod tests {
             right: 600.0,
             top: 800.0,
         }];
-        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, None);
         assert!(tables.is_empty());
     }
 
@@ -379,7 +394,7 @@ mod tests {
         ];
         let hints = vec![make_table_hint(0.3, 0.0, 0.0, 200.0, 800.0)];
         // min_confidence = 0.5, hint has 0.3 → filtered
-        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, None);
         assert!(tables.is_empty());
     }
 
@@ -388,14 +403,14 @@ mod tests {
         // Only 2 words in the region — below the 4-word minimum
         let words = vec![make_word("A", 10, 10, 50, 12), make_word("B", 100, 10, 50, 12)];
         let hints = vec![make_table_hint(0.9, 0.0, 0.0, 200.0, 800.0)];
-        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, None);
         assert!(tables.is_empty());
     }
 
     #[test]
     fn test_empty_words_returns_empty() {
         let hints = vec![make_table_hint(0.9, 0.0, 0.0, 200.0, 800.0)];
-        let tables = extract_tables_from_layout_hints(&[], &hints, 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&[], &hints, 0, 800.0, 0.5, false, None);
         assert!(tables.is_empty());
     }
 
@@ -407,7 +422,7 @@ mod tests {
             make_word("C", 10, 30, 50, 12),
             make_word("D", 100, 30, 50, 12),
         ];
-        let tables = extract_tables_from_layout_hints(&words, &[], 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &[], 0, 800.0, 0.5, false, None);
         assert!(tables.is_empty());
     }
 
@@ -422,7 +437,7 @@ mod tests {
         ];
         // Hint covers (0, 0) to (100, 100) in PDF coords → image y = 700..800
         let hints = vec![make_table_hint(0.9, 0.0, 700.0, 100.0, 800.0)];
-        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, None);
         // Words at (500, 500) don't overlap the hint → too few words → empty
         assert!(tables.is_empty());
     }
@@ -437,7 +452,7 @@ mod tests {
         ];
         // Only 3 non-empty words → below 4-word minimum
         let hints = vec![make_table_hint(0.9, 0.0, 0.0, 200.0, 800.0)];
-        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, None);
         assert!(tables.is_empty());
     }
 
@@ -455,10 +470,30 @@ mod tests {
         ];
         // Hint in PDF coords: bottom=700, top=800 → image top=0, image bottom=100
         let hints = vec![make_table_hint(0.9, 0.0, 700.0, 400.0, 800.0)];
-        let tables = extract_tables_from_layout_hints(&words, &hints, 2, 800.0, 0.5, false);
+        let tables = extract_tables_from_layout_hints(&words, &hints, 2, 800.0, 0.5, false, None);
         // If a valid table is produced, its page_number should be page_index + 1
         for table in &tables {
             assert_eq!(table.page_number, 3); // page_index=2 → page_number=3
         }
+    }
+
+    #[test]
+    fn test_max_table_cells_limit_skips_table() {
+        let words = vec![
+            make_word("Header1", 10, 10, 80, 15),
+            make_word("Header2", 200, 10, 80, 15),
+            make_word("Cell1", 10, 40, 80, 15),
+            make_word("Cell2", 200, 40, 80, 15),
+        ];
+        let hints = vec![make_table_hint(0.9, 0.0, 700.0, 400.0, 800.0)];
+
+        // This 2x2 table has 4 cells.
+        // limit = Some(4) -> allowed
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, Some(4));
+        assert_eq!(tables.len(), 1);
+
+        // limit = Some(3) -> skipped
+        let tables = extract_tables_from_layout_hints(&words, &hints, 0, 800.0, 0.5, false, Some(3));
+        assert!(tables.is_empty());
     }
 }

--- a/crates/kreuzberg/src/rendering/markdown.rs
+++ b/crates/kreuzberg/src/rendering/markdown.rs
@@ -13,10 +13,7 @@ use super::comrak_bridge::build_comrak_ast;
 ///
 /// Returns [`Cow::Borrowed`] when no replacement occurs (zero allocation).
 /// Returns [`Cow::Owned`] with one pre-sized allocation when any hit is found.
-fn unescape_backslash_sequences<'a>(
-    input: &'a str,
-    targets: &[char],
-) -> Cow<'a, str> {
+fn unescape_backslash_sequences<'a>(input: &'a str, targets: &[char]) -> Cow<'a, str> {
     // Walk byte-by-byte looking for a backslash followed by a target char.
     let bytes = input.as_bytes();
     let len = bytes.len();

--- a/crates/kreuzberg/src/table_core.rs
+++ b/crates/kreuzberg/src/table_core.rs
@@ -220,6 +220,7 @@ pub(crate) fn reconstruct_table(
     words: &[HocrWord],
     column_threshold: u32,
     row_threshold_ratio: f64,
+    max_table_cells: Option<usize>,
 ) -> Vec<Vec<String>> {
     if words.is_empty() {
         return Vec::new();
@@ -231,6 +232,19 @@ pub(crate) fn reconstruct_table(
 
     if col_positions.is_empty() || row_positions.is_empty() {
         return Vec::new();
+    }
+
+    // Complexity check: prevent memory exhaustion from massive/degenerate tables
+    if let Some(limit) = max_table_cells {
+        if col_positions.len() * row_positions.len() > limit {
+            tracing::warn!(
+                cols = col_positions.len(),
+                rows = row_positions.len(),
+                limit,
+                "Table complexity exceeded max_table_cells limit, skipping reconstruction"
+            );
+            return Vec::new();
+        }
     }
 
     // Initialize table grid
@@ -442,13 +456,61 @@ mod tests {
             },
         ];
 
-        let table = reconstruct_table(&words, 20, 0.5);
+        let table = reconstruct_table(&words, 20, 0.5, None);
         assert_eq!(table.len(), 2);
         assert_eq!(table[0].len(), 2);
         assert_eq!(table[0][0], "Name");
         assert_eq!(table[0][1], "Value");
         assert_eq!(table[1][0], "Alice");
         assert_eq!(table[1][1], "42");
+    }
+
+    #[test]
+    fn test_reconstruct_table_complexity_limit() {
+        let words = vec![
+            HocrWord {
+                text: "A".to_string(),
+                left: 100,
+                top: 50,
+                width: 20,
+                height: 30,
+                confidence: 95.0,
+            },
+            HocrWord {
+                text: "B".to_string(),
+                left: 200,
+                top: 50,
+                width: 20,
+                height: 30,
+                confidence: 95.0,
+            },
+            HocrWord {
+                text: "C".to_string(),
+                left: 100,
+                top: 100,
+                width: 20,
+                height: 30,
+                confidence: 95.0,
+            },
+            HocrWord {
+                text: "D".to_string(),
+                left: 200,
+                top: 100,
+                width: 20,
+                height: 30,
+                confidence: 95.0,
+            },
+        ];
+
+        // This would create a 2x2 table (4 cells)
+        // Set limit to 3 -> should fail
+        let table = reconstruct_table(&words, 20, 0.5, Some(3));
+        assert!(table.is_empty());
+
+        // Set limit to 4 -> should succeed
+        let table = reconstruct_table(&words, 20, 0.5, Some(4));
+        assert_eq!(table.len(), 2);
+        assert_eq!(table[0].len(), 2);
     }
 
     #[test]

--- a/crates/kreuzberg/src/types/formats.rs
+++ b/crates/kreuzberg/src/types/formats.rs
@@ -358,6 +358,10 @@ pub struct TesseractConfig {
 
     /// Use adaptive thresholding method
     pub thresholding_method: bool,
+
+    /// Maximum number of cells allowed in a reconstructed table (default: 5000).
+    /// Prevents memory exhaustion from massive or degenerate tables.
+    pub max_table_cells: Option<usize>,
 }
 
 impl Default for TesseractConfig {
@@ -388,6 +392,7 @@ impl Default for TesseractConfig {
             tessedit_use_primary_params_model: true,
             textord_space_size_is_variable: true,
             thresholding_method: false,
+            max_table_cells: Some(5000),
         }
     }
 }


### PR DESCRIPTION
`SecurityLimits::max_table_cells` was incorrectly dropped to 5,000, severely restricting the streaming extraction of CSV, XLSX, and HTML files. 

This restores the global DoS threshold to 100,000 cells. The 5,000 cell cap is explicitly maintained as a separate, soft limit for OCR reconstruction (`OcrConfig::max_table_cells`) that only applies after layout hint evaluation.

Also adds missing `max_table_cells` fields to the `kreuzberg-cli` overrides layer.


fixes #897