### PR TITLE
feat(pptx): extract speaker notes and section names per slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **pptx**: `PageContent` gains two optional fields populated during PPTX per-page extraction (requires `page_config` to be set): `speaker_notes` (text from `ppt/notesSlides/notesSlideN.xml`) and `section_name` (from `<p14:sectionLst>` in `ppt/presentation.xml`). Both serialize with `skip_serializing_if = "Option::is_none"` and are `None` for all non-PPTX formats. (`crates/kreuzberg/src/types/page.rs`, `crates/kreuzberg/src/extraction/pptx/`)
+
 ### Changed
 
 - **deps**: bump alef pin to v0.19.5 (bundles AHashMap binding fixes for FFI/Dart/Swift/Elixir/Ruby/PHP and WASM emitter dedup + collect + From-impl + sub-config deserialize fixes).

--- a/crates/kreuzberg/src/extraction/derive.rs
+++ b/crates/kreuzberg/src/extraction/derive.rs
@@ -763,6 +763,8 @@ fn build_pages(doc: &InternalDocument) -> Option<Vec<PageContent>> {
                 hierarchy: None,
                 is_blank: None,
                 layout_regions: None,
+                speaker_notes: None,
+                section_name: None,
             }
         })
         .collect();

--- a/crates/kreuzberg/src/extraction/image.rs
+++ b/crates/kreuzberg/src/extraction/image.rs
@@ -557,6 +557,8 @@ pub(crate) fn extract_text_from_image_with_ocr(
             hierarchy: None,
             is_blank: Some(crate::extraction::blank_detection::is_page_text_blank(frame_text)),
             layout_regions: None,
+            speaker_notes: None,
+            section_name: None,
         });
 
         byte_offset = frame_end;

--- a/crates/kreuzberg/src/extraction/ooxml_constants.rs
+++ b/crates/kreuzberg/src/extraction/ooxml_constants.rs
@@ -43,3 +43,8 @@ pub const WORDPROCESSINGDRAWING_NAMESPACE: &str =
 ///
 /// Used in: `<pic:...>` elements (pic, blipFill)
 pub const PICTURE_NAMESPACE: &str = "http://schemas.openxmlformats.org/drawingml/2006/picture";
+
+/// PowerPoint 2010 extension namespace - sections and other extended features.
+///
+/// Used in: `<p14:sectionLst>`, `<p14:section>` elements inside `<p:extLst>`
+pub const PRESENTATIONML_2010_NAMESPACE: &str = "http://schemas.microsoft.com/office/powerpoint/2010/main";

--- a/crates/kreuzberg/src/extraction/pptx/content_builder.rs
+++ b/crates/kreuzberg/src/extraction/pptx/content_builder.rs
@@ -57,7 +57,14 @@ impl ContentBuilder {
         byte_start
     }
 
-    pub(super) fn end_slide(&mut self, slide_number: u32, byte_start: usize, slide_content: String) {
+    pub(super) fn end_slide(
+        &mut self,
+        slide_number: u32,
+        byte_start: usize,
+        slide_content: String,
+        speaker_notes: Option<String>,
+        section_name: Option<String>,
+    ) {
         let byte_end = self.content.len();
 
         if self.config.is_some() {
@@ -76,6 +83,8 @@ impl ContentBuilder {
                 hierarchy: None,
                 is_blank,
                 layout_regions: None,
+                speaker_notes,
+                section_name,
             });
         }
     }

--- a/crates/kreuzberg/src/extraction/pptx/metadata.rs
+++ b/crates/kreuzberg/src/extraction/pptx/metadata.rs
@@ -21,7 +21,9 @@ use serde_json::Value;
 
 use super::container::PptxContainer;
 
-use crate::extraction::ooxml_constants::DRAWINGML_NAMESPACE;
+use crate::extraction::ooxml_constants::{
+    DRAWINGML_NAMESPACE, PRESENTATIONML_2010_NAMESPACE, PRESENTATIONML_NAMESPACE,
+};
 
 /// Extract comprehensive metadata from PPTX using office_metadata module.
 ///
@@ -151,6 +153,86 @@ pub(super) fn extract_all_notes<R: Read + Seek>(container: &mut PptxContainer<R>
     Ok(notes)
 }
 
+/// Extract section names from `ppt/presentation.xml`.
+///
+/// Reads the `<p14:sectionLst>` extension element (PowerPoint 2010+) and maps
+/// each slide position (1-indexed) to the name of the section it belongs to.
+/// Returns an empty map when no sections exist or the feature is unavailable.
+pub(super) fn extract_section_names<R: Read + Seek>(container: &mut PptxContainer<R>) -> Result<HashMap<u32, String>> {
+    let xml = match container.read_file("ppt/presentation.xml") {
+        Ok(data) => data,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let xml_str = match crate::text::utf8_validation::from_utf8(&xml) {
+        Ok(s) => s,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    let doc = match roxmltree::Document::parse(xml_str) {
+        Ok(d) => d,
+        Err(_) => return Ok(HashMap::new()),
+    };
+
+    // Build ordered slide-id → position map from <p:sldIdLst><p:sldId id="N"/>
+    let mut id_to_position: HashMap<u32, u32> = HashMap::new();
+    for node in doc.descendants() {
+        if node.has_tag_name((PRESENTATIONML_NAMESPACE, "sldIdLst")) {
+            let mut position: u32 = 1;
+            for child in node.children() {
+                if child.has_tag_name((PRESENTATIONML_NAMESPACE, "sldId")) {
+                    if let Some(id_str) = child.attribute("id")
+                        && let Ok(id) = id_str.parse::<u32>()
+                    {
+                        id_to_position.insert(id, position);
+                    }
+                    position += 1;
+                }
+            }
+            break;
+        }
+    }
+
+    if id_to_position.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Find <p14:sectionLst> inside <p:extLst> and map slide positions to section names
+    let mut result: HashMap<u32, String> = HashMap::new();
+    for node in doc.descendants() {
+        if node.has_tag_name((PRESENTATIONML_2010_NAMESPACE, "sectionLst")) {
+            for section in node.children() {
+                if !section.has_tag_name((PRESENTATIONML_2010_NAMESPACE, "section")) {
+                    continue;
+                }
+                let name = match section.attribute("name") {
+                    Some(n) if !n.is_empty() => n.to_string(),
+                    _ => continue,
+                };
+                for sld_id_lst in section.children() {
+                    if !sld_id_lst.has_tag_name((PRESENTATIONML_2010_NAMESPACE, "sectionSldIdLst")) {
+                        continue;
+                    }
+                    for sld_id in sld_id_lst.children() {
+                        if !sld_id.has_tag_name((PRESENTATIONML_2010_NAMESPACE, "sectionSldId")) {
+                            continue;
+                        }
+                        if let Some(id_str) = sld_id.attribute("id")
+                            && let Ok(id) = id_str.parse::<u32>()
+                            && let Some(&position) = id_to_position.get(&id)
+                        {
+                            result.insert(position, name.clone());
+                        }
+                    }
+                }
+            }
+            break;
+        }
+    }
+
+    Ok(result)
+}
+
 fn extract_notes_text(notes_xml: &[u8]) -> Result<String> {
     let xml_str = utf8_validation::from_utf8(notes_xml)
         .map_err(|e| crate::error::KreuzbergError::parsing(format!("Invalid UTF-8 in notes XML: {}", e)))?;
@@ -168,4 +250,179 @@ fn extract_notes_text(notes_xml: &[u8]) -> Result<String> {
     }
 
     Ok(text_parts.join(" "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use zip::write::{SimpleFileOptions, ZipWriter};
+
+    fn make_pptx_with_sections(slide_ids: &[(u32, &str)], sections: &[(&str, &[u32])]) -> Vec<u8> {
+        use std::io::Write;
+
+        // Build <p:sldIdLst>
+        let mut sld_id_lst = String::new();
+        for (i, (id, _)) in slide_ids.iter().enumerate() {
+            sld_id_lst.push_str(&format!(r#"<p:sldId id="{}" r:id="rId{}"/>"#, id, i + 1));
+        }
+
+        // Build <p14:sectionLst>
+        let mut section_lst = String::new();
+        for (name, ids) in sections {
+            let mut sld_ids = String::new();
+            for id in *ids {
+                sld_ids.push_str(&format!(r#"<p14:sectionSldId id="{}"/>"#, id));
+            }
+            section_lst.push_str(&format!(
+                r#"<p14:section name="{}"><p14:sectionSldIdLst>{}</p14:sectionSldIdLst></p14:section>"#,
+                name, sld_ids
+            ));
+        }
+
+        let presentation_xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+                xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main">
+  <p:sldIdLst>{}</p:sldIdLst>
+  <p:extLst>
+    <p:ext uri="{{521415D9-36F7-43E2-AB2F-B90AF26B5E84}}">
+      <p14:sectionLst>{}</p14:sectionLst>
+    </p:ext>
+  </p:extLst>
+</p:presentation>"#,
+            sld_id_lst, section_lst
+        );
+
+        let mut buffer = Vec::new();
+        let mut zip = ZipWriter::new(Cursor::new(&mut buffer));
+        let opts = SimpleFileOptions::default();
+
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(
+            b"<?xml version=\"1.0\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"/>",
+        )
+        .unwrap();
+
+        zip.start_file("_rels/.rels", opts).unwrap();
+        zip.write_all(b"<?xml version=\"1.0\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"/>").unwrap();
+
+        zip.start_file("ppt/_rels/presentation.xml.rels", opts).unwrap();
+        let mut pres_rels = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        );
+        for (i, (_, path)) in slide_ids.iter().enumerate() {
+            pres_rels.push_str(&format!(
+                r#"<Relationship Id="rId{}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="{}"/>"#,
+                i + 1,
+                path
+            ));
+        }
+        pres_rels.push_str("</Relationships>");
+        zip.write_all(pres_rels.as_bytes()).unwrap();
+
+        zip.start_file("ppt/presentation.xml", opts).unwrap();
+        zip.write_all(presentation_xml.as_bytes()).unwrap();
+
+        for (i, (_, path)) in slide_ids.iter().enumerate() {
+            let slide_xml = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>Slide {}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+</p:sld>"#,
+                i + 1
+            );
+            zip.start_file(format!("ppt/{}", path), opts).unwrap();
+            zip.write_all(slide_xml.as_bytes()).unwrap();
+        }
+
+        let _ = zip.finish().unwrap();
+        buffer
+    }
+
+    #[test]
+    fn test_extract_section_names_two_sections() {
+        let pptx = make_pptx_with_sections(
+            &[
+                (256, "slides/slide1.xml"),
+                (257, "slides/slide2.xml"),
+                (258, "slides/slide3.xml"),
+            ],
+            &[("Introduction", &[256]), ("Main Content", &[257, 258])],
+        );
+        let mut container = PptxContainer::from_bytes(&pptx).unwrap();
+        let sections = extract_section_names(&mut container).unwrap();
+
+        assert_eq!(sections.get(&1), Some(&"Introduction".to_string()));
+        assert_eq!(sections.get(&2), Some(&"Main Content".to_string()));
+        assert_eq!(sections.get(&3), Some(&"Main Content".to_string()));
+    }
+
+    #[test]
+    fn test_extract_section_names_no_sections() {
+        let pptx = make_pptx_with_sections(
+            &[(256, "slides/slide1.xml"), (257, "slides/slide2.xml")],
+            &[], // no sections
+        );
+        let mut container = PptxContainer::from_bytes(&pptx).unwrap();
+        let sections = extract_section_names(&mut container).unwrap();
+
+        assert!(sections.is_empty(), "Expected empty map when no sections defined");
+    }
+
+    #[test]
+    fn test_extract_section_names_single_section_all_slides() {
+        let pptx = make_pptx_with_sections(
+            &[(300, "slides/slide1.xml"), (301, "slides/slide2.xml")],
+            &[("Only Section", &[300, 301])],
+        );
+        let mut container = PptxContainer::from_bytes(&pptx).unwrap();
+        let sections = extract_section_names(&mut container).unwrap();
+
+        assert_eq!(sections.get(&1), Some(&"Only Section".to_string()));
+        assert_eq!(sections.get(&2), Some(&"Only Section".to_string()));
+    }
+
+    #[test]
+    fn test_extract_section_names_invalid_utf8_returns_empty() {
+        use std::io::Write;
+
+        // Build a PPTX with a presentation.xml containing invalid UTF-8 bytes.
+        let mut buffer = Vec::new();
+        let mut zip = ZipWriter::new(Cursor::new(&mut buffer));
+        let opts = SimpleFileOptions::default();
+
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(
+            b"<?xml version=\"1.0\"?><Types xmlns=\"http://schemas.openxmlformats.org/package/2006/content-types\"/>",
+        )
+        .unwrap();
+
+        zip.start_file("_rels/.rels", opts).unwrap();
+        zip.write_all(b"<?xml version=\"1.0\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"/>").unwrap();
+
+        zip.start_file("ppt/_rels/presentation.xml.rels", opts).unwrap();
+        zip.write_all(b"<?xml version=\"1.0\"?><Relationships xmlns=\"http://schemas.openxmlformats.org/package/2006/relationships\"><Relationship Id=\"rId1\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide\" Target=\"slides/slide1.xml\"/></Relationships>").unwrap();
+
+        // Write invalid UTF-8 bytes into presentation.xml
+        zip.start_file("ppt/presentation.xml", opts).unwrap();
+        zip.write_all(b"\xff\xfe invalid utf8 \x80\x81\x82").unwrap();
+
+        zip.start_file("ppt/slides/slide1.xml", opts).unwrap();
+        zip.write_all(b"<?xml version=\"1.0\"?><p:sld xmlns:p=\"http://schemas.openxmlformats.org/presentationml/2006/main\" xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\"><p:cSld><p:spTree/></p:cSld></p:sld>").unwrap();
+
+        let _ = zip.finish().unwrap();
+
+        let mut container = PptxContainer::from_bytes(&buffer).unwrap();
+        // Must not panic; returns empty map gracefully.
+        let sections = extract_section_names(&mut container).unwrap();
+        assert!(
+            sections.is_empty(),
+            "Expected empty map for invalid UTF-8 presentation.xml"
+        );
+    }
 }

--- a/crates/kreuzberg/src/extraction/pptx/mod.rs
+++ b/crates/kreuzberg/src/extraction/pptx/mod.rs
@@ -58,7 +58,7 @@ use container::{PptxContainer, SlideIterator};
 use content_builder::ContentBuilder;
 use elements::{ParserConfig, Run, SlideElement};
 use image_handling::detect_image_format;
-use metadata::{extract_all_notes, extract_metadata};
+use metadata::{extract_all_notes, extract_metadata, extract_section_names};
 
 /// Options for PPTX content extraction.
 #[cfg_attr(alef, alef(skip))]
@@ -153,6 +153,7 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
     let (metadata, office_metadata) = extract_metadata(&mut container.archive);
 
     let notes = extract_all_notes(&mut container)?;
+    let section_names = extract_section_names(&mut container)?;
 
     let mut iterator = SlideIterator::new(container);
     let slide_count = iterator.slide_count();
@@ -181,12 +182,21 @@ fn extract_pptx_from_container<R: std::io::Read + std::io::Seek>(
         let slide_content = slide.to_markdown(&config);
         content_builder.add_text(&slide_content);
 
-        if let Some(slide_notes) = notes.get(&slide.slide_number) {
-            content_builder.add_notes(slide_notes);
+        let slide_notes = notes.get(&slide.slide_number).cloned();
+        if let Some(ref note_text) = slide_notes {
+            content_builder.add_notes(note_text);
         }
 
+        let slide_section = section_names.get(&slide.slide_number).cloned();
+
         if page_config.is_some() {
-            content_builder.end_slide(slide.slide_number, byte_start, slide_content.clone());
+            content_builder.end_slide(
+                slide.slide_number,
+                byte_start,
+                slide_content.clone(),
+                slide_notes,
+                slide_section,
+            );
         }
 
         // Build document structure for this slide (only when requested)
@@ -693,7 +703,7 @@ impl elements::Slide {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     fn create_test_pptx_bytes(slides: Vec<&str>) -> Vec<u8> {
@@ -903,6 +913,263 @@ mod tests {
         );
 
         assert!(result.is_err());
+    }
+
+    /// Build a PPTX bytes with sections and optional speaker notes for integration testing.
+    pub(crate) fn create_pptx_with_sections_and_notes(
+        slides: &[(&str, Option<&str>)], // (text, notes)
+        sections: &[(&str, &[usize])],   // (name, 1-indexed slide positions)
+    ) -> Vec<u8> {
+        use std::io::Write;
+        use zip::write::{SimpleFileOptions, ZipWriter};
+
+        let mut buffer = Vec::new();
+        let mut zip = ZipWriter::new(std::io::Cursor::new(&mut buffer));
+        let opts = SimpleFileOptions::default();
+
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+    <Default Extension="xml" ContentType="application/xml"/>
+    <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+</Types>"#,
+        )
+        .unwrap();
+
+        zip.start_file("_rels/.rels", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+    <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>"#).unwrap();
+
+        // Build rels file listing each slide
+        let mut pres_rels = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        );
+        for (i, _) in slides.iter().enumerate() {
+            use std::fmt::Write as FmtWrite;
+            let _ = write!(
+                pres_rels,
+                r#"<Relationship Id="rId{id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide{id}.xml"/>"#,
+                id = i + 1
+            );
+        }
+        pres_rels.push_str("</Relationships>");
+        zip.start_file("ppt/_rels/presentation.xml.rels", opts).unwrap();
+        zip.write_all(pres_rels.as_bytes()).unwrap();
+
+        // Build sldIdLst: base ID = 256
+        let base_id: u32 = 256;
+        let mut sld_id_lst = String::new();
+        for (i, _) in slides.iter().enumerate() {
+            use std::fmt::Write as FmtWrite;
+            let _ = write!(
+                sld_id_lst,
+                r#"<p:sldId id="{}" r:id="rId{}"/>"#,
+                base_id + i as u32,
+                i + 1
+            );
+        }
+
+        // Build sectionLst
+        let mut section_lst = String::new();
+        for (name, positions) in sections {
+            use std::fmt::Write as FmtWrite;
+            let mut sld_ids = String::new();
+            for &pos in *positions {
+                let _ = write!(sld_ids, r#"<p14:sectionSldId id="{}"/>"#, base_id + (pos as u32 - 1));
+            }
+            let _ = write!(
+                section_lst,
+                r#"<p14:section name="{}"><p14:sectionSldIdLst>{}</p14:sectionSldIdLst></p14:section>"#,
+                name, sld_ids
+            );
+        }
+
+        let ext_lst = if section_lst.is_empty() {
+            String::new()
+        } else {
+            format!(
+                r#"<p:extLst><p:ext uri="{{521415D9-36F7-43E2-AB2F-B90AF26B5E84}}"><p14:sectionLst xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main">{}</p14:sectionLst></p:ext></p:extLst>"#,
+                section_lst
+            )
+        };
+
+        let presentation_xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main"
+                xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <p:sldIdLst>{}</p:sldIdLst>
+  {}
+</p:presentation>"#,
+            sld_id_lst, ext_lst
+        );
+        zip.start_file("ppt/presentation.xml", opts).unwrap();
+        zip.write_all(presentation_xml.as_bytes()).unwrap();
+
+        // Write slide XML and optional notes XML
+        for (i, (text, notes)) in slides.iter().enumerate() {
+            let slide_xml = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+       xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+    <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>{}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+</p:sld>"#,
+                text
+            );
+            zip.start_file(format!("ppt/slides/slide{}.xml", i + 1), opts).unwrap();
+            zip.write_all(slide_xml.as_bytes()).unwrap();
+
+            if let Some(note_text) = notes {
+                let notes_xml = format!(
+                    r#"<?xml version="1.0" encoding="UTF-8"?>
+<p:notes xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+         xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+    <p:cSld><p:spTree><p:sp><p:txBody><a:p><a:r><a:t>{}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld>
+</p:notes>"#,
+                    note_text
+                );
+                zip.start_file(format!("ppt/notesSlides/notesSlide{}.xml", i + 1), opts)
+                    .unwrap();
+                zip.write_all(notes_xml.as_bytes()).unwrap();
+            }
+        }
+
+        zip.start_file("docProps/core.xml", opts).unwrap();
+        zip.write_all(
+            br#"<?xml version="1.0" encoding="UTF-8"?>
+<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties"
+                   xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>Test</dc:title></cp:coreProperties>"#,
+        )
+        .unwrap();
+
+        let app_xml = format!(
+            r#"<?xml version="1.0"?><Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties"><Slides>{}</Slides></Properties>"#,
+            slides.len()
+        );
+        zip.start_file("docProps/app.xml", opts).unwrap();
+        zip.write_all(app_xml.as_bytes()).unwrap();
+
+        let _ = zip.finish().unwrap();
+        buffer
+    }
+
+    #[test]
+    fn test_speaker_notes_in_page_contents() {
+        use crate::core::config::PageConfig;
+
+        let pptx = create_pptx_with_sections_and_notes(
+            &[
+                ("Intro Slide", Some("These are intro notes.")),
+                ("Content Slide", None),
+                ("Outro Slide", Some("Final notes here.")),
+            ],
+            &[],
+        );
+
+        let result = extract_pptx_from_bytes(
+            &pptx,
+            &PptxExtractionOptions {
+                extract_images: false,
+                page_config: Some(PageConfig::default()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let pages = result
+            .page_contents
+            .as_ref()
+            .expect("page_contents should be populated");
+        assert_eq!(pages.len(), 3);
+
+        assert_eq!(pages[0].speaker_notes.as_deref(), Some("These are intro notes."));
+        assert!(pages[1].speaker_notes.is_none(), "slide 2 has no notes");
+        assert_eq!(pages[2].speaker_notes.as_deref(), Some("Final notes here."));
+    }
+
+    #[test]
+    fn test_section_name_in_page_contents() {
+        use crate::core::config::PageConfig;
+
+        let pptx = create_pptx_with_sections_and_notes(
+            &[("Slide 1", None), ("Slide 2", None), ("Slide 3", None)],
+            &[("Introduction", &[1]), ("Deep Dive", &[2, 3])],
+        );
+
+        let result = extract_pptx_from_bytes(
+            &pptx,
+            &PptxExtractionOptions {
+                extract_images: false,
+                page_config: Some(PageConfig::default()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let pages = result
+            .page_contents
+            .as_ref()
+            .expect("page_contents should be populated");
+        assert_eq!(pages.len(), 3);
+
+        assert_eq!(pages[0].section_name.as_deref(), Some("Introduction"));
+        assert_eq!(pages[1].section_name.as_deref(), Some("Deep Dive"));
+        assert_eq!(pages[2].section_name.as_deref(), Some("Deep Dive"));
+    }
+
+    #[test]
+    fn test_section_name_and_notes_combined() {
+        use crate::core::config::PageConfig;
+
+        let pptx = create_pptx_with_sections_and_notes(
+            &[
+                ("Title Slide", Some("Welcome notes.")),
+                ("Methods", Some("Methodology notes.")),
+            ],
+            &[("Part One", &[1, 2])],
+        );
+
+        let result = extract_pptx_from_bytes(
+            &pptx,
+            &PptxExtractionOptions {
+                extract_images: false,
+                page_config: Some(PageConfig::default()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let pages = result
+            .page_contents
+            .as_ref()
+            .expect("page_contents should be populated");
+        assert_eq!(pages[0].section_name.as_deref(), Some("Part One"));
+        assert_eq!(pages[0].speaker_notes.as_deref(), Some("Welcome notes."));
+        assert_eq!(pages[1].section_name.as_deref(), Some("Part One"));
+        assert_eq!(pages[1].speaker_notes.as_deref(), Some("Methodology notes."));
+    }
+
+    #[test]
+    fn test_no_page_contents_without_page_config() {
+        let pptx = create_pptx_with_sections_and_notes(&[("Slide 1", Some("Notes."))], &[("Section A", &[1])]);
+
+        let result = extract_pptx_from_bytes(
+            &pptx,
+            &PptxExtractionOptions {
+                extract_images: false,
+                // no page_config → page_contents should be None
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        assert!(
+            result.page_contents.is_none(),
+            "page_contents should be None when page_config is not set"
+        );
     }
 
     #[test]

--- a/crates/kreuzberg/src/extraction/transform/mod.rs
+++ b/crates/kreuzberg/src/extraction/transform/mod.rs
@@ -295,6 +295,8 @@ mod tests {
                     }),
                     is_blank: None,
                     layout_regions: None,
+                    speaker_notes: None,
+                    section_name: None,
                 },
                 PageContent {
                     page_number: 2,
@@ -304,6 +306,8 @@ mod tests {
                     hierarchy: None,
                     is_blank: None,
                     layout_regions: None,
+                    speaker_notes: None,
+                    section_name: None,
                 },
             ]),
             ..Default::default()
@@ -400,6 +404,8 @@ mod tests {
                 hierarchy: None,
                 is_blank: None,
                 layout_regions: None,
+                speaker_notes: None,
+                section_name: None,
             }]),
             ..Default::default()
         };
@@ -599,6 +605,8 @@ mod tests {
                 }),
                 is_blank: None,
                 layout_regions: None,
+                speaker_notes: None,
+                section_name: None,
             }]),
             ..Default::default()
         };
@@ -663,6 +671,8 @@ mod tests {
                 }),
                 is_blank: None,
                 layout_regions: None,
+                speaker_notes: None,
+                section_name: None,
             }]),
             ..Default::default()
         };

--- a/crates/kreuzberg/src/extractors/docx.rs
+++ b/crates/kreuzberg/src/extractors/docx.rs
@@ -1381,6 +1381,8 @@ impl DocumentExtractor for DocxExtractor {
                         hierarchy: None,
                         is_blank: Some(is_blank),
                         layout_regions: None,
+                        speaker_notes: None,
+                        section_name: None,
                     });
                 }
                 Some(pages)
@@ -1394,6 +1396,8 @@ impl DocumentExtractor for DocxExtractor {
                     hierarchy: None,
                     is_blank: Some(text.chars().filter(|c| !c.is_whitespace()).count() < 3),
                     layout_regions: None,
+                    speaker_notes: None,
+                    section_name: None,
                 }])
             }
         };

--- a/crates/kreuzberg/src/extractors/image.rs
+++ b/crates/kreuzberg/src/extractors/image.rs
@@ -119,6 +119,8 @@ impl ImageExtractor {
                         hierarchy: None,
                         is_blank: None,
                         layout_regions: None,
+                        speaker_notes: None,
+                        section_name: None,
                     }]);
                 }
             }
@@ -144,6 +146,8 @@ impl ImageExtractor {
                     hierarchy: None,
                     is_blank: None,
                     layout_regions: None,
+                    speaker_notes: None,
+                    section_name: None,
                 }]);
             }
             Ok(doc)

--- a/crates/kreuzberg/src/extractors/pdf/mod.rs
+++ b/crates/kreuzberg/src/extractors/pdf/mod.rs
@@ -387,6 +387,8 @@ impl PdfExtractor {
                                 hierarchy: None,
                                 is_blank: None,
                                 layout_regions: None,
+                                speaker_notes: None,
+                                section_name: None,
                             })
                             .collect(),
                     );
@@ -1303,6 +1305,8 @@ mod tests {
                 hierarchy: None,
                 is_blank: None,
                 layout_regions: None,
+                speaker_notes: None,
+                section_name: None,
             })
             .collect();
         let pages_len = pages.len();

--- a/crates/kreuzberg/src/extractors/ppt.rs
+++ b/crates/kreuzberg/src/extractors/ppt.rs
@@ -318,4 +318,37 @@ mod tests {
         let slide_count = result.metadata.additional.get("slide_count").unwrap();
         assert!(slide_count.as_u64().unwrap_or(0) > 0, "Slide count should be > 0");
     }
+
+    /// PPT speaker notes go to `metadata.additional["speaker_notes"]` as a JSON array,
+    /// NOT to `PageContent.speaker_notes`.  The legacy binary format does not support
+    /// per-slide `PageContent` objects, so `page_contents` is always `None` for PPT
+    /// regardless of whether `page_config` is set.
+    #[tokio::test]
+    async fn test_ppt_speaker_notes_in_metadata_not_page_contents() {
+        let test_file = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test_documents/ppt/simple.ppt");
+        if !test_file.exists() {
+            return;
+        }
+        let content = std::fs::read(&test_file).expect("Failed to read test PPT");
+        let extractor = PptExtractor::new();
+        let config = ExtractionConfig {
+            pages: Some(crate::core::config::PageConfig::default()),
+            ..Default::default()
+        };
+        let result = extractor
+            .extract_bytes(&content, "application/vnd.ms-powerpoint", &config)
+            .await
+            .expect("PPT extraction failed");
+        let result =
+            crate::extraction::derive::derive_extraction_result(result, true, crate::core::config::OutputFormat::Plain);
+        // PPT path uses InternalDocumentBuilder — no per-slide PageContent objects.
+        assert!(
+            result.pages.is_none(),
+            "PPT should not produce pages; speaker notes are in metadata.additional"
+        );
+        // If the fixture has notes, they surface under metadata.additional["speaker_notes"].
+        if let Some(notes) = result.metadata.additional.get("speaker_notes") {
+            assert!(notes.is_array(), "PPT speaker_notes in metadata should be a JSON array");
+        }
+    }
 }

--- a/crates/kreuzberg/src/extractors/pptx.rs
+++ b/crates/kreuzberg/src/extractors/pptx.rs
@@ -293,6 +293,9 @@ impl PptxExtractor {
             doc.push_uri(Uri::hyperlink(&url, label));
         }
 
+        // Transfer per-page content (speaker notes, section names, etc.)
+        doc.prebuilt_pages = pptx_result.page_contents;
+
         // Transfer images
         if extract_images {
             doc.images = pptx_result.images;
@@ -479,5 +482,47 @@ mod tests {
         let mime_types = extractor.supported_mime_types();
         assert_eq!(mime_types.len(), 5);
         assert!(mime_types.contains(&"application/vnd.openxmlformats-officedocument.presentationml.presentation"));
+    }
+
+    /// Full round-trip through PptxExtractor::extract_bytes → derive_extraction_result →
+    /// ExtractionResult.pages, asserting that speaker_notes and section_name are present.
+    #[tokio::test]
+    async fn test_extract_bytes_populates_speaker_notes_and_section_name() {
+        use crate::core::config::{ExtractionConfig, PageConfig};
+        use crate::extraction::derive::derive_extraction_result;
+        use crate::plugins::DocumentExtractor;
+
+        let pptx = crate::extraction::pptx::tests::create_pptx_with_sections_and_notes(
+            &[
+                ("Title", Some("Intro notes.")),
+                ("Body", Some("Body notes.")),
+                ("End", None),
+            ],
+            &[("Chapter 1", &[1, 2]), ("Chapter 2", &[3])],
+        );
+
+        let extractor = PptxExtractor::new();
+        let config = ExtractionConfig {
+            pages: Some(PageConfig::default()),
+            ..Default::default()
+        };
+        let mime = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+        let internal_doc = extractor
+            .extract_bytes(&pptx, mime, &config)
+            .await
+            .expect("extraction failed");
+        let result = derive_extraction_result(internal_doc, true, crate::core::config::OutputFormat::Plain);
+
+        let pages = result.pages.as_ref().expect("pages should be populated");
+        assert_eq!(pages.len(), 3);
+
+        assert_eq!(pages[0].speaker_notes.as_deref(), Some("Intro notes."));
+        assert_eq!(pages[0].section_name.as_deref(), Some("Chapter 1"));
+
+        assert_eq!(pages[1].speaker_notes.as_deref(), Some("Body notes."));
+        assert_eq!(pages[1].section_name.as_deref(), Some("Chapter 1"));
+
+        assert!(pages[2].speaker_notes.is_none());
+        assert_eq!(pages[2].section_name.as_deref(), Some("Chapter 2"));
     }
 }

--- a/crates/kreuzberg/src/pdf/oxide/text.rs
+++ b/crates/kreuzberg/src/pdf/oxide/text.rs
@@ -188,6 +188,8 @@ fn extract_text_with_tracking(doc: &mut OxideDocument, config: &PageConfig) -> R
                 hierarchy: None,
                 is_blank,
                 layout_regions: None,
+                speaker_notes: None,
+                section_name: None,
             });
         }
 

--- a/crates/kreuzberg/src/types/mod.rs
+++ b/crates/kreuzberg/src/types/mod.rs
@@ -170,6 +170,8 @@ mod tests {
             hierarchy: None,
             is_blank: None,
             layout_regions: None,
+            speaker_notes: None,
+            section_name: None,
         };
 
         let json = serde_json::to_string(&page).unwrap();
@@ -192,6 +194,8 @@ mod tests {
             hierarchy: None,
             is_blank: None,
             layout_regions: None,
+            speaker_notes: None,
+            section_name: None,
         };
 
         let json = serde_json::to_string(&page).unwrap();
@@ -222,6 +226,8 @@ mod tests {
             hierarchy: None,
             is_blank: None,
             layout_regions: None,
+            speaker_notes: None,
+            section_name: None,
         };
 
         let page2 = PageContent {
@@ -232,6 +238,8 @@ mod tests {
             hierarchy: None,
             is_blank: None,
             layout_regions: None,
+            speaker_notes: None,
+            section_name: None,
         };
 
         assert!(Arc::ptr_eq(&page1.tables[0], &page2.tables[0]));
@@ -255,6 +263,8 @@ mod tests {
             hierarchy: None,
             is_blank: None,
             layout_regions: None,
+            speaker_notes: None,
+            section_name: None,
         };
 
         let json = serde_json::to_string(&page).unwrap();

--- a/crates/kreuzberg/src/types/page.rs
+++ b/crates/kreuzberg/src/types/page.rs
@@ -176,6 +176,21 @@ pub struct PageContent {
     /// and area fraction. Only populated when layout detection is configured.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layout_regions: Option<Vec<LayoutRegion>>,
+
+    /// Speaker notes for this slide (PPTX only).
+    ///
+    /// Contains the text from the slide's notes pane (`ppt/notesSlides/notesSlide{N}.xml`).
+    /// Only populated when the source is a PPTX file and notes are present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub speaker_notes: Option<String>,
+
+    /// Section name this slide belongs to (PPTX only).
+    ///
+    /// PowerPoint sections group slides into logical chapters (`<p:sectionLst>` in
+    /// `ppt/presentation.xml`). Only populated when the source is a PPTX file and
+    /// the slide belongs to a named section.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub section_name: Option<String>,
 }
 
 /// A detected layout region on a page.


### PR DESCRIPTION
implements `speaker_notes` and `section_name` to `PageContent` for PPTX extraction.

Both fields are `Option<String>` with `skip_serializing_if = "Option::is_none"`. They are only populated when `pages` config is set and the source is a PPTX file; all other extractors receive `None`.

Also fixes a data-loss bug in `build_document_from_result` where `page_contents` was not transferred to `doc.prebuilt_pages`, causing both fields to be dropped through the full extractor path even when correctly populated by `extract_pptx_from_bytes`.

The legacy `.ppt` (OLE binary) path uses `InternalDocumentBuilder` and does not produce per-slide `PageContent` objects; speaker notes for `.ppt` remain in `metadata.additional["speaker_notes"]` as a JSON array (documented by `test_ppt_speaker_notes_in_metadata_not_page_contents`).

Closes #960