### PR TITLE
fix(php): make wrapper installable via plain Composer

### DIFF
--- a/packages/php/composer.json
+++ b/packages/php/composer.json
@@ -2,9 +2,12 @@
   "name": "kreuzberg-dev/kreuzberg",
   "description": "High-performance document intelligence library",
   "license": "Elastic-2.0",
-  "type": "php-ext",
+  "type": "library",
   "require": {
     "php": ">=8.2"
+  },
+  "suggest": {
+    "ext-kreuzberg": "Required at runtime. Build from crates/kreuzberg-php (cargo) or install a prebuilt .so — see https://github.com/kreuzberg-dev/kreuzberg/releases"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",
@@ -23,11 +26,6 @@
     "test": "php vendor/bin/phpunit",
     "lint": "@phpstan",
     "lint:fix": "PHP_CS_FIXER_IGNORE_ENV=1 php vendor/bin/php-cs-fixer fix && php -d detect_unicode=0 vendor/bin/phpstan --configuration=phpstan.neon --memory-limit=512M"
-  },
-  "php-ext": {
-    "extension-name": "kreuzberg",
-    "support-zts": true,
-    "support-nts": true
   },
   "keywords": ["document", "extraction", "pdf", "ocr", "text"]
 }


### PR DESCRIPTION
`type: php-ext` on Packagist forces Composer to hand off to PIE, which can't build this package — no `config.m4`, the extension is cargo-built. So `composer require kreuzberg-dev/kreuzberg` fails outright on Composer 2.7+.

Flipping the type to `library` lets the wrapper install like any other Composer package. The extension still has to be present at runtime, but that's already true today and `suggest` makes it explicit. The `php-ext.*` block is dropped because it has no effect on `type: library`.

Verified locally: `composer require kreuzberg-dev/kreuzberg` now resolves, autoload picks up `packages/php/src/` correctly, the wrapper calls into the native functions when the extension is loaded and surfaces the existing `KreuzbergException` when it isn't. No behavior change.

Out of scope: making the extension installable via PIE (would need a `config.m4` shim that invokes cargo, or PIE's newer build-cwd hooks), and publishing prebuilt `.so` artifacts per platform. Both fit better as a separate `kreuzberg-dev/kreuzberg-ext` package — happy to do that as a follow-up if you want.

Fixes #940.