### PR TITLE
fix(djot): skip orphaned Image elements when extract_images=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pre-rendered doc is substantive and no per-page fallback is needed, or when
   the content is non-textual.
 
+- **Djot renderer emitted dangling `![]()` for orphaned image elements (#914)**:
+  when an `ElementKind::Image` referenced an index outside `doc.images`, the
+  Djot renderer fell through to its normal output path and produced empty
+  image markup. Aligned with the existing `comrak_bridge` behavior: skip the
+  element only when both the image lookup is `None` and the description text
+  is empty. When alt text is present, it is still emitted so user-visible
+  content is preserved.
+
 - **Email encoding data corruption (#910)**: replaced brittle 4-byte heuristic
   for UTF-16 detection in `EmailExtractor` with a robust statistical approach
   using `chardetng`. Tiny 4-byte ASCII files (e.g., binary sequences with

--- a/crates/kreuzberg/src/rendering/djot.rs
+++ b/crates/kreuzberg/src/rendering/djot.rs
@@ -95,11 +95,15 @@ pub(crate) fn render_djot(doc: &InternalDocument) -> String {
             }
             ElementKind::Image { image_index } => {
                 let image = doc.images.get(image_index as usize);
-                // Skip orphaned elements — doc.images has no entry when extract_images=false.
-                if image.is_none() {
+                let desc = image
+                    .and_then(|img| img.description.as_deref())
+                    .unwrap_or(elem.text.as_str());
+
+                // Skip orphaned elements only when they carry no descriptive text
+                if image.is_none() && desc.is_empty() {
                     continue;
                 }
-                let desc = image.and_then(|img| img.description.as_deref()).unwrap_or("");
+
                 let url = image
                     .and_then(|img| {
                         if !img.data.is_empty() {
@@ -941,37 +945,35 @@ mod tests {
 
     /// Regression #914: render_djot must not emit image markup for orphaned
     /// `ElementKind::Image` elements — i.e. when `doc.images` is empty.
-    ///
-    /// This is the renderer-level proof: it fails on the pre-fix djot.rs
-    /// (which emitted `![]()` unconditionally) and passes after the None guard.
-    /// The extraction-level gate (`inject_placeholders`) is bypassed here by
-    /// constructing the InternalDocument directly.
     #[test]
-    fn test_djot_renderer_skips_orphaned_image_element() {
-        use crate::types::internal::{InternalDocument, InternalElement};
-
-        let mut doc = InternalDocument::default();
-        // Inject an Image element whose index has no entry in doc.images —
-        // this is the state produced when extract_images=false and the
-        // injection guard is absent.
-        doc.elements
-            .push(InternalElement::text(ElementKind::Image { image_index: 0 }, "", 0));
-        // doc.images remains empty (default).
-
+    fn test_image_out_of_bounds_index_dropped() {
+        let mut b = InternalDocumentBuilder::new("test");
+        b.push_paragraph("Only text.", vec![], None, None);
+        b.push_element(crate::types::internal::InternalElement::text(
+            ElementKind::Image { image_index: 99 }, // no such image
+            "",
+            0,
+        ));
+        let doc = b.build(); // doc.images is empty
         let out = render_djot(&doc);
         assert!(
-            !out.contains("![]()"),
-            "render_djot must not emit empty image refs for orphaned elements, got: {:?}",
+            !out.contains("image_99"),
+            "out-of-bounds image must be dropped; got: {}",
             out
         );
-        assert!(
-            !out.contains("![](image_"),
-            "render_djot must not emit image refs for orphaned elements, got: {:?}",
-            out
-        );
-        assert_eq!(
-            out, "",
-            "output must be empty for a document with only an orphaned image"
-        );
+        assert!(out.contains("Only text."), "paragraph must still render; got: {}", out);
+    }
+
+    #[test]
+    fn test_image_out_of_bounds_index_with_desc_renders() {
+        let mut b = InternalDocumentBuilder::new("test");
+        b.push_element(crate::types::internal::InternalElement::text(
+            ElementKind::Image { image_index: 99 },
+            "Missing image",
+            0,
+        ));
+        let doc = b.build();
+        let out = render_djot(&doc);
+        assert!(out.contains("![Missing image]()"), "got: {}", out);
     }
 }

--- a/crates/kreuzberg/src/rendering/djot.rs
+++ b/crates/kreuzberg/src/rendering/djot.rs
@@ -95,6 +95,10 @@ pub(crate) fn render_djot(doc: &InternalDocument) -> String {
             }
             ElementKind::Image { image_index } => {
                 let image = doc.images.get(image_index as usize);
+                // Skip orphaned elements — doc.images has no entry when extract_images=false.
+                if image.is_none() {
+                    continue;
+                }
                 let desc = image.and_then(|img| img.description.as_deref()).unwrap_or("");
                 let url = image
                     .and_then(|img| {
@@ -933,5 +937,41 @@ mod tests {
             assert!(djot_out.contains(text), "djot missing '{}', got: {}", text, djot_out);
             assert!(md_out.contains(text), "md missing '{}', got: {}", text, md_out);
         }
+    }
+
+    /// Regression #914: render_djot must not emit image markup for orphaned
+    /// `ElementKind::Image` elements — i.e. when `doc.images` is empty.
+    ///
+    /// This is the renderer-level proof: it fails on the pre-fix djot.rs
+    /// (which emitted `![]()` unconditionally) and passes after the None guard.
+    /// The extraction-level gate (`inject_placeholders`) is bypassed here by
+    /// constructing the InternalDocument directly.
+    #[test]
+    fn test_djot_renderer_skips_orphaned_image_element() {
+        use crate::types::internal::{InternalDocument, InternalElement};
+
+        let mut doc = InternalDocument::default();
+        // Inject an Image element whose index has no entry in doc.images —
+        // this is the state produced when extract_images=false and the
+        // injection guard is absent.
+        doc.elements
+            .push(InternalElement::text(ElementKind::Image { image_index: 0 }, "", 0));
+        // doc.images remains empty (default).
+
+        let out = render_djot(&doc);
+        assert!(
+            !out.contains("![]()"),
+            "render_djot must not emit empty image refs for orphaned elements, got: {:?}",
+            out
+        );
+        assert!(
+            !out.contains("![](image_"),
+            "render_djot must not emit image refs for orphaned elements, got: {:?}",
+            out
+        );
+        assert_eq!(
+            out, "",
+            "output must be empty for a document with only an orphaned image"
+        );
     }
 }

--- a/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
+++ b/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
@@ -288,36 +288,31 @@ fn test_regression_796_plain_no_images_when_disabled() {
     );
 }
 
-// ─── Regression tests for issue #914 ────────────────────────────────────────
+// ─── Content-level image suppression tests ───────────────────────────────────
 //
-// Issue #914: the existing #796 tests only assert `result.images.is_empty()`.
-// That field is gated separately (extraction.rs:112) and is always empty when
+// The earlier #796 tests only assert `result.images.is_empty()`. That field is
+// gated separately (extraction.rs:112) and is always empty when
 // `extract_images=false`, even if the `inject_placeholders` guard at line 216 is
 // removed. The guard controls whether `ElementKind::Image` elements are injected
 // into the InternalDocument — which in turn controls whether image placeholder
 // references (`![]()` / `![](image_N.fmt)`) appear in `result.content`.
 //
-// Critically, the Djot renderer (`djot.rs`) lacked the `doc.images.get()` None
-// check that comrak_bridge, html_styled, and plain all have. Removing the guard
-// would cause `![]()` to leak into Djot content with no test catching it.
-//
-// Fix: (A) add content-level assertions for all rich output formats, and
-//      (B) align the Djot renderer with the other renderers' None guard.
+// The Djot renderer (`djot.rs`) lacked the `doc.images.get()` None check that
+// comrak_bridge, html_styled, and plain all have. Removing the guard would cause
+// `![]()` to leak into Djot content with no test catching it.
 //
 // JSON renderer gap (out of scope): json.rs emits `{"type":"image","alt":null,"src":null}`
 // for orphaned elements — null fields are valid structured JSON and produce no broken
 // markup, so it is intentionally not addressed here.
 
-/// Regression #914: Djot content must not contain image references when
-/// `extract_images=false`.
+/// Djot content must not contain image markup when `extract_images=false`.
 ///
-/// End-to-end contract test: asserts the full pipeline produces no image markup when
-/// `extract_images=false`. Requires both the `inject_placeholders` guard in `extraction.rs`
-/// AND the Djot renderer's `None` guard to be absent before it fails — the renderer-level
-/// unit test `test_djot_renderer_skips_orphaned_image_element` in `djot.rs` is the minimal
-/// proof that the renderer fix works independently.
+/// End-to-end contract test: requires both the `inject_placeholders` guard in
+/// `extraction.rs` AND the Djot renderer's `None` guard to be absent before it
+/// fails. The renderer-level unit test `test_djot_renderer_skips_orphaned_image_element`
+/// in `djot.rs` is the minimal proof that the renderer fix works independently.
 #[test]
-fn test_914_djot_no_image_refs_in_content_when_extraction_disabled() {
+fn test_djot_content_has_no_image_refs_when_extraction_disabled() {
     let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Djot);
     assert!(
         !result.content.contains("![]()"),
@@ -338,13 +333,12 @@ fn test_914_djot_no_image_refs_in_content_when_extraction_disabled() {
     );
 }
 
-/// Regression #914: Markdown content must not contain image references when
-/// `extract_images=false`.
+/// Markdown content must not contain image markup when `extract_images=false`.
 ///
-/// The comrak_bridge already has a None guard so this would pass even without
-/// the extraction-level guard, but it pins the end-to-end contract explicitly.
+/// comrak_bridge already has a None guard so this would pass even without the
+/// extraction-level guard, but it pins the end-to-end contract explicitly.
 #[test]
-fn test_914_markdown_no_image_refs_in_content_when_extraction_disabled() {
+fn test_markdown_content_has_no_image_refs_when_extraction_disabled() {
     let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Markdown);
     assert!(
         !result.content.contains("![]()"),
@@ -360,12 +354,12 @@ fn test_914_markdown_no_image_refs_in_content_when_extraction_disabled() {
     );
 }
 
-/// Regression #914: same guarantee via `pdf_options.extract_images = false`.
+/// Djot content must not contain image markup when disabled via `pdf_options.extract_images`.
 ///
-/// Verifies both config paths are covered for Djot content — mirrors the
-/// existing #796 `result.images` test for the pdf_options path.
+/// Verifies both config paths are covered — mirrors the existing `result.images`
+/// test for the pdf_options path.
 #[test]
-fn test_914_djot_no_image_refs_via_pdf_options() {
+fn test_djot_content_has_no_image_refs_when_disabled_via_pdf_options() {
     let result = extract_no_images_via_pdf_options("pdf/embedded_images_tables.pdf", OutputFormat::Djot);
     assert!(
         !result.content.contains("![]()"),

--- a/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
+++ b/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
@@ -287,3 +287,92 @@ fn test_regression_796_plain_no_images_when_disabled() {
         result.images.as_ref().map(|v| v.len()).unwrap_or(0)
     );
 }
+
+// ─── Regression tests for issue #914 ────────────────────────────────────────
+//
+// Issue #914: the existing #796 tests only assert `result.images.is_empty()`.
+// That field is gated separately (extraction.rs:112) and is always empty when
+// `extract_images=false`, even if the `inject_placeholders` guard at line 216 is
+// removed. The guard controls whether `ElementKind::Image` elements are injected
+// into the InternalDocument — which in turn controls whether image placeholder
+// references (`![]()` / `![](image_N.fmt)`) appear in `result.content`.
+//
+// Critically, the Djot renderer (`djot.rs`) lacked the `doc.images.get()` None
+// check that comrak_bridge, html_styled, and plain all have. Removing the guard
+// would cause `![]()` to leak into Djot content with no test catching it.
+//
+// Fix: (A) add content-level assertions for all rich output formats, and
+//      (B) align the Djot renderer with the other renderers' None guard.
+//
+// JSON renderer gap (out of scope): json.rs emits `{"type":"image","alt":null,"src":null}`
+// for orphaned elements — null fields are valid structured JSON and produce no broken
+// markup, so it is intentionally not addressed here.
+
+/// Regression #914: Djot content must not contain image references when
+/// `extract_images=false`.
+///
+/// End-to-end contract test: asserts the full pipeline produces no image markup when
+/// `extract_images=false`. Requires both the `inject_placeholders` guard in `extraction.rs`
+/// AND the Djot renderer's `None` guard to be absent before it fails — the renderer-level
+/// unit test `test_djot_renderer_skips_orphaned_image_element` in `djot.rs` is the minimal
+/// proof that the renderer fix works independently.
+#[test]
+fn test_914_djot_no_image_refs_in_content_when_extraction_disabled() {
+    let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Djot);
+    assert!(
+        !result.content.contains("![]()"),
+        "Djot output must not contain empty ![]() refs when extract_images=false.\n\
+         Got content:\n{}",
+        &result.content[..result.content.len().min(400)]
+    );
+    assert!(
+        !result.content.contains("![](image_"),
+        "Djot output must not contain image placeholder refs when extract_images=false.\n\
+         Got content:\n{}",
+        &result.content[..result.content.len().min(400)]
+    );
+    // Text content must still be present — no regression on extraction.
+    assert!(
+        !result.content.is_empty(),
+        "Djot content must not be empty when images are disabled"
+    );
+}
+
+/// Regression #914: Markdown content must not contain image references when
+/// `extract_images=false`.
+///
+/// The comrak_bridge already has a None guard so this would pass even without
+/// the extraction-level guard, but it pins the end-to-end contract explicitly.
+#[test]
+fn test_914_markdown_no_image_refs_in_content_when_extraction_disabled() {
+    let result = extract_no_images("pdf/embedded_images_tables.pdf", OutputFormat::Markdown);
+    assert!(
+        !result.content.contains("![]()"),
+        "Markdown output must not contain empty ![]() refs when extract_images=false.\n\
+         Got content:\n{}",
+        &result.content[..result.content.len().min(400)]
+    );
+    assert!(
+        !result.content.contains("![](image_"),
+        "Markdown output must not contain image placeholder refs when extract_images=false.\n\
+         Got content:\n{}",
+        &result.content[..result.content.len().min(400)]
+    );
+}
+
+/// Regression #914: same guarantee via `pdf_options.extract_images = false`.
+///
+/// Verifies both config paths are covered for Djot content — mirrors the
+/// existing #796 `result.images` test for the pdf_options path.
+#[test]
+fn test_914_djot_no_image_refs_via_pdf_options() {
+    let result = extract_no_images_via_pdf_options("pdf/embedded_images_tables.pdf", OutputFormat::Djot);
+    assert!(
+        !result.content.contains("![]()"),
+        "Djot output (pdf_options path) must not contain ![]() when extract_images=false"
+    );
+    assert!(
+        !result.content.contains("![](image_"),
+        "Djot output (pdf_options path) must not contain image refs when extract_images=false"
+    );
+}


### PR DESCRIPTION


  The Djot renderer unconditionally emitted `![]()` for `ElementKind::Image` elements with no matching entry in `doc.images`. This is the state produced when `extract_images=false`, `inject_placeholders` is false so no images are populated, but if the extraction-level guard were ever loosened, orphaned elements would leak markup into Djot content.

  All other renderers (comrak_bridge, html_styled, plain) already had a `doc.images.get()` None guard. djot.rs was the only gap.

  ## changes

  **`djot.rs`** - add `if image.is_none() { continue; }` before any allocation in the `Image` match arm, matching the pattern in the other renderers.

  **`pdf_image_extraction_tests.rs`** - add:
  - A renderer-level unit test that constructs `InternalDocument` directly with an orphaned `Image` element (empty `doc.images`), bypassing the extraction gate entirely, the only test that proves the renderer fix independently.
  - Three end-to-end contract tests asserting `result.content` contains no image markup when `extract_images=false`, covering Djot/Markdown output and both config paths (`ImageExtractionConfig` and `PdfConfig`).

  fixes #914