### PR TITLE
fix(pdf): eliminate unconditional image decompression pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Only legitimate WASM/Rust platform-imposed skips remain (7× WASM-async,
   1× Rust-missing-file-path).
 
+### Fixed (#985 pdf image extraction hang)
+
+- **PDF image extraction hang on dense pages (#985)**: `extract_image_positions`
+  previously ran a full decompression pass over every page unconditionally — even
+  when `extract_images=false` — causing multi-minute hangs on PDFs with many image
+  objects per page (e.g. InDesign/Acrobat exports). The pre-pass is eliminated;
+  image positions are now derived from the capped extraction result, so the
+  decompression path is skipped entirely when images are not requested. Also adds
+  cancellation-token support inside `extract_images_with_data` so
+  `extraction_timeout_secs` can interrupt multi-page extraction between pages, and
+  inside the inline-OCR image loop so a timeout can interrupt per-image OCR.
+
+  `max_images_per_page` now bounds decompression for XObject images: the pdf_oxide
+  backend enumerates the page XObject resource dictionary and stops decompressing
+  after `limit` images, avoiding the eager cost of `extract_images()` for images
+  beyond the cap. Inline images (`BI`/`EI` content-stream operators) fall back to
+  the eager path with a `.take(limit)` guard; full inline-image support is tracked
+  in #989.
+
+- **`kreuzberg::utils::pool` API simplified**: `Pool::acquire()` is now infallible
+  — it returns `PoolGuard<T>` directly instead of `Result<PoolGuard<T>, PoolError>`.
+  `PoolError` is removed. `parking_lot::Mutex` cannot poison, so the `Result`
+  wrapper was dead code. `Pool`, `PoolGuard`, `Recyclable`, `StringBufferPool`, and
+  `ByteBufferPool` are marked `#[doc(hidden)]` — they were technically reachable via
+  `kreuzberg::utils::pool` but were never part of the stable public API.
+
 ### Added
 
 - **`kreuzberg` crate root**: plugin_api surface (`list_*`, `clear_*`, `register_*`,

--- a/crates/kreuzberg/src/core/batch_optimizations.rs
+++ b/crates/kreuzberg/src/core/batch_optimizations.rs
@@ -18,7 +18,6 @@
 
 use crate::utils::pool::{ByteBufferPool, StringBufferPool, create_byte_buffer_pool, create_string_buffer_pool};
 use crate::utils::pool_sizing::PoolSizeHint;
-use crate::{KreuzbergError, Result};
 use parking_lot::Mutex;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -221,20 +220,13 @@ impl BatchProcessor {
     ///
     /// Useful for memory-constrained environments or to reclaim memory
     /// after processing large batches.
-    pub fn clear_pools(&self) -> Result<()> {
-        let pool_opt = self.string_pool.lock();
-        if let Some(pool) = pool_opt.as_ref() {
-            pool.clear()
-                .map_err(|e| KreuzbergError::Other(format!("string pool error: {}", e)))?;
+    pub fn clear_pools(&self) {
+        if let Some(pool) = self.string_pool.lock().as_ref() {
+            pool.clear();
         }
-
-        let pool_opt = self.byte_pool.lock();
-        if let Some(pool) = pool_opt.as_ref() {
-            pool.clear()
-                .map_err(|e| KreuzbergError::Other(format!("byte pool error: {}", e)))?;
+        if let Some(pool) = self.byte_pool.lock().as_ref() {
+            pool.clear();
         }
-
-        Ok(())
     }
 }
 
@@ -276,12 +268,12 @@ mod tests {
         let pool = processor.string_pool();
 
         {
-            let mut s = pool.acquire().unwrap();
+            let mut s = pool.acquire();
             s.push_str("test");
         }
 
         {
-            let s = pool.acquire().unwrap();
+            let s = pool.acquire();
             assert_eq!(s.len(), 0);
         }
     }
@@ -292,12 +284,12 @@ mod tests {
         let pool = processor.byte_pool();
 
         {
-            let mut buf = pool.acquire().unwrap();
+            let mut buf = pool.acquire();
             buf.extend_from_slice(b"test");
         }
 
         {
-            let buf = pool.acquire().unwrap();
+            let buf = pool.acquire();
             assert_eq!(buf.len(), 0);
         }
     }
@@ -306,8 +298,8 @@ mod tests {
     fn test_batch_processor_clear_pools() {
         let processor = BatchProcessor::new();
 
-        let s1 = processor.string_pool().acquire().unwrap();
-        let s2 = processor.byte_pool().acquire().unwrap();
+        let s1 = processor.string_pool().acquire();
+        let s2 = processor.byte_pool().acquire();
 
         drop(s1);
         drop(s2);
@@ -315,7 +307,7 @@ mod tests {
         assert!(processor.string_pool_size() > 0);
         assert!(processor.byte_pool_size() > 0);
 
-        processor.clear_pools().unwrap();
+        processor.clear_pools();
 
         assert_eq!(processor.string_pool_size(), 0);
         assert_eq!(processor.byte_pool_size(), 0);

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -92,15 +92,8 @@ pub(crate) fn extract_all_from_oxide_document(
         None
     };
 
-    // --- Image positions for assembly pipeline ---
-    let image_positions = crate::pdf::oxide::images::extract_image_positions(&mut doc).map_err(|e| {
-        crate::error::KreuzbergError::Parsing {
-            message: format!("pdf_oxide image position extraction failed: {e}"),
-            source: None,
-        }
-    })?;
-
     // --- Extracted images (data + OCR) ---
+    // Positions are derived from extracted data — no separate decompression pass needed.
     let images_extraction_enabled = config.images.as_ref().map(|c| c.extract_images).unwrap_or(false)
         || config.pdf_options.as_ref().map(|p| p.extract_images).unwrap_or(false);
 
@@ -110,15 +103,15 @@ pub(crate) fn extract_all_from_oxide_document(
         .map(|p| p.ocr_inline_images)
         .unwrap_or(false);
 
-    let images = if images_extraction_enabled || ocr_inline_images {
+    let (images, image_positions) = if images_extraction_enabled || ocr_inline_images {
         let max_images = config.images.as_ref().and_then(|i| i.max_images_per_page);
         #[cfg_attr(not(feature = "ocr"), allow(unused_mut))]
-        let mut extracted = crate::pdf::oxide::images::extract_images_with_data(&mut doc, max_images).map_err(|e| {
-            crate::error::KreuzbergError::Parsing {
-                message: format!("pdf_oxide image extraction failed: {e}"),
-                source: None,
-            }
-        })?;
+        let mut extracted =
+            crate::pdf::oxide::images::extract_images_with_data(&mut doc, max_images, config.cancel_token.as_ref())
+                .map_err(|e| crate::error::KreuzbergError::Parsing {
+                    message: format!("pdf_oxide image extraction failed: {e}"),
+                    source: None,
+                })?;
 
         // Perform OCR on extracted images if enabled
         if ocr_inline_images && !extracted.is_empty() {
@@ -139,6 +132,9 @@ pub(crate) fn extract_all_from_oxide_document(
                     .unwrap_or_default();
 
                 for img in &mut extracted {
+                    if config.cancel_token.as_ref().is_some_and(|t| t.is_cancelled()) {
+                        break;
+                    }
                     let internal_config: crate::ocr::types::TesseractConfig = (&tesseract_config).into();
                     match ocr_processor.process_image(&img.data, &internal_config) {
                         Ok(ocr_result) => {
@@ -156,9 +152,15 @@ pub(crate) fn extract_all_from_oxide_document(
                 }
             }
         }
-        Some(extracted)
+        // Derive positions from the capped set — no second decompression pass.
+        let positions: Vec<(u32, u32)> = extracted
+            .iter()
+            .map(|img| (img.page_number.unwrap_or(1), img.image_index))
+            .collect();
+        (Some(extracted), positions)
     } else {
-        None
+        // inject_placeholders is gated on images_extraction_enabled, so empty is correct.
+        (None, Vec::new())
     };
 
     if config.cancel_token.as_ref().is_some_and(|t| t.is_cancelled()) {
@@ -213,8 +215,6 @@ pub(crate) fn extract_all_from_oxide_document(
             // Same gate as the oxide path: only inject placeholders when image extraction
             // is explicitly enabled. Prevents base64 data from leaking into results when
             // the caller sets extract_images=false (fixes #796).
-            let images_extraction_enabled = config.images.as_ref().map(|c| c.extract_images).unwrap_or(false)
-                || config.pdf_options.as_ref().map(|p| p.extract_images).unwrap_or(false);
             let inject_placeholders =
                 images_extraction_enabled && config.images.as_ref().map(|c| c.inject_placeholders).unwrap_or(false);
 

--- a/crates/kreuzberg/src/pdf/oxide/images.rs
+++ b/crates/kreuzberg/src/pdf/oxide/images.rs
@@ -4,54 +4,142 @@
 //! actual image data and metadata.
 
 use super::OxideDocument;
+use crate::cancellation::CancellationToken;
 use crate::pdf::error::{PdfError, Result};
 use bytes::Bytes;
 use std::borrow::Cow;
 
-/// Extract image positions from all pages for interleaving into the assembly pipeline.
+/// Extract at most `limit` images from a page by walking its XObject resource dictionary.
 ///
-/// Calls `doc.doc.extract_images(page_idx)` for each page and creates an
-/// `(page_number, image_index)` pair for each image found. These positions
-/// are used by the assembly pipeline to insert image placeholders into the
-/// document structure.
+/// Unlike `doc.doc.extract_images(page_idx)` which decompresses every image on the page
+/// before returning, this function stops after `limit` successful decompressions, avoiding
+/// the eager-API cost for images beyond the cap.
 ///
-/// # Arguments
+/// **Trade-offs vs. `extract_images()`**:
+/// - Does not cover inline images (`BI`/`EI` content stream operators). Those are rare in
+///   practice for PDFs that embed large numbers of images.
+/// - Uses XObject resource dictionary order sorted alphabetically for determinism.
+///   Content stream `Do`-operator order may differ.
 ///
-/// * `doc` - Mutable reference to the oxide document
-///
-/// # Returns
-///
-/// A `Vec<(u32, u32)>` of (1-indexed page number, global image index) pairs.
-pub(crate) fn extract_image_positions(doc: &mut OxideDocument) -> Result<Vec<(u32, u32)>> {
-    let page_count = doc
-        .doc
-        .page_count()
-        .map_err(|e| PdfError::MetadataExtractionFailed(format!("pdf_oxide: failed to get page count: {e}")))?;
+/// On any error accessing the resource dictionary the function returns an empty vec.
+/// The caller may then fall back to the full eager path.
+fn extract_n_images_from_xobject_resources(
+    doc: &OxideDocument,
+    page_idx: usize,
+    limit: usize,
+) -> Result<Vec<pdf_oxide::extractors::PdfImage>> {
+    let resources = match doc.doc.get_page_resources(page_idx) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(page = page_idx, "get_page_resources failed: {e}");
+            return Ok(Vec::new());
+        }
+    };
 
-    let mut positions = Vec::new();
-    let mut global_index = 0u32;
+    let res_dict = match resources.as_dict() {
+        Some(d) => d,
+        None => return Ok(Vec::new()),
+    };
 
-    for page_idx in 0..page_count {
-        let oxide_images = match doc.doc.extract_images(page_idx) {
-            Ok(images) => images,
+    let xobj_entry = match res_dict.get("XObject") {
+        Some(x) => x,
+        None => return Ok(Vec::new()),
+    };
+
+    // Resolve the XObject dictionary (it may be an indirect reference).
+    let xobj_owned;
+    let xobj_obj = if let Some(r) = xobj_entry.as_reference() {
+        match doc.doc.load_object(r) {
+            Ok(o) => {
+                xobj_owned = o;
+                &xobj_owned
+            }
+            Err(e) => {
+                tracing::debug!(page = page_idx, "load XObject dict ref failed: {e}");
+                return Ok(Vec::new());
+            }
+        }
+    } else {
+        xobj_entry
+    };
+
+    let xobj_dict = match xobj_obj.as_dict() {
+        Some(d) => d,
+        None => return Ok(Vec::new()),
+    };
+
+    // Collect and sort keys for deterministic ordering across calls.
+    let mut names: Vec<String> = xobj_dict.keys().cloned().collect();
+    names.sort();
+
+    let mut images = Vec::new();
+
+    for name in &names {
+        if images.len() >= limit {
+            break;
+        }
+
+        let val = match xobj_dict.get(name.as_str()) {
+            Some(v) => v,
+            None => continue,
+        };
+
+        let obj_ref = val.as_reference();
+
+        // Fast skip: is_form_xobject peeks at /Subtype without loading the stream.
+        // Returns true for Form XObjects (and conservatively for unknowns) so that
+        // we do not waste a load_object call on non-image XObjects.
+        if let Some(r) = obj_ref
+            && doc.doc.is_form_xobject(r)
+        {
+            continue;
+        }
+
+        // Load the XObject: fetches the stream dictionary + compressed bytes.
+        // Decompression (the expensive step) happens inside extract_image_from_xobject.
+        let loaded;
+        let xobj = if let Some(r) = obj_ref {
+            match doc.doc.load_object(r) {
+                Ok(o) => {
+                    loaded = o;
+                    &loaded
+                }
+                Err(e) => {
+                    tracing::debug!(page = page_idx, xobject = %name, "load XObject failed: {e}");
+                    continue;
+                }
+            }
+        } else {
+            val
+        };
+
+        // Guard: verify /Subtype = /Image before decompressing. is_form_xobject
+        // returns true (conservative) for some non-Image types, so this check
+        // filters those that slipped through.
+        if xobj.as_dict().and_then(|d| d.get("Subtype")).and_then(|s| s.as_name()) != Some("Image") {
+            continue;
+        }
+
+        // Decompress. This is the expensive step — it happens at most `limit` times
+        // per page, which is what this function is designed to guarantee.
+        match pdf_oxide::extractors::extract_image_from_xobject(
+            Some(&doc.doc),
+            xobj,
+            obj_ref,
+            None, // color_space_map: document-level resolution via doc
+        ) {
+            Ok(img) => images.push(img),
             Err(e) => {
                 tracing::debug!(
                     page = page_idx,
-                    "pdf_oxide: failed to extract images for positions: {e}"
+                    xobject = %name,
+                    "image decompression failed: {e}"
                 );
-                continue;
             }
-        };
-
-        let page_number = (page_idx + 1) as u32; // Kreuzberg uses 1-indexed page numbers
-
-        for _img in &oxide_images {
-            positions.push((page_number, global_index));
-            global_index += 1;
         }
     }
 
-    Ok(positions)
+    Ok(images)
 }
 
 /// Extract full image data from all pages of a PDF.
@@ -63,6 +151,7 @@ pub(crate) fn extract_image_positions(doc: &mut OxideDocument) -> Result<Vec<(u3
 ///
 /// * `doc` - Mutable reference to the oxide document
 /// * `max_images_per_page` - Optional limit on images per page
+/// * `cancel_token` - Optional cancellation token checked between pages
 ///
 /// # Returns
 ///
@@ -70,7 +159,19 @@ pub(crate) fn extract_image_positions(doc: &mut OxideDocument) -> Result<Vec<(u3
 pub(crate) fn extract_images_with_data(
     doc: &mut OxideDocument,
     max_images_per_page: Option<u32>,
+    cancel_token: Option<&CancellationToken>,
 ) -> Result<Vec<crate::types::ExtractedImage>> {
+    // When the cap is zero no image can ever pass through — skip decompression entirely.
+    if max_images_per_page == Some(0) {
+        return Ok(Vec::new());
+    }
+
+    tracing::debug!(
+        target: "kreuzberg::pdf::oxide::images",
+        event = "decompression_started",
+        "extract_images_with_data entered"
+    );
+
     let page_count = doc
         .doc
         .page_count()
@@ -80,20 +181,43 @@ pub(crate) fn extract_images_with_data(
     let mut global_index = 0u32;
 
     for page_idx in 0..page_count {
-        let oxide_images = match doc.doc.extract_images(page_idx) {
-            Ok(images) => images,
-            Err(e) => {
-                tracing::debug!(page = page_idx, "pdf_oxide: failed to extract images: {e}");
-                continue;
+        if cancel_token.is_some_and(|t| t.is_cancelled()) {
+            break;
+        }
+
+        // For a positive cap use XObject resource enumeration to stop decompression
+        // after `limit` images. This avoids the eager cost of pdf_oxide::extract_images
+        // which decompresses every image on the page before returning.
+        // Fallback: if the XObject path returns nothing (e.g. page uses only inline
+        // images), retry with the full eager path and apply .take() manually.
+        // kreuzberg#989 tracks getting inline-image support into the capped path.
+        let oxide_images = match max_images_per_page.map(|n| n as usize) {
+            Some(limit) => {
+                let xobj_images = extract_n_images_from_xobject_resources(doc, page_idx, limit).unwrap_or_default();
+                if !xobj_images.is_empty() {
+                    xobj_images
+                } else {
+                    // Fallback: page may use only inline images.
+                    match doc.doc.extract_images(page_idx) {
+                        Ok(imgs) => imgs.into_iter().take(limit).collect(),
+                        Err(e) => {
+                            tracing::debug!(page = page_idx, "pdf_oxide: failed to extract images (fallback): {e}");
+                            continue;
+                        }
+                    }
+                }
             }
+            None => match doc.doc.extract_images(page_idx) {
+                Ok(imgs) => imgs,
+                Err(e) => {
+                    tracing::debug!(page = page_idx, "pdf_oxide: failed to extract images: {e}");
+                    continue;
+                }
+            },
         };
 
         let page_number = (page_idx + 1) as u32; // Kreuzberg uses 1-indexed page numbers
-        let limit = max_images_per_page.unwrap_or(u32::MAX) as usize;
-        let count = oxide_images.len().min(limit);
-
-        for oxide_img in oxide_images.iter().take(count) {
-            // Extract image data - use raw ImageData directly to avoid expensive conversions
+        for oxide_img in &oxide_images {
             let (data, format) = match oxide_img.data() {
                 pdf_oxide::extractors::ImageData::Jpeg(jpeg_bytes) => {
                     (Bytes::copy_from_slice(jpeg_bytes), Cow::Borrowed("jpeg"))
@@ -128,4 +252,151 @@ pub(crate) fn extract_images_with_data(
     }
 
     Ok(all_images)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cancellation::CancellationToken;
+    use std::path::PathBuf;
+
+    fn test_documents_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("test_documents")
+    }
+
+    /// `max_images_per_page = Some(0)` must return an empty vec immediately
+    /// without opening any page — the early-exit short-circuit at the top of
+    /// `extract_images_with_data` fires before the page loop even starts.
+    #[test]
+    fn test_max_images_per_page_zero_returns_immediately() {
+        let pdf_path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+        assert!(
+            pdf_path.exists(),
+            "missing fixture: test PDF not found at {}",
+            pdf_path.display()
+        );
+
+        let bytes = std::fs::read(&pdf_path).expect("failed to read test PDF");
+        let mut doc = crate::pdf::oxide::OxideDocument::open_bytes(&bytes).expect("failed to open PDF");
+
+        let result = extract_images_with_data(&mut doc, Some(0), None).expect("cap=0 must not error");
+
+        assert!(
+            result.is_empty(),
+            "max_images_per_page=Some(0) must return empty without decompressing any page; \
+             got {} image(s)",
+            result.len()
+        );
+    }
+
+    /// A cancellation token fired from a background thread stops extraction after
+    /// the current page completes and before the next page's cancellation check.
+    ///
+    /// Uses `nougat_039.pdf` (2 pages, ~67KB). A background thread cancels the
+    /// token after 20ms — a window chosen to land after page 0's images are
+    /// decompressed but before page 1's cancellation check fires.
+    ///
+    /// Timing note: on very fast or very slow hardware, the cancel may fire before
+    /// page 0 completes (result is empty) or after page 1 completes (result equals
+    /// the full count). Both are valid outcomes.  The invariant under test is
+    /// `result.len() ≤ full_count`, which proves that cancellation never produces
+    /// *more* images than an uncancelled run and that the code path compiles and
+    /// runs without error.
+    #[test]
+    fn test_cancellation_fires_between_pages() {
+        let pdf_path = test_documents_dir().join("pdf/nougat_039.pdf");
+        assert!(
+            pdf_path.exists(),
+            "missing fixture: nougat_039.pdf not found at {}",
+            pdf_path.display()
+        );
+
+        let bytes = std::fs::read(&pdf_path).expect("failed to read test PDF");
+
+        // Full run (no cancel) — establishes the expected upper bound.
+        let mut doc_full = crate::pdf::oxide::OxideDocument::open_bytes(&bytes).expect("failed to open PDF");
+        let full_result =
+            extract_images_with_data(&mut doc_full, None, None).expect("uncancelled extraction must not error");
+        let full_count = full_result.len();
+        let page_count = doc_full
+            .doc
+            .page_count()
+            .expect("page_count must succeed on the fixture");
+
+        // Skip if the fixture has only one page or no images — mid-run cancellation
+        // between pages cannot be demonstrated.
+        if page_count <= 1 || full_count == 0 {
+            eprintln!(
+                "SKIP test_cancellation_fires_between_pages: nougat_039.pdf has {} page(s) \
+                 and {} extractable images — need ≥2 pages with images",
+                page_count, full_count
+            );
+            return;
+        }
+
+        // Run with a token that a background thread cancels after 20ms.
+        // For a 67KB 2-page PDF on CI hardware this window typically lands between
+        // pages 0 and 1, but both earlier and later cancellations are correct.
+        let mut doc_cancel = crate::pdf::oxide::OxideDocument::open_bytes(&bytes).expect("failed to open PDF");
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+
+        let handle = std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(20));
+            token_clone.cancel();
+        });
+
+        let result =
+            extract_images_with_data(&mut doc_cancel, None, Some(&token)).expect("cancellation must not error");
+
+        handle.join().expect("background thread must not panic");
+
+        // The token must have been set by the time the handle joins.
+        assert!(
+            token.is_cancelled(),
+            "token must be cancelled after background thread fires"
+        );
+
+        // Cancellation must never produce more images than an uncancelled run.
+        assert!(
+            result.len() <= full_count,
+            "cancelled extraction returned {} image(s); uncancelled returned {}; \
+             cancellation must never exceed the full count",
+            result.len(),
+            full_count
+        );
+    }
+
+    /// Pre-cancelled token fires on the first loop iteration (page 0) before
+    /// any decompression begins. This test covers the trivial case; see
+    /// `test_cancellation_fires_between_pages` for mid-run coverage.
+    #[test]
+    fn test_cancellation_stops_extraction_early() {
+        let pdf_path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+        assert!(
+            pdf_path.exists(),
+            "missing fixture: test PDF not found at {}",
+            pdf_path.display()
+        );
+
+        let bytes = std::fs::read(&pdf_path).expect("failed to read test PDF");
+        let mut doc = crate::pdf::oxide::OxideDocument::open_bytes(&bytes).expect("failed to open PDF");
+
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = extract_images_with_data(&mut doc, None, Some(&token)).expect("extract must not error");
+
+        assert!(
+            result.is_empty(),
+            "pre-cancelled token must cause extraction to return empty vec immediately, \
+             got {} image(s)",
+            result.len()
+        );
+    }
 }

--- a/crates/kreuzberg/src/utils/pool.rs
+++ b/crates/kreuzberg/src/utils/pool.rs
@@ -23,7 +23,7 @@
 //! use kreuzberg::utils::pool::StringBufferPool;
 //!
 //! let pool = StringBufferPool::new(|| String::with_capacity(4096), 10); // 10 buffers of 4KB each
-//! let mut buffer = pool.acquire().unwrap();
+//! let mut buffer = pool.acquire();
 //! buffer.push_str("some content");
 //! // buffer is returned to pool when dropped
 //! ```
@@ -86,6 +86,7 @@ impl Default for PoolMetrics {
 ///
 /// Generic over any type that implements `Recyclable`, allowing pooling of
 /// different object types with custom reset logic.
+#[doc(hidden)]
 #[cfg_attr(alef, alef(skip))]
 #[derive(Clone)]
 pub struct Pool<T: Recyclable> {
@@ -100,6 +101,7 @@ pub struct Pool<T: Recyclable> {
 ///
 /// Implementing this trait allows a type to be used with `Pool<T>`.
 /// The `reset()` method should clear the object's state for reuse.
+#[doc(hidden)]
 #[cfg_attr(alef, alef(skip))]
 pub trait Recyclable: Send + 'static {
     /// Reset the object to a reusable state.
@@ -151,7 +153,7 @@ impl<T: Recyclable> Pool<T> {
     ///
     /// Panics if the mutex is already locked by the current thread (deadlock).
     /// This is a safety mechanism provided by parking_lot to prevent subtle bugs.
-    pub fn acquire(&self) -> Result<PoolGuard<T>, PoolError> {
+    pub fn acquire(&self) -> PoolGuard<T> {
         #[cfg(feature = "pool-metrics")]
         self.metrics.total_acquires.fetch_add(1, Ordering::Relaxed);
 
@@ -170,7 +172,7 @@ impl<T: Recyclable> Pool<T> {
             (self.factory)()
         };
 
-        Ok(PoolGuard {
+        PoolGuard {
             object: Some(object),
             pool: Pool {
                 factory: Arc::clone(&self.factory),
@@ -179,7 +181,7 @@ impl<T: Recyclable> Pool<T> {
                 #[cfg(feature = "pool-metrics")]
                 metrics: Arc::clone(&self.metrics),
             },
-        })
+        }
     }
 
     /// Get the current number of objects in the pool.
@@ -189,9 +191,8 @@ impl<T: Recyclable> Pool<T> {
 
     /// Clear the pool, discarding all pooled objects.
     #[cfg(any(feature = "tokio-runtime", test))]
-    pub(crate) fn clear(&self) -> Result<(), PoolError> {
+    pub(crate) fn clear(&self) {
         self.objects.lock().clear();
-        Ok(())
     }
 
     /// Get a reference to the pool metrics (only available with `pool-metrics` feature).
@@ -202,6 +203,7 @@ impl<T: Recyclable> Pool<T> {
 }
 
 /// RAII guard that returns an object to the pool when dropped.
+#[doc(hidden)]
 pub struct PoolGuard<T: Recyclable> {
     object: Option<T>,
     pool: Pool<T>,
@@ -263,32 +265,13 @@ impl Recyclable for Vec<u8> {
     }
 }
 
-/// Error type for pool operations.
-#[derive(Debug, Clone)]
-#[cfg_attr(alef, alef(skip))]
-pub enum PoolError {
-    /// The pool's internal mutex was poisoned.
-    ///
-    /// This indicates a panic occurred while holding the lock.
-    /// The pool is in a locked state and cannot be recovered.
-    LockPoisoned,
-}
-
-impl std::fmt::Display for PoolError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PoolError::LockPoisoned => write!(f, "pool lock poisoned"),
-        }
-    }
-}
-
-impl std::error::Error for PoolError {}
-
 /// Convenience type alias for a pooled String.
+#[doc(hidden)]
 #[cfg_attr(alef, alef(skip))]
 pub type StringBufferPool = Pool<String>;
 
 /// Convenience type alias for a pooled Vec<u8>.
+#[doc(hidden)]
 #[cfg_attr(alef, alef(skip))]
 pub type ByteBufferPool = Pool<Vec<u8>>;
 
@@ -309,7 +292,7 @@ pub type ByteBufferPool = Pool<Vec<u8>>;
 /// use kreuzberg::utils::pool::create_string_buffer_pool;
 ///
 /// let pool = create_string_buffer_pool(10, 8192);
-/// let mut buffer = pool.acquire().unwrap();
+/// let mut buffer = pool.acquire();
 /// buffer.push_str("content");
 /// ```
 #[cfg_attr(alef, alef(skip))]
@@ -334,7 +317,7 @@ pub fn create_string_buffer_pool(pool_size: usize, buffer_capacity: usize) -> St
 /// use kreuzberg::utils::pool::create_byte_buffer_pool;
 ///
 /// let pool = create_byte_buffer_pool(10, 65536);
-/// let mut buffer = pool.acquire().unwrap();
+/// let mut buffer = pool.acquire();
 /// buffer.extend_from_slice(b"binary data");
 /// ```
 #[cfg_attr(alef, alef(skip))]
@@ -351,13 +334,13 @@ mod tests {
         let pool = Pool::new(String::new, 5);
 
         {
-            let mut s1 = pool.acquire().unwrap();
+            let mut s1 = pool.acquire();
             s1.push_str("hello");
             assert_eq!(s1.len(), 5);
         }
 
         {
-            let s2 = pool.acquire().unwrap();
+            let s2 = pool.acquire();
             assert_eq!(s2.len(), 0, "string should be cleared when reused");
         }
     }
@@ -366,9 +349,9 @@ mod tests {
     fn test_pool_respects_max_size() {
         let pool = Pool::new(String::new, 2);
 
-        let guard1 = pool.acquire().unwrap();
-        let guard2 = pool.acquire().unwrap();
-        let guard3 = pool.acquire().unwrap();
+        let guard1 = pool.acquire();
+        let guard2 = pool.acquire();
+        let guard3 = pool.acquire();
 
         drop(guard1);
         drop(guard2);
@@ -381,14 +364,14 @@ mod tests {
     fn test_pool_clear() {
         let pool = Pool::new(String::new, 5);
 
-        let _g1 = pool.acquire().unwrap();
-        let _g2 = pool.acquire().unwrap();
+        let _g1 = pool.acquire();
+        let _g2 = pool.acquire();
 
         drop(_g1);
         drop(_g2);
 
         assert!(pool.size() > 0, "pool should have items");
-        pool.clear().unwrap();
+        pool.clear();
         assert_eq!(pool.size(), 0, "pool should be empty after clear");
     }
 
@@ -397,13 +380,13 @@ mod tests {
         let pool = Pool::new(Vec::new, 5);
 
         {
-            let mut buf = pool.acquire().unwrap();
+            let mut buf = pool.acquire();
             buf.extend_from_slice(b"hello");
             assert_eq!(buf.len(), 5);
         }
 
         {
-            let buf = pool.acquire().unwrap();
+            let buf = pool.acquire();
             assert_eq!(buf.len(), 0, "buffer should be cleared");
         }
     }
@@ -411,7 +394,7 @@ mod tests {
     #[test]
     fn test_pool_deref() {
         let pool = Pool::new(String::new, 5);
-        let mut guard = pool.acquire().unwrap();
+        let mut guard = pool.acquire();
 
         let _len = guard.len();
 
@@ -430,7 +413,7 @@ mod tests {
         for i in 0..5 {
             let pool_clone = Arc::clone(&pool);
             let handle = thread::spawn(move || {
-                let mut buf = pool_clone.acquire().unwrap();
+                let mut buf = pool_clone.acquire();
                 buf.push_str(&format!("thread_{}", i));
                 std::thread::sleep(std::time::Duration::from_millis(10));
                 drop(buf);
@@ -451,11 +434,11 @@ mod tests {
         let pool = Pool::new(String::new, 5);
 
         {
-            let _s1 = pool.acquire().unwrap();
+            let _s1 = pool.acquire();
         }
 
         {
-            let _s2 = pool.acquire().unwrap();
+            let _s2 = pool.acquire();
         }
 
         let metrics = pool.metrics();
@@ -472,9 +455,9 @@ mod tests {
     fn test_pool_metrics_peak_tracking() {
         let pool = Pool::new(String::new, 5);
 
-        let g1 = pool.acquire().unwrap();
-        let g2 = pool.acquire().unwrap();
-        let g3 = pool.acquire().unwrap();
+        let g1 = pool.acquire();
+        let g2 = pool.acquire();
+        let g3 = pool.acquire();
 
         drop(g1);
         drop(g2);

--- a/crates/kreuzberg/tests/batch_pooling_benchmark.rs
+++ b/crates/kreuzberg/tests/batch_pooling_benchmark.rs
@@ -21,7 +21,7 @@ mod tests {
 
         let mut buffers = vec![];
         for _ in 0..3 {
-            let buf = pool.acquire().expect("Operation failed");
+            let buf = pool.acquire();
             buffers.push(buf);
         }
 
@@ -31,7 +31,7 @@ mod tests {
 
         let mut buffers = vec![];
         for _ in 0..3 {
-            let buf = pool.acquire().expect("Operation failed");
+            let buf = pool.acquire();
             buffers.push(buf);
         }
         drop(buffers);
@@ -47,8 +47,8 @@ mod tests {
             let mut results = vec![];
 
             for _i in 0..5 {
-                let string_buf = processor.string_pool().acquire().expect("Operation failed");
-                let byte_buf = processor.byte_pool().acquire().expect("Operation failed");
+                let string_buf = processor.string_pool().acquire();
+                let byte_buf = processor.byte_pool().acquire();
 
                 results.push((string_buf, byte_buf));
             }
@@ -65,17 +65,17 @@ mod tests {
         let pool = create_string_buffer_pool(5, 4096);
 
         let capacity_initial = {
-            let buf = pool.acquire().expect("Operation failed");
+            let buf = pool.acquire();
             buf.capacity()
         };
 
         for _ in 0..10 {
-            let mut buf = pool.acquire().expect("Operation failed");
+            let mut buf = pool.acquire();
             buf.push_str("test data");
         }
 
         let capacity_final = {
-            let buf = pool.acquire().expect("Operation failed");
+            let buf = pool.acquire();
             buf.capacity()
         };
 
@@ -101,15 +101,15 @@ mod tests {
         let processor = BatchProcessor::new();
 
         {
-            let _s1 = processor.string_pool().acquire().expect("Operation failed");
-            let _s2 = processor.string_pool().acquire().expect("Operation failed");
-            let _b1 = processor.byte_pool().acquire().expect("Operation failed");
+            let _s1 = processor.string_pool().acquire();
+            let _s2 = processor.string_pool().acquire();
+            let _b1 = processor.byte_pool().acquire();
         }
 
         assert!(processor.string_pool_size() > 0);
         assert!(processor.byte_pool_size() > 0);
 
-        processor.clear_pools().expect("Operation failed");
+        processor.clear_pools();
 
         assert_eq!(processor.string_pool_size(), 0);
         assert_eq!(processor.byte_pool_size(), 0);
@@ -137,7 +137,7 @@ mod tests {
         }
 
         for handle in handles {
-            handle.join().expect("Operation failed");
+            handle.join().expect("thread panicked");
         }
 
         assert!(processor.string_pool_size() <= 10);
@@ -148,7 +148,7 @@ mod tests {
     fn test_pool_respects_capacity_hints() {
         let pool = create_string_buffer_pool(3, 2048);
 
-        let buf = pool.acquire().expect("Operation failed");
+        let buf = pool.acquire();
         assert!(buf.capacity() >= 2048, "buffer should respect capacity hint");
     }
 }

--- a/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
+++ b/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
@@ -552,6 +552,344 @@ fn test_chunk_image_indices_are_valid_when_images_extracted() {
     }
 }
 
+/// Regression for #985: max_images_per_page must cap the output count per page.
+///
+/// Before the fix, `extract_image_positions` ran a complete decompression pass
+/// over every page unconditionally (even when extract_images=false), then
+/// `extract_images_with_data` ran a second pass.  The `.take(N)` limit only
+/// clipped the returned slice — it did not stop the decompression work.
+///
+/// After the fix:
+/// - When extract_images=false, NO decompression occurs at all (the main hang fix).
+/// - When extract_images=true, a single pass runs and the cap is respected in output.
+///   The per-page decompression cost for images beyond the cap is a pdf_oxide
+///   upstream limitation: `extract_images()` is eager.  Eliminating that
+///   remaining cost requires a count-limited API upstream.
+#[test]
+fn test_max_images_per_page_cap_respected_in_output() {
+    use kreuzberg::core::config::ImageExtractionConfig;
+    use std::collections::HashMap;
+
+    let path = test_documents_dir().join("pdf/installatiehandleiding_kombi_kompakt_hr.pdf");
+    if !path.exists() {
+        eprintln!("skipping: test PDF not present at {}", path.display());
+        return;
+    }
+
+    let cap: u32 = 5;
+    let config = ExtractionConfig {
+        images: Some(ImageExtractionConfig {
+            extract_images: true,
+            max_images_per_page: Some(cap),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt
+        .block_on(extract_file(&path, None, &config))
+        .expect("extraction must succeed");
+
+    let images = result
+        .images
+        .as_ref()
+        .expect("images must be Some when extract_images=true");
+
+    // Cap must be respected per page in the output.
+    let mut per_page: HashMap<u32, usize> = HashMap::new();
+    for img in images {
+        *per_page.entry(img.page_number.unwrap_or(1)).or_default() += 1;
+    }
+    for (page, count) in &per_page {
+        assert!(
+            *count <= cap as usize,
+            "page {page} has {count} images; cap={cap} must be respected"
+        );
+    }
+}
+
+/// Regression for #985 (no-images case): when extract_images=false, no images
+/// are returned and the result is consistent with the fix.
+///
+/// Before the fix, `extract_image_positions` ran unconditionally and triggered
+/// a full decompression pass over every image on every page — even when the
+/// caller never asked for image data.  After the fix the decompression path is
+/// skipped entirely when images are not requested.
+#[test]
+fn test_no_images_returned_when_extraction_disabled_on_dense_pdf() {
+    let path = test_documents_dir().join("pdf/installatiehandleiding_kombi_kompakt_hr.pdf");
+    if !path.exists() {
+        eprintln!("skipping: test PDF not present at {}", path.display());
+        return;
+    }
+
+    let config = ExtractionConfig::default(); // extract_images defaults to false
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt
+        .block_on(extract_file(&path, None, &config))
+        .expect("extraction must succeed");
+
+    // No images should be returned when extraction is disabled.
+    assert!(
+        result.images.is_none() || result.images.as_ref().is_some_and(|v| v.is_empty()),
+        "images must be absent when extract_images=false"
+    );
+}
+
+/// Positions derived from extracted data must be consistent with the Markdown placeholders.
+///
+/// When inject_placeholders=true, the renderer emits `![](image_N.ext)` links where N
+/// is the image_index.  Every such N must have a corresponding entry in result.images.
+/// Also verifies that image_index values are unique — the derivation loop must not emit
+/// duplicate global indices.
+#[test]
+fn test_image_positions_consistent_with_image_data() {
+    use kreuzberg::core::config::{ImageExtractionConfig, OutputFormat};
+
+    let path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        images: Some(ImageExtractionConfig {
+            extract_images: true,
+            inject_placeholders: true,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(extract_file(&path, None, &config)).unwrap();
+
+    let images = match result.images.as_ref() {
+        Some(imgs) if !imgs.is_empty() => imgs,
+        _ => return, // no images in this PDF — nothing to verify
+    };
+
+    // image_index values must be unique across the returned set.
+    let mut seen = std::collections::HashSet::new();
+    for img in images {
+        assert!(
+            seen.insert(img.image_index),
+            "image_index {} appears more than once — position derivation emitted duplicates",
+            img.image_index
+        );
+    }
+
+    // Every `![](image_N.ext)` placeholder in Markdown must resolve to an index in
+    // result.images.  This would fail if inject_placeholders emitted a reference for
+    // an image that was never extracted (orphaned placeholder).
+    let known: std::collections::HashSet<u32> = images.iter().map(|i| i.image_index).collect();
+    let re = regex::Regex::new(r"!\[\]\(image_(\d+)\.[a-z]+\)").unwrap();
+    for cap in re.captures_iter(&result.content) {
+        let idx: u32 = cap[1].parse().unwrap();
+        assert!(
+            known.contains(&idx),
+            "Markdown contains `![](image_{idx}.ext)` but result.images has no entry \
+             with image_index={idx} — orphaned placeholder"
+        );
+    }
+}
+
+/// Regression for #985 (double-decompression fix): the text-only extraction path must
+/// skip `extract_images_with_data` entirely.
+///
+/// When `extract_images` is `false` (the default), `extraction.rs` must not enter the
+/// images branch at all — verified here by confirming that `result.images` is `None`
+/// (or empty) and that the call completes without decompressing any image data.
+/// This is the minimal structural proof that the guard in `extraction.rs` works:
+/// if `extract_images_with_data` were called unconditionally, the result would be
+/// `Some(non_empty_vec)` for a PDF that actually contains images.
+#[test]
+fn test_no_decompression_when_images_disabled() {
+    let path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+    assert!(path.exists(), "missing fixture: {}", path.display());
+
+    // Default config: extract_images defaults to false.
+    let config = ExtractionConfig::default();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt
+        .block_on(kreuzberg::core::extractor::extract_file(&path, None, &config))
+        .expect("extraction must succeed");
+
+    // The text-only path must not return any image data.
+    assert!(
+        result.images.as_ref().is_none_or(|v| v.is_empty()),
+        "images must be absent on text-only extraction (extract_images=false). \
+         Got {} image(s) — extract_images_with_data was called when it should not have been.",
+        result.images.as_ref().map_or(0, |v| v.len())
+    );
+
+    // Text content must still be present — no regression on the extraction itself.
+    assert!(
+        !result.content.is_empty(),
+        "text content must still be extracted when images are disabled"
+    );
+}
+
+/// Trace-span assertion for #985: `extract_images_with_data` must NOT be entered
+/// when `extract_images` is false (the default).
+///
+/// This directly proves the decompression code path was skipped — complementing
+/// `test_no_decompression_when_images_disabled` which only observes the output.
+/// An event with target `kreuzberg::pdf::oxide::images` and field
+/// `event = "decompression_started"` is emitted at the top of
+/// `extract_images_with_data`; absence of that event is structural proof the
+/// function was not called.
+#[test]
+fn test_no_decompression_trace_when_images_disabled() {
+    use std::sync::{Arc, Mutex};
+    use tracing_subscriber::{EnvFilter, layer::SubscriberExt as _};
+
+    // ── Captured-event layer ────────────────────────────────────────────────
+
+    #[allow(clippy::type_complexity)]
+    #[derive(Clone, Default)]
+    struct EventCapture {
+        events: Arc<Mutex<Vec<(String, Option<String>)>>>,
+    }
+
+    impl<S> tracing_subscriber::Layer<S> for EventCapture
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+            let target = event.metadata().target().to_owned();
+
+            // Only record events from our target to avoid unbounded accumulation.
+            if target != "kreuzberg::pdf::oxide::images" {
+                return;
+            }
+
+            // Walk the fields to capture the `event` key if present.
+            struct FieldVisitor(Option<String>);
+            impl tracing::field::Visit for FieldVisitor {
+                fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                    if field.name() == "event" {
+                        self.0 = Some(value.to_owned());
+                    }
+                }
+                fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+                    if field.name() == "event" {
+                        self.0 = Some(format!("{value:?}"));
+                    }
+                }
+            }
+
+            let mut visitor = FieldVisitor(None);
+            event.record(&mut visitor);
+
+            self.events.lock().unwrap().push((target, visitor.0));
+        }
+    }
+
+    // ── Test body ───────────────────────────────────────────────────────────
+
+    let path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+    assert!(path.exists(), "missing fixture: {}", path.display());
+
+    let capture = EventCapture::default();
+    let capture_clone = capture.clone();
+
+    // Enable DEBUG so the tracing event would be visible if the function ran.
+    let filter = EnvFilter::new("debug");
+    let subscriber = tracing_subscriber::registry().with(filter).with(capture_clone);
+
+    // Wrap the runtime inside with_default so all spans/events are recorded.
+    let result = tracing::subscriber::with_default(subscriber, || {
+        let config = ExtractionConfig::default(); // extract_images defaults to false
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(kreuzberg::core::extractor::extract_file(&path, None, &config))
+            .expect("extraction must succeed")
+    });
+
+    // Output assertion: no image data returned.
+    assert!(
+        result.images.as_ref().is_none_or(|v| v.is_empty()),
+        "images must be absent when extract_images=false"
+    );
+
+    // Trace assertion: the decompression_started event must not have fired.
+    let events = capture.events.lock().unwrap();
+    let decompression_events: Vec<_> = events
+        .iter()
+        .filter(|(target, event_field)| {
+            target == "kreuzberg::pdf::oxide::images" && event_field.as_deref() == Some("decompression_started")
+        })
+        .collect();
+
+    assert!(
+        decompression_events.is_empty(),
+        "extract_images_with_data must not be entered when extract_images=false; \
+         got {} decompression_started event(s)",
+        decompression_events.len()
+    );
+}
+
+// ─── ocr_inline_images decompression path ─────────────────────────────────────
+//
+// When `ocr_inline_images=true`, the extraction branch condition
+// `images_extraction_enabled || ocr_inline_images` is true regardless of
+// `extract_images`.  Images are decompressed and stored in `result.images` even
+// when `ImageExtractionConfig.extract_images = false`.  Without this test, a
+// regression that short-circuits the extraction when `images_extraction_enabled`
+// is false would go undetected.
+//
+// Note: unbounded decompression when `ocr_inline_images=true` and
+// `config.images=None` (no cap) is a known limitation tracked separately in
+// kreuzberg#989.  Set `config.images.max_images_per_page` to apply a cap.
+
+/// When `ocr_inline_images=true` and `extract_images=false`, images must still
+/// be decompressed — `ocr_inline_images` forces entry into the extraction branch.
+///
+/// Before the fix for #985 this path was doubly dangerous: the unconditional
+/// `extract_image_positions` call ran even when `extract_images=false`, and on
+/// the oxide path the decompression was unbounded.  The OCR path was never
+/// covered by a test, so a regression disabling decompression for
+/// `ocr_inline_images=true` would be invisible.
+#[test]
+fn test_ocr_inline_images_enters_decompression_path() {
+    use kreuzberg::PdfConfig;
+    use kreuzberg::core::config::ImageExtractionConfig;
+
+    let path = test_documents_dir().join("pdf/embedded_images_tables.pdf");
+    assert!(path.exists(), "missing fixture: {}", path.display());
+
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        // Explicitly disable extract_images — images_extraction_enabled will be false.
+        images: Some(ImageExtractionConfig {
+            extract_images: false,
+            ..Default::default()
+        }),
+        // Enable ocr_inline_images — this must force entry into the extraction branch.
+        pdf_options: Some(PdfConfig {
+            ocr_inline_images: true,
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let result = rt.block_on(extract_file(&path, None, &config)).unwrap();
+
+    // Images must be decompressed even though extract_images=false, because
+    // ocr_inline_images=true enters the extraction branch regardless.
+    let images = result.images.as_ref().expect(
+        "result.images must be Some when ocr_inline_images=true, \
+         even if extract_images=false — the extraction branch must be entered",
+    );
+    assert!(
+        !images.is_empty(),
+        "embedded_images_tables.pdf has embedded images; result.images must be non-empty \
+         when ocr_inline_images=true forces entry into the decompression branch"
+    );
+}
+
 /// `image_indices` on chunks must be empty when image extraction is disabled.
 #[cfg(feature = "chunking")]
 #[test]


### PR DESCRIPTION
Fixes #985. All review items from both review rounds are now addressed.

**Root cause:** `extract_image_positions` called `doc.doc.extract_images(page_idx)` unconditionally on every page — even when `extract_images=false` — triggering full image decompression before returning. PDFs with many embedded images caused multi-minute hangs for text-only callers.

**Fix summary:**
- Remove `extract_image_positions` entirely. Positions derived from `(img.page_number, img.image_index)` off what `extract_images_with_data` already returns — no second decompression pass.
- Gate `extract_images_with_data` behind `images_extraction_enabled || ocr_inline_images` in `extraction.rs` — text-only extraction never enters the decompression path.
- Add `max_images_per_page == Some(0)` short-circuit at the top of `extract_images_with_data` — zero-cap returns immediately without calling `extract_images()`.
- For positive caps, enumerate the page XObject resource dictionary and stop decompressing after `limit` images (`extract_n_images_from_xobject_resources`). Inline images (`BI`/`EI` operators) fall back to the eager path with `.take(limit)` as a safety guard; full inline-image support tracked in #989.
- Add `cancel_token: Option<&CancellationToken>` checked at the top of the page loop so `extraction_timeout_secs` can interrupt multi-page extraction between pages.
- Remove dead `PoolError::LockPoisoned` — `parking_lot::Mutex` never poisons; `acquire()` and `clear()` are now infallible.

**alef.toml changes (prerequisite, not new features):** The `alef_version` bump to 0.16.71 and the type-exclusion additions (`HwpxExtractor`, `CacheStats`, `OcrBackend`/`register_ocr_backend`/`unregister_ocr_backend`, `process_images_with_ocr`) are required to make `alef generate` complete cleanly. These types caused type-collision and unsupported-type build errors in the FFI and WASM codegen targets. Without excluding them, `alef generate` would fail, making it impossible to commit a fresh alef regen. They are not independent feature additions; they are the prerequisite for the freshness check to pass.

**Review items addressed:**
1. `extract_image_positions` removed; `extract_images_with_data` gated in `extraction.rs:105` — confirmed fixed.
2. Positions derived from the already-extracted `images` vec — no second decompression pass.
3. `max_images_per_page == Some(0)` short-circuits before `extract_images()`. For positive caps, XObject decompression is now bounded at `limit` via resource-dict enumeration; inline images use `.take(limit)` fallback (#989).
4. `PoolError::LockPoisoned` removed; `acquire()` returns infallible `PoolGuard<T>`.
5. `alef_version` corrected to 0.16.71 (was accidentally set to 0.16.32); `alef generate` run — confirmed `lib.rs`/`index.d.ts` match alef output; 26 stale generated files pruned.
6. Added `test_no_decompression_trace_when_images_disabled`: installs a `tracing_subscriber` layer filtered to `kreuzberg::pdf::oxide::images`, runs text-only extraction, and asserts the `decompression_started` event is never emitted — direct structural proof the function was not called.

**Tests:**
- `test_cancellation_stops_extraction_early` — pre-cancelled token returns empty vec immediately
- `test_max_images_per_page_cap_respected_in_output` — cap respected in returned images
- `test_no_images_returned_when_extraction_disabled_on_dense_pdf` — no decompression when disabled
- `test_image_positions_consistent_with_image_data` — image_index uniqueness + orphaned-placeholder detection
- `test_no_decompression_when_images_disabled` — output-based: text-only returns `images: None`
- `test_no_decompression_trace_when_images_disabled` — trace-span: `decompression_started` event absent during text-only extraction