### PR TITLE
feat(publish): fix pub.dev trigger condition

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2037,11 +2037,11 @@ jobs:
 
   trigger-pubdev:
     name: Trigger pub.dev publish workflow
-    needs: [prepare, assemble-dart-bundle]
+    needs: [prepare, check-pub, assemble-dart-bundle]
     # pub.dev OIDC rejects tokens from `release` events. We dispatch a separate
     # workflow whose `workflow_dispatch` event produces an accepted token, then
     # have it download the assembled Dart package artifact from this run.
-    if: ${{ needs.prepare.outputs.release_dart == 'true' && needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.dry_run != 'true' }}
+    if: ${{ needs.prepare.outputs.release_dart == 'true' && needs.prepare.outputs.is_tag == 'true' && needs.prepare.outputs.dry_run != 'true' && (needs.check-pub.outputs.exists != 'true' || needs.prepare.outputs.force_republish == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       actions: write


### PR DESCRIPTION
Mirror html-to-markdown's pub.dev trigger logic: only dispatch publish-pubdev when the version doesn't already exist, or force_republish is set. This allows RC versions and explicit republishes to trigger correctly.

Previously, trigger-pubdev was missing the check-pub dependency and the force_republish/exists condition, causing pub.dev publishes to be skipped for v5.0.0-rc.1.