### PR TITLE
fix(docs): eliminate textlint stop-word violations in Rust source doc comments

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Setup Ruby
         if: matrix.ruby-version
-        uses: ruby/setup-ruby@v1.309.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true

--- a/.github/workflows/ci-lint.yaml
+++ b/.github/workflows/ci-lint.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: kreuzberg-dev/actions/setup-elixir@v1
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.309.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           ruby-version: "3.4"
           bundler-cache: true

--- a/.github/workflows/profiling.yaml
+++ b/.github/workflows/profiling.yaml
@@ -780,7 +780,7 @@ jobs:
           use-sccache: true
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.309.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           ruby-version: "3.2"
 
@@ -885,7 +885,7 @@ jobs:
           use-sccache: true
 
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.309.0
+        uses: ruby/setup-ruby@v1.310.0
         with:
           ruby-version: "3.2"
 

--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -56,7 +56,8 @@
         "long tail",
         "all of",
         "demonstrate",
-        "Specifically"
+        "Specifically",
+        "MARGINAL"
       ]
     },
     "en-capitalization": {

--- a/crates/kreuzberg/src/core/config/content_filter.rs
+++ b/crates/kreuzberg/src/core/config/content_filter.rs
@@ -49,8 +49,8 @@ pub struct ContentFilterConfig {
     ///
     /// Note: when a layout-detection model is active, the model may independently
     /// classify page-header / page-footer regions as furniture on a per-page basis.
-    /// To preserve those regions, set `include_headers = true` and/or
-    /// `include_footers = true` in addition to disabling this flag.
+    /// To preserve those regions, set `include_headers = true`, `include_footers = true`,
+    /// or both, in addition to disabling this flag.
     ///
     /// Primarily affects PDF extraction.
     ///

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -160,7 +160,7 @@ pub struct ExtractionConfig {
     ///
     /// Controls maximum archive size, compression ratio, file count, and other
     /// security thresholds to prevent decompression bomb attacks. Also caps
-    /// nesting depth, iteration count, entity / token length, cumulative
+    /// nesting depth, iteration count, entity / token length, total
     /// content size, and table cell count for every extraction path that
     /// ingests user-controlled bytes.
     /// When `None`, default limits are used.
@@ -199,7 +199,7 @@ pub struct ExtractionConfig {
     ///
     /// When `true` and `layout` is `Some(_)`, layout regions inform heading,
     /// table, list, and figure detection in the structure pipeline that would
-    /// otherwise rely on font-clustering heuristics alone. Substantially
+    /// otherwise rely on font-clustering heuristics alone. Significantly
     /// improves SF1 (structural F1) at the cost of inference latency
     /// (~150-300ms/page CPU, ~20-50ms/page GPU). Default: `false`.
     /// Requires the `layout-detection` feature.

--- a/crates/kreuzberg/src/core/config/formats.rs
+++ b/crates/kreuzberg/src/core/config/formats.rs
@@ -10,8 +10,8 @@ use std::str::FromStr;
 /// Output format for extraction results.
 ///
 /// Controls the format of the `content` field in `ExtractionResult`.
-/// When set to `Markdown`, `Djot`, or `Html`, the output will be formatted
-/// accordingly. `Plain` returns the raw extracted text.
+/// When set to `Markdown`, `Djot`, or `Html`, the output uses that format.
+/// `Plain` returns the raw extracted text.
 /// `Structured` returns JSON with full OCR element data including bounding
 /// boxes and confidence scores.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/kreuzberg/src/extractors/security.rs
+++ b/crates/kreuzberg/src/extractors/security.rs
@@ -30,7 +30,7 @@ pub struct SecurityLimits {
     pub max_nesting_depth: usize,
 
     /// Maximum length of any single XML entity / attribute / token (1 MiB).
-    /// This is a per-token cap, NOT a cumulative cap — billion-laughs class
+    /// This is a per-token cap, NOT a total cap — billion-laughs class
     /// attacks where a single entity expands to hundreds of MB are caught
     /// here, while normal long text content (a paragraph, a CDATA block) is
     /// caught by `max_content_size` instead.
@@ -231,7 +231,7 @@ impl ZipBombValidator {
     }
 }
 
-/// Helper struct for tracking and validating cumulative string growth during extraction.
+/// Helper struct for tracking and validating aggregate string growth during extraction.
 ///
 /// Use this when an extractor accumulates user-controlled content into a `String`
 /// or `Vec<u8>`. Call `check_append(len)` *before* pushing each chunk so the producer
@@ -256,7 +256,7 @@ impl StringGrowthValidator {
 
     /// Account for `len` more bytes about to be appended.
     ///
-    /// Returns `Err(SecurityError::ContentTooLarge)` when the cumulative total exceeds
+    /// Returns `Err(SecurityError::ContentTooLarge)` when the running total exceeds
     /// `max_size`. Counter is updated using saturating arithmetic so a malicious caller
     /// cannot wrap to zero.
     pub(crate) fn check_append(&mut self, len: usize) -> Result<(), SecurityError> {
@@ -389,7 +389,7 @@ impl EntityValidator {
     }
 }
 
-/// Helper struct for capping cumulative table-cell counts across a document.
+/// Helper struct for capping aggregate table-cell counts across a document.
 ///
 /// Use in CSV/XLSX/HTML table extraction to prevent a malicious document
 /// from claiming billions of empty cells and exhausting memory. Call
@@ -411,7 +411,7 @@ impl TableValidator {
     }
 
     /// Account for `count` more cells. Returns `Err(SecurityError::TooManyCells)`
-    /// once the cumulative total exceeds `max_cells`. Saturating arithmetic.
+    /// once the running total exceeds `max_cells`. Saturating arithmetic.
     pub(crate) fn add_cells(&mut self, count: usize) -> Result<(), SecurityError> {
         self.current_cells = self.current_cells.saturating_add(count);
         if self.current_cells > self.max_cells {
@@ -492,7 +492,7 @@ impl SecurityBudget {
     }
 
     /// Account for `len` bytes of emitted text. Returns `Err(ContentTooLarge)`
-    /// once cumulative output exceeds `max_content_size`.
+    /// once total output exceeds `max_content_size`.
     pub(crate) fn account_text(&mut self, len: usize) -> Result<(), SecurityError> {
         self.growth.check_append(len)
     }
@@ -509,7 +509,7 @@ impl SecurityBudget {
     }
 
     /// Account for `count` more table cells. Returns `Err(TooManyCells)` once
-    /// cumulative cells exceed `max_table_cells`.
+    /// the running total of cells exceeds `max_table_cells`.
     pub(crate) fn add_cells(&mut self, count: usize) -> Result<(), SecurityError> {
         self.table.add_cells(count)
     }

--- a/crates/kreuzberg/src/types/document_structure.rs
+++ b/crates/kreuzberg/src/types/document_structure.rs
@@ -255,7 +255,7 @@ pub struct DocumentNode {
 
     /// Format-specific key-value attributes.
     ///
-    /// Extensible bag for data that doesn't warrant a typed field: CSS classes,
+    /// Extensible bag for miscellaneous data without a dedicated typed field: CSS classes,
     /// LaTeX environment names, Excel cell formulas, slide layout names, etc.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub attributes: Option<HashMap<String, String>>,

--- a/crates/kreuzberg/src/types/extraction.rs
+++ b/crates/kreuzberg/src/types/extraction.rs
@@ -224,7 +224,7 @@ pub struct ExtractionResult {
     /// LLM token usage and cost data for all LLM calls made during this extraction.
     ///
     /// Contains one entry per LLM call. Multiple entries are produced when
-    /// VLM OCR, structured extraction, and/or LLM embeddings all run during
+    /// VLM OCR, structured extraction, or LLM embeddings run during
     /// the same extraction.
     ///
     /// `None` when no LLM was used.

--- a/packages/dart/rust/src/frb_generated.rs
+++ b/packages/dart/rust/src/frb_generated.rs
@@ -28,7 +28,7 @@
 
 use crate::*;
 use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
+use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
 use flutter_rust_bridge::{Handler, IntoIntoDart};
 
 // Section: boilerplate
@@ -20355,7 +20355,7 @@ mod io {
     use super::*;
     use crate::*;
     use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
-    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
+    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate
@@ -20818,7 +20818,7 @@ mod web {
     use flutter_rust_bridge::for_generated::byteorder::{NativeEndian, ReadBytesExt, WriteBytesExt};
     use flutter_rust_bridge::for_generated::wasm_bindgen;
     use flutter_rust_bridge::for_generated::wasm_bindgen::prelude::*;
-    use flutter_rust_bridge::for_generated::{transform_result_dco, Lifetimeable, Lockable};
+    use flutter_rust_bridge::for_generated::{Lifetimeable, Lockable, transform_result_dco};
     use flutter_rust_bridge::{Handler, IntoIntoDart};
 
     // Section: boilerplate


### PR DESCRIPTION
**Situation**: CI textlint job flagged stop-word violations across all generated API reference docs and binding files. The warnings appeared in ~17 generated files but traced back to ~8 doc comment phrases in the core Rust source.

**Task**: Fix violations at the source so any future `alef` regeneration produces clean output without touching generated files.

**Action**:
- Replaced `and/or` with explicit alternatives (`or`, `or both`) in `content_filter.rs`, `extraction.rs`
- Replaced `cumulative` with `total`/`aggregate`/`running total` across 7 locations in `security.rs`
- Replaced `Substantially` → `Significantly` in `extraction/core.rs`
- Replaced `accordingly` → `in that format` in `formats.rs`
- Replaced `warrant` → `without a dedicated typed field` in `document_structure.rs`
- Added `"MARGINAL"` to `.textlintrc.json` stop-words exclude list (domain-specific benchmark verdict, must not be renamed)
- Also fixes import sort order in `packages/dart/rust/src/frb_generated.rs` (cargo fmt)

**Result**: All textlint stop-word violations eliminated at source. Generated files left for the next `alef` run to update.