### PR TITLE
ci(e2e): install WASI SDK for wasm matrix lane

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -217,6 +217,10 @@ jobs:
         with:
           label: e2e-${{ matrix.lang }}
 
+      - name: Install WASI SDK
+        if: matrix.lang == 'wasm'
+        uses: kreuzberg-dev/actions/install-wasi-sdk@v1.0.0
+
       - name: Setup Python
         if: matrix.python-version
         uses: kreuzberg-dev/actions/setup-python-env@v1.0.0


### PR DESCRIPTION
kreuzberg-tesseract pulls `build-tesseract-wasm` on wasm32, which invokes the WASI SDK at compile time. The publish workflow already installs wasi-sdk via `kreuzberg-dev/actions/install-wasi-sdk@v1.0.0`; mirror that step in ci-e2e.yaml so the wasm matrix lane isn't blocked on `build.rs` failing the `WASI_SDK_PATH` check.

Root cause: `crates/kreuzberg-wasm` depends on `kreuzberg` with `ocr-wasm`, and `ocr-wasm` -> `kreuzberg-tesseract`. On wasm32 the workspace overrides `kreuzberg-tesseract` to `build-tesseract-wasm` (intentional, real WASI Tesseract build for in-memory OCR). The e2e workflow was just missing the SDK install step.

Fix: add a conditional `Install WASI SDK` step gated on `matrix.lang == 'wasm'`.