### PR TITLE
refactor(cli): replace panic! with .expect() in logging setup

### DIFF
--- a/crates/kreuzberg-cli/src/logging.rs
+++ b/crates/kreuzberg-cli/src/logging.rs
@@ -72,11 +72,7 @@ pub fn build_env_filter(level_override: Option<&str>) -> EnvFilter {
                 .unwrap_or(true)
         })
         .fold(base, |filter, directive| {
-            filter.add_directive(
-                directive
-                    .parse()
-                    .unwrap_or_else(|_| panic!("BUG: invalid built-in logging directive: {directive}")),
-            )
+            filter.add_directive(directive.parse().expect("built-in logging directive must be valid"))
         })
 }
 
@@ -172,7 +168,7 @@ mod tests {
         for directive in super::QUIET_DIRECTIVES {
             directive
                 .parse::<tracing_subscriber::filter::Directive>()
-                .unwrap_or_else(|e| panic!("built-in directive '{directive}' is invalid: {e}"));
+                .expect("built-in directive is invalid");
         }
     }
 


### PR DESCRIPTION
This PR replaces several `panic!` calls in the CLI's logging initialization logic with idiomatic `.expect()` calls.

- **Rationale**: The built-in logging directives (`QUIET_DIRECTIVES`) are internal constants. If they fail to parse, it represents a programmer error (invariant violation) rather than a runtime error. Using `.expect()` with a descriptive message is the standard Rust pattern for these cases.
- **Validation**:
    - Replaced `panic!` in `build_env_filter`.
    - Updated `all_quiet_directives_are_valid` test to use `.expect()`.
    - Verified that all 11 logging unit tests pass.


closes #907