### PR TITLE
fix(pdf): MCID-tagged content dropped in markdown/html output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **MCID-tagged PDF content dropped in markdown/html output**: two
+  independent failure chains in the structured-PDF path caused content loss.
+  (1) `mark_cross_page_repeating_text` and `mark_cross_page_repeating_short_text`
+  had no first-occurrence exemption — a title block whose text also appeared as
+  a running header on later pages was furniture-marked on every page including
+  the first, silently dropping it from output. Fixed by preserving the first
+  occurrence of any repeating span, matching the exemption already present in
+  pdf_oxide's own `mark_running_artifact_spans`. (2) The OCR skip gate
+  incorrectly suppressed OCR when `fallback=true` (a per-page quality check
+  detected a scanned page): the gate now runs OCR whenever `fallback=true`,
+  regardless of aggregate character count. OCR is still skipped when the
+  pre-rendered doc is substantive and no per-page fallback is needed, or when
+  the content is non-textual.
+
 - **Email encoding data corruption (#910)**: replaced brittle 4-byte heuristic
   for UTF-16 detection in `EmailExtractor` with a robust statistical approach
   using `chardetng`. Tiny 4-byte ASCII files (e.g., binary sequences with

--- a/crates/kreuzberg/src/extractors/pdf/mod.rs
+++ b/crates/kreuzberg/src/extractors/pdf/mod.rs
@@ -289,32 +289,32 @@ impl PdfExtractor {
                 1.0
             };
 
-            let has_substantive_doc = pre_rendered_doc.is_some()
-                && total_chars >= thresholds.substantive_min_chars
-                && alnum_ws_ratio >= thresholds.alnum_ws_ratio_threshold;
-
-            let skip_ocr_for_non_text = pre_rendered_doc.is_some()
-                && total_chars >= thresholds.non_text_min_chars
-                && alnum_ws_ratio < thresholds.alnum_ws_ratio_threshold;
-
-            if skip_ocr_for_non_text {
-                tracing::debug!(
-                    alnum_ws_ratio,
-                    total_chars,
-                    alnum_ws_chars,
-                    "Skipping OCR: content is non-textual and pre-rendered structured doc available"
-                );
-                (native_text, ExtractionMethod::Native)
-            } else if has_substantive_doc {
-                tracing::debug!(
-                    total_chars,
-                    alnum_ws_ratio,
-                    ocr_fallback = decision.fallback,
-                    "Skipping OCR: pre-rendered structured doc available with substantive native text"
-                );
-                (native_text, ExtractionMethod::Native)
-            } else if decision.fallback {
-                match run_ocr_with_layout(content, config, path).await {
+            match ocr::evaluate_ocr_skip_gate(
+                pre_rendered_doc.is_some(),
+                total_chars,
+                alnum_ws_ratio,
+                decision.fallback,
+                &thresholds,
+            ) {
+                ocr::OcrGateOutcome::SkipNonText => {
+                    tracing::debug!(
+                        alnum_ws_ratio,
+                        total_chars,
+                        alnum_ws_chars,
+                        "Skipping OCR: content is non-textual and pre-rendered structured doc available"
+                    );
+                    (native_text, ExtractionMethod::Native)
+                }
+                ocr::OcrGateOutcome::SkipSubstantive => {
+                    tracing::debug!(
+                        total_chars,
+                        alnum_ws_ratio,
+                        ocr_fallback = decision.fallback,
+                        "Skipping OCR: pre-rendered structured doc available with substantive native text"
+                    );
+                    (native_text, ExtractionMethod::Native)
+                }
+                ocr::OcrGateOutcome::RunFallback => match run_ocr_with_layout(content, config, path).await {
                     Ok((ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage, ocr_pts)) => {
                         ocr_tables = ocr_tbls;
                         ocr_elements = ocr_elems;
@@ -330,9 +330,8 @@ impl PdfExtractor {
                         );
                         (native_text, ExtractionMethod::Native)
                     }
-                }
-            } else {
-                (native_text, ExtractionMethod::Native)
+                },
+                ocr::OcrGateOutcome::UseNative => (native_text, ExtractionMethod::Native),
             }
         } else {
             (native_text, ExtractionMethod::Native)
@@ -1355,5 +1354,78 @@ mod tests {
             .extract_bytes(&content, "application/pdf", &config)
             .await
             .expect("Extraction with ocr=None and ocr_inline_images=true must not panic");
+    }
+
+    /// Regression for issue #917: a mixed document with good aggregate text but a
+    /// scanned page must still reach OCR. Before the fix, `has_substantive_doc=true`
+    /// alone suppressed OCR even when `decision.fallback=true`.
+    ///
+    /// Tests `evaluate_ocr_skip_gate` directly — the function that the production
+    /// path delegates to — so that reverting `&& !decision_fallback` breaks this test.
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn test_ocr_gate_runs_ocr_when_substantive_doc_but_fallback_needed() {
+        let thresholds = OcrQualityThresholds::default();
+
+        // Inputs that reproduce the bug: pre_rendered_doc present, total_chars well
+        // above substantive_min_chars (100), good alnum_ws_ratio, but fallback=true
+        // because a scanned page was detected.
+        let outcome = ocr::evaluate_ocr_skip_gate(
+            true, // pre_rendered_doc present
+            500,  // total_chars > substantive_min_chars
+            0.9,  // alnum_ws_ratio > threshold (0.4)
+            true, // decision.fallback — scanned page detected
+            &thresholds,
+        );
+        assert_eq!(
+            outcome,
+            ocr::OcrGateOutcome::RunFallback,
+            "substantive doc must not suppress OCR when per-page fallback is needed (issue #917)"
+        );
+    }
+
+    /// Counterpart: when no per-page fallback is needed, a substantive doc correctly
+    /// skips OCR. Ensures the fix doesn't over-correct and always run OCR.
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn test_ocr_gate_skips_when_substantive_doc_and_no_fallback() {
+        let thresholds = OcrQualityThresholds::default();
+
+        let outcome = ocr::evaluate_ocr_skip_gate(
+            true,  // pre_rendered_doc present
+            500,   // total_chars > substantive_min_chars
+            0.9,   // alnum_ws_ratio > threshold
+            false, // decision.fallback — all pages look fine
+            &thresholds,
+        );
+        assert_eq!(
+            outcome,
+            ocr::OcrGateOutcome::SkipSubstantive,
+            "OCR should be skipped when doc is substantive and no per-page fallback is needed"
+        );
+    }
+
+    /// Non-textual content (charts, diagrams) with a pre-rendered structured doc
+    /// present should skip OCR regardless of the per-page fallback flag — OCR
+    /// won't improve extraction quality for non-textual pages.
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn test_ocr_gate_skips_non_textual_content_even_when_fallback_requested() {
+        let thresholds = OcrQualityThresholds::default();
+
+        // Non-textual: high char count but alnum_ws_ratio below threshold (lots of symbols).
+        // Simulate a chart-heavy page that also triggered a per-page quality check.
+        let outcome = ocr::evaluate_ocr_skip_gate(
+            true, // pre_rendered_doc present
+            500,  // total_chars > non_text_min_chars
+            0.1,  // alnum_ws_ratio < threshold — non-textual content
+            true, // decision.fallback — per-page quality check fired
+            &thresholds,
+        );
+        assert_eq!(
+            outcome,
+            ocr::OcrGateOutcome::SkipNonText,
+            "non-textual content with a structured doc must skip OCR even if fallback was requested"
+        );
     }
 }

--- a/crates/kreuzberg/src/extractors/pdf/ocr.rs
+++ b/crates/kreuzberg/src/extractors/pdf/ocr.rs
@@ -39,6 +39,54 @@ pub struct OcrFallbackDecision {
     pub fallback: bool,
 }
 
+/// Which branch the OCR skip gate selects, given pre-rendered doc presence,
+/// text statistics, and the per-page fallback decision.
+#[cfg(feature = "ocr")]
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum OcrGateOutcome {
+    /// Content is non-textual and a pre-rendered doc is available — skip OCR.
+    SkipNonText,
+    /// Pre-rendered doc is substantive and no per-page fallback is needed — skip OCR.
+    SkipSubstantive,
+    /// A per-page quality check flagged a scanned page — run OCR fallback.
+    RunFallback,
+    /// Insufficient native text or no structured doc available — use native text.
+    UseNative,
+}
+
+/// Decide whether to skip OCR, run OCR fallback, or use native text.
+///
+/// Extracted from the async PDF pipeline so the gate logic can be unit-tested
+/// independently. Fixes #917: `has_substantive_doc` alone must not suppress
+/// OCR when `decision_fallback` is true (a scanned page was detected despite
+/// good aggregate text).
+#[cfg(feature = "ocr")]
+pub(crate) fn evaluate_ocr_skip_gate(
+    pre_rendered_doc_present: bool,
+    total_chars: usize,
+    alnum_ws_ratio: f64,
+    decision_fallback: bool,
+    thresholds: &crate::core::config::OcrQualityThresholds,
+) -> OcrGateOutcome {
+    let skip_for_non_text = pre_rendered_doc_present
+        && total_chars >= thresholds.non_text_min_chars
+        && alnum_ws_ratio < thresholds.alnum_ws_ratio_threshold;
+
+    let has_substantive_doc = pre_rendered_doc_present
+        && total_chars >= thresholds.substantive_min_chars
+        && alnum_ws_ratio >= thresholds.alnum_ws_ratio_threshold;
+
+    if skip_for_non_text {
+        OcrGateOutcome::SkipNonText
+    } else if has_substantive_doc && !decision_fallback {
+        OcrGateOutcome::SkipSubstantive
+    } else if decision_fallback {
+        OcrGateOutcome::RunFallback
+    } else {
+        OcrGateOutcome::UseNative
+    }
+}
+
 #[cfg(feature = "ocr")]
 impl NativeTextStats {
     pub(crate) fn compute(text: &str, thresholds: &OcrQualityThresholds) -> Self {

--- a/crates/kreuzberg/src/pdf/structure/classify.rs
+++ b/crates/kreuzberg/src/pdf/structure/classify.rs
@@ -1087,6 +1087,9 @@ pub(super) fn mark_cross_page_repeating_text(all_pages: &mut [Vec<PdfParagraph>]
     // Count how many pages each margin text appears on (fuzzy: alphanum-only).
     let mut text_page_count: ahash::AHashMap<String, usize> = ahash::AHashMap::new();
     let mut alphanum_to_exact: ahash::AHashMap<String, ahash::AHashSet<String>> = ahash::AHashMap::new();
+    // Track the page index where each alphanum key is first seen so it can be
+    // exempted from furniture-marking (mirrors pdf_oxide's first-occurrence rule).
+    let mut first_seen_page: ahash::AHashMap<String, usize> = ahash::AHashMap::new();
 
     for (page_idx, page) in all_pages.iter().enumerate() {
         let page_h = page_heights.get(page_idx).copied().unwrap_or(792.0);
@@ -1124,7 +1127,14 @@ pub(super) fn mark_cross_page_repeating_text(all_pages: &mut [Vec<PdfParagraph>]
                 .insert(normalized.clone());
 
             if seen.insert(alphanum_key.clone()) {
-                *text_page_count.entry(alphanum_key).or_insert(0) += 1;
+                let count = text_page_count.entry(alphanum_key.clone()).or_insert(0);
+                if *count == 0 {
+                    // Collision risk: two distinct normalized texts with the same alphanum
+                    // key share one first_seen entry. This mirrors the pre-existing collision
+                    // in text_page_count and does not introduce new inaccuracy.
+                    first_seen_page.insert(alphanum_key, page_idx);
+                }
+                *count += 1;
             }
         }
     }
@@ -1154,7 +1164,8 @@ pub(super) fn mark_cross_page_repeating_text(all_pages: &mut [Vec<PdfParagraph>]
         "cross-page margin repeating text detected"
     );
 
-    // Mark matching paragraphs as furniture — only in margins.
+    // Mark matching paragraphs as furniture — only in margins, but never on the
+    // first page where the text appears (mirrors pdf_oxide's first-occurrence rule).
     for (page_idx, page) in all_pages.iter_mut().enumerate() {
         let page_h = page_heights.get(page_idx).copied().unwrap_or(792.0);
         let top_margin_y = page_h * (1.0 - margin_frac);
@@ -1173,6 +1184,10 @@ pub(super) fn mark_cross_page_repeating_text(all_pages: &mut [Vec<PdfParagraph>]
             let text = paragraph_plain_text(para);
             let normalized = text.trim().to_lowercase();
             if repeating.contains(&normalized) {
+                let alphanum_key: String = normalized.chars().filter(|c| c.is_alphanumeric()).collect();
+                if first_seen_page.get(&alphanum_key).copied() == Some(page_idx) {
+                    continue; // preserve the first occurrence
+                }
                 tracing::trace!(
                     text = %normalized.chars().take(60).collect::<String>(),
                     was_heading = ?para.heading_level,
@@ -1322,7 +1337,9 @@ pub(super) fn mark_cross_page_repeating_short_text(all_pages: &mut [Vec<PdfParag
 
     // Count how many pages each short text appears on.
     let mut text_page_count: ahash::AHashMap<String, usize> = ahash::AHashMap::new();
-    for page in all_pages.iter() {
+    // Track the page where each key first appears to exempt it from furniture-marking.
+    let mut first_seen_page: ahash::AHashMap<String, usize> = ahash::AHashMap::new();
+    for (page_idx, page) in all_pages.iter().enumerate() {
         let mut seen: ahash::AHashSet<String> = ahash::AHashSet::new();
         for para in page {
             if para.is_page_furniture {
@@ -1342,7 +1359,14 @@ pub(super) fn mark_cross_page_repeating_short_text(all_pages: &mut [Vec<PdfParag
                 continue;
             }
             if seen.insert(alphanum_key.clone()) {
-                *text_page_count.entry(alphanum_key).or_insert(0) += 1;
+                let count = text_page_count.entry(alphanum_key.clone()).or_insert(0);
+                if *count == 0 {
+                    // Collision risk: two distinct normalized texts with the same alphanum
+                    // key share one first_seen entry. This mirrors the pre-existing collision
+                    // in text_page_count and does not introduce new inaccuracy.
+                    first_seen_page.insert(alphanum_key, page_idx);
+                }
+                *count += 1;
             }
         }
     }
@@ -1365,8 +1389,9 @@ pub(super) fn mark_cross_page_repeating_short_text(all_pages: &mut [Vec<PdfParag
         "cross-page short-text repeating detection (tier 2)"
     );
 
-    // Mark matching paragraphs as furniture.
-    for page in all_pages.iter_mut() {
+    // Mark matching paragraphs as furniture, but never on the first page where
+    // the text appears (mirrors pdf_oxide's first-occurrence rule).
+    for (page_idx, page) in all_pages.iter_mut().enumerate() {
         for para in page.iter_mut() {
             if para.is_page_furniture {
                 continue;
@@ -1379,6 +1404,9 @@ pub(super) fn mark_cross_page_repeating_short_text(all_pages: &mut [Vec<PdfParag
             }
             let alphanum_key: String = normalized.chars().filter(|c| c.is_alphanumeric()).collect();
             if repeating.contains(&alphanum_key) {
+                if first_seen_page.get(&alphanum_key).copied() == Some(page_idx) {
+                    continue; // preserve the first occurrence
+                }
                 tracing::trace!(
                     text = %normalized.chars().take(60).collect::<String>(),
                     "marking repeating short text as furniture (tier 2)"
@@ -1626,8 +1654,14 @@ mod tests {
             vec![make_margin_body("Page 1 of 10"), make_body_center("Unique content D")],
         ];
         mark_cross_page_repeating_text(&mut pages, &page_heights);
-        // "Page 1 of 10" appears in the margin on all 4 pages (>50%) → furniture
-        assert!(pages[0][0].is_page_furniture);
+        // "Page 1 of 10" appears in the margin on all 4 pages (>50%) → furniture on pages 1-3.
+        // Page 0 is the first occurrence and must be preserved (first-occurrence rule, issue #917).
+        // Previously this assertion was `true` — that was the bug: the first appearance was
+        // incorrectly stripped, dropping real content from the output.
+        assert!(!pages[0][0].is_page_furniture, "first occurrence must not be furniture");
+        assert!(pages[1][0].is_page_furniture);
+        assert!(pages[2][0].is_page_furniture);
+        assert!(pages[3][0].is_page_furniture);
         assert!(!pages[0][1].is_page_furniture);
     }
 
@@ -1645,9 +1679,13 @@ mod tests {
             pages.push(vec![h, body]);
         }
         mark_cross_page_repeating_text(&mut pages, &page_heights);
-        // Headings repeating in margins on >50% of pages → furniture.
-        assert!(pages[0][0].is_page_furniture);
-        assert!(pages[0][0].heading_level.is_none());
+        // Headings repeating in margins on >50% of pages → furniture on pages 1-5.
+        // Page 0 is the first occurrence and must be preserved (issue #917).
+        // Previously this assertion was `true` — that was the bug.
+        assert!(!pages[0][0].is_page_furniture, "first occurrence must not be furniture");
+        assert!(pages[1][0].is_page_furniture);
+        assert!(pages[1][0].heading_level.is_none());
+        assert!(pages[5][0].is_page_furniture);
     }
 
     #[test]
@@ -1680,9 +1718,17 @@ mod tests {
             ],
         ];
         mark_cross_page_repeating_text(&mut pages, &page_heights);
+        // Both variants share the same alphanum key; first_seen is page 0.
+        // Page 0 is exempt (first-occurrence rule, issue #917); pages 1-5 are furniture.
+        // Previously both `pages[0][0]` and `pages[3][0]` were asserted `true` — that was
+        // the bug: the first copyright occurrence was stripped from the output.
         assert!(
-            pages[0][0].is_page_furniture,
-            "even-page copyright variant should be furniture"
+            !pages[0][0].is_page_furniture,
+            "first occurrence of copyright notice must be preserved"
+        );
+        assert!(
+            pages[1][0].is_page_furniture,
+            "subsequent even-page copyright variant should be furniture"
         );
         assert!(
             pages[3][0].is_page_furniture,
@@ -2313,5 +2359,63 @@ mod tests {
             paragraphs[0].heading_level, None,
             "bold mixed-case with colon should not be promoted"
         );
+    }
+
+    // ── Issue #917: first-occurrence exemption for repeating text ──
+
+    /// A title block that also appears as a running header on subsequent pages must
+    /// NOT be marked as furniture on the first page where it occurs.
+    /// Regression test for #917: MCID-tagged title dropped in markdown/html output.
+    #[test]
+    fn test_cross_page_repeating_text_preserves_first_occurrence() {
+        // 6 pages: the title text appears in the top margin of every page.
+        // Pages 1-5: running header (furniture). Page 0: actual title (must be kept).
+        let page_heights = vec![792.0_f32; 6];
+        let title = "Analysis of Thermodynamic Properties";
+        let mut pages: Vec<Vec<PdfParagraph>> = (0..6)
+            .map(|_| vec![make_margin_body(title), make_body_center("body text here")])
+            .collect();
+        mark_cross_page_repeating_text(&mut pages, &page_heights);
+
+        assert!(
+            !pages[0][0].is_page_furniture,
+            "first occurrence of title on page 0 must be preserved (issue #917)"
+        );
+        for i in 1..6 {
+            assert!(
+                pages[i][0].is_page_furniture,
+                "page {i} running header should be furniture"
+            );
+        }
+        // Body text on every page must never be touched
+        for i in 0..6 {
+            assert!(
+                !pages[i][1].is_page_furniture,
+                "body text on page {i} must not be furniture"
+            );
+        }
+    }
+
+    /// Short-text tier-2 detection must also exempt the first occurrence of repeating text.
+    /// Regression test for #917: short title paragraphs dropped in markdown/html output.
+    #[test]
+    fn test_cross_page_repeating_short_text_preserves_first_occurrence() {
+        // 5 pages (minimum for tier-2 to run): short title repeats on all pages.
+        let title = "Kreuzberg Conference Proceedings 2024";
+        let mut pages: Vec<Vec<PdfParagraph>> = (0..5)
+            .map(|_| vec![make_margin_body(title), make_body_center("section body")])
+            .collect();
+        mark_cross_page_repeating_short_text(&mut pages);
+
+        assert!(
+            !pages[0][0].is_page_furniture,
+            "first occurrence of short repeating title must be preserved (issue #917)"
+        );
+        for i in 1..5 {
+            assert!(
+                pages[i][0].is_page_furniture,
+                "page {i} short repeating text should be furniture"
+            );
+        }
     }
 }


### PR DESCRIPTION
  Two independent failure chains both originate from the needs_structured flag that activates the pre-rendered document path for markdown/djot/html output.

  **root cause a: furniture over-marking (`classify.rs`)**
  mark_cross_page_repeating_text and mark_cross_page_repeating_short_text had no first-occurrence exemption. A title block whose text also appears as a running header on subsequent pages was furniture-marked on all pages, including the first, silently dropping it from the output. pdf_oxide's own `mark_running_artifact_spans` already has this exemption,.. this change aligns kreuzberg's classifier with it. Three existing test assertions were encoding the buggy behaviour and have been corrected.

  **root cause b: OCR suppressed on mixed documents (`mod.rs, ocr.rs`)**
  `has_substantive_doc = true` (enough aggregate native text) was sufficient to skip OCR entirely, even when `decision.fallback = true` (a per-page quality check had flagged a scanned page). Scanned pages in otherwise text-layer documents never received OCR. Fix: gate becomes `has_substantive_doc && !decision.fallback`. The decision logic is extracted into` ocr::evaluate_ocr_skip_gate` so it can be tested without the async pipeline; two tests cover both the bug and its non-regression.

  Why both fixes ship together:  Fix #917 by including both components needed to reproduce the end-to-end behavior: a document with a title-as-header and a scanned page.