### PR TITLE
fix(ffi): add embedding-preset stubs to prevent Java class-load crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Java `UnsatisfiedLinkError` on `kreuzberg_list_embedding_presets` / `kreuzberg_get_embedding_preset` (#998)**:
+  the alef-generated FFI surface references `kreuzberg::EmbeddingPreset` unconditionally
+  in function return-type positions, so any build of `kreuzberg-ffi` that omitted the
+  `embedding-presets` feature would silently drop these two C symbols — causing the Java
+  static initialiser (which uses `.orElseThrow()`) to crash the entire JVM at class-load
+  time. Added `#[cfg(not(feature = "embedding-presets"))]` stubs in
+  `crates/kreuzberg/src/lib.rs`: a no-op `EmbeddingPreset` struct and empty-return
+  implementations of both functions. The stubs ensure the symbols are always present
+  and callers degrade gracefully (empty list / `null` handle) instead of crashing.
+
 ### Changed
 
 - **API surface lockdown via `#[cfg_attr(alef, alef(skip))]`**: 41 internal types

--- a/crates/kreuzberg/src/lib.rs
+++ b/crates/kreuzberg/src/lib.rs
@@ -275,3 +275,42 @@ pub fn get_embedding_preset(name: &str) -> Option<embeddings::EmbeddingPreset> {
 pub fn list_embedding_presets() -> Vec<String> {
     embeddings::list_presets()
 }
+
+// ── Embedding-preset stubs for builds without the feature ────────────────────
+// The alef-generated kreuzberg-ffi crate references `kreuzberg::EmbeddingPreset`
+// unconditionally in FFI return-type positions. Without these stubs, any build
+// that omits `embedding-presets` fails to compile kreuzberg-ffi and — if the
+// feature was accidentally dropped from a release build — causes a Java
+// `UnsatisfiedLinkError` at class-load time (issue #998).  Stubs return
+// empty/None so callers degrade gracefully instead of crashing.
+
+/// Stub preset type for builds without the `embedding-presets` feature.
+///
+/// Field names match the real type so JSON round-trips through
+/// `kreuzberg_embedding_preset_from_json` remain schema-compatible. When the
+/// feature is absent, `get_embedding_preset` always returns `None`, so the
+/// stub is never allocated in practice.
+#[cfg(not(feature = "embedding-presets"))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EmbeddingPreset {
+    pub name: String,
+    pub chunk_size: usize,
+    pub overlap: usize,
+    pub model_repo: String,
+    pub pooling: String,
+    pub model_file: String,
+    pub dimensions: usize,
+    pub description: String,
+}
+
+/// Returns `None` for builds without the `embedding-presets` feature.
+#[cfg(not(feature = "embedding-presets"))]
+pub fn get_embedding_preset(_name: &str) -> Option<EmbeddingPreset> {
+    None
+}
+
+/// Returns an empty list for builds without the `embedding-presets` feature.
+#[cfg(not(feature = "embedding-presets"))]
+pub fn list_embedding_presets() -> Vec<String> {
+    Vec::new()
+}

--- a/crates/kreuzberg/tests/embedding_preset_stubs.rs
+++ b/crates/kreuzberg/tests/embedding_preset_stubs.rs
@@ -1,0 +1,16 @@
+// Tests that the no-feature stubs compile and return empty/None.
+// Only active when `embedding-presets` is absent; run with:
+//   cargo test -p kreuzberg --test embedding_preset_stubs --no-default-features
+
+#[cfg(not(feature = "embedding-presets"))]
+mod tests {
+    #[test]
+    fn get_returns_none_without_feature() {
+        assert!(kreuzberg::get_embedding_preset("all-minilm-l6-v2").is_none());
+    }
+
+    #[test]
+    fn list_returns_empty_without_feature() {
+        assert!(kreuzberg::list_embedding_presets().is_empty());
+    }
+}


### PR DESCRIPTION
Fixes #998.

In v4.9.8, the native library was built without `embedding-presets`, causing the Java static initialiser (which uses `.orElseThrow()` on both symbol lookups) to throw `UnsatisfiedLinkError` at class-load time and crash all extraction.

The structural cause: the alef-generated FFI surface references `kreuzberg::EmbeddingPreset` unconditionally in function return-type positions, so any build omitting the feature both fails to compile `kreuzberg-ffi` and produces no C symbols for `kreuzberg_get_embedding_preset` / `kreuzberg_list_embedding_presets`.

**Fix**: Add `#[cfg(not(feature = "embedding-presets"))]` stubs in `crates/kreuzberg/src/lib.rs`:
- `EmbeddingPreset` stub struct (field names match the real type for JSON schema compatibility)
- `get_embedding_preset` returning `None`
- `list_embedding_presets` returning `Vec::new()`

The symbols are now always present. Callers degrade gracefully (null handle / empty list) instead of crashing the JVM.

**Tests**: `crates/kreuzberg/tests/embedding_preset_stubs.rs` — guarded `#[cfg(not(feature = "embedding-presets"))]`, 2 assertions. Run with: `cargo test -p kreuzberg --test embedding_preset_stubs --no-default-features`

**Feature checks run**:
- `cargo check -p kreuzberg --no-default-features` ✓
- `cargo check -p kreuzberg --features "embedding-presets,embeddings"` ✓
- `cargo check -p kreuzberg-ffi` ✓

**alef generate**: stubs are behind `#[cfg(not(feature = "embedding-presets"))]` — invisible to alef, which always processes with features enabled. No binding regen needed.

v5 main is not currently broken (`kreuzberg-ffi/Cargo.toml` always includes the feature), but these stubs guard against future build regressions.