### PR TITLE
fix(docs): run lint:prose task via prek hook

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -122,7 +122,7 @@ jobs:
           ref: ${{ needs.prepare.outputs.tag }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -214,7 +214,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: ${{ needs.prepare.outputs.dry_run != 'true' && (needs.prepare.outputs.force_republish == 'true' || (matrix.variant == 'core' && needs.check-docker.outputs.core_exists != 'true') || (matrix.variant == 'full' && needs.check-docker.outputs.full_exists != 'true') || (matrix.variant == 'cli' && needs.check-docker.outputs.cli_exists != 'true')) }}
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-helm.yaml
+++ b/.github/workflows/publish-helm.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Log in to GitHub Container Registry
         if: ${{ steps.meta.outputs.dry_run != 'true' }}
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.task/tools/docs.yml
+++ b/.task/tools/docs.yml
@@ -33,9 +33,9 @@ tasks:
       - lychee --offline --root-dir "$PWD/docs" --exclude-path "docs/overrides" docs/ README.md
 
   lint:prose:
-    desc: Lint prose with textlint
+    desc: Lint prose with textlint (via prek hook)
     cmds:
-      - npx textlint 'docs/**/*.md'
+      - prek run textlint --all-files
 
   snippets:install:
     desc: Install alef CLI (which now includes the snippets subcommand) if missing
@@ -48,13 +48,13 @@ tasks:
 
   snippets:validate:
     desc: Validate all docs/snippets via `alef snippets` (syntax level)
-    deps: [snippets:install]
+    deps: ["snippets:install"]
     cmds:
       - alef snippets validate --snippets docs/snippets --level syntax --timeout 120 -j 4
 
   snippets:validate:lang:
     desc: "Validate snippets for one language (set LANG=dart|kotlin|swift|...)"
-    deps: [snippets:install]
+    deps: ["snippets:install"]
     cmds:
       - alef snippets validate --snippets docs/snippets --level syntax --languages {{.LANG}} --timeout 120 -j 4
     requires:
@@ -62,18 +62,18 @@ tasks:
 
   snippets:list:
     desc: List all snippets discovered under docs/snippets
-    deps: [snippets:install]
+    deps: ["snippets:install"]
     cmds:
       - alef snippets list --snippets docs/snippets
 
   snippets:audit:
     desc: Audit snippet metadata and coverage
-    deps: [snippets:install]
+    deps: ["snippets:install"]
     cmds:
       - alef snippets audit --snippets docs/snippets
 
   snippets:gaps:
     desc: Report missing snippet variants across languages
-    deps: [snippets:install]
+    deps: ["snippets:install"]
     cmds:
       - alef snippets gaps --snippets docs/snippets


### PR DESCRIPTION
## Summary

- Fix `docs:lint:prose`: delegate to `prek run textlint --all-files` so the textlint rule pack (declared in the pre-commit hook's isolated env via `additional_dependencies`) is actually loaded. The previous bare `npx textlint` reported "No rules found".
- Quote the `snippets:install` flow scalars in `deps` so `.task/tools/docs.yml` passes the repo's `check-yaml` hook (a pre-existing latent failure unrelated to this task).
- Bump `docker/login-action` v4.1.0 → v4.2.0 (auto-applied by the `gh-actions-updater` hook).