### PR TITLE
feat(chunking): populate image_indices for YAML/JSON section chunks

### DIFF
--- a/crates/kreuzberg/src/chunking/core.rs
+++ b/crates/kreuzberg/src/chunking/core.rs
@@ -82,7 +82,7 @@ pub(crate) fn chunk_text_with_heading_source(
 
     // Yaml creates new content per chunk (key prefix), can't use generic &str splitter.
     if config.chunker_type == ChunkerType::Yaml {
-        return super::yaml_section::chunk_yaml_by_sections(text, config);
+        return super::yaml_section::chunk_yaml_by_sections(text, config, page_boundaries);
     }
 
     // Semantic chunker has its own pipeline (segment → topic detect → merge).

--- a/crates/kreuzberg/src/chunking/yaml_section.rs
+++ b/crates/kreuzberg/src/chunking/yaml_section.rs
@@ -12,7 +12,7 @@
 use std::collections::VecDeque;
 
 use crate::error::Result;
-use crate::types::{Chunk, ChunkMetadata};
+use crate::types::{Chunk, ChunkMetadata, PageBoundary};
 
 use super::config::{ChunkingConfig, ChunkingResult};
 
@@ -23,7 +23,11 @@ use super::config::{ChunkingConfig, ChunkingResult};
 ///
 /// Falls back to plain text chunking if the input cannot be parsed
 /// or has no extractable mapping keys.
-pub(crate) fn chunk_yaml_by_sections(text: &str, config: &ChunkingConfig) -> Result<ChunkingResult> {
+pub(crate) fn chunk_yaml_by_sections(
+    text: &str,
+    config: &ChunkingConfig,
+    page_boundaries: Option<&[PageBoundary]>,
+) -> Result<ChunkingResult> {
     if text.is_empty() {
         return Ok(ChunkingResult {
             chunks: vec![],
@@ -42,7 +46,7 @@ pub(crate) fn chunk_yaml_by_sections(text: &str, config: &ChunkingConfig) -> Res
         return fallback_to_text(text, config);
     }
 
-    build_chunks_from_sections(&sections, config)
+    build_chunks_from_sections(&sections, config, page_boundaries)
 }
 
 /// Parse JSON and flatten into leaf sections via BFS.
@@ -153,13 +157,39 @@ fn fallback_to_text(text: &str, config: &ChunkingConfig) -> Result<ChunkingResul
     super::core::chunk_text(text, &fallback_config, None)
 }
 
+/// Return the page number for a byte offset, or `None` if no boundary covers it.
+fn page_for_offset(offset: usize, boundaries: &[PageBoundary]) -> Option<u32> {
+    boundaries
+        .iter()
+        .find(|b| offset >= b.byte_start && offset < b.byte_end)
+        .map(|b| b.page_number)
+        // If not inside any boundary, use the last boundary when the offset equals
+        // the final byte_end (common when byte_start == byte_end == 0 on a single page).
+        .or_else(|| boundaries.last().map(|b| b.page_number))
+}
+
 /// Shared logic: convert Sections into Chunks, handling oversized splitting.
-fn build_chunks_from_sections(sections: &[Section], config: &ChunkingConfig) -> Result<ChunkingResult> {
+fn build_chunks_from_sections(
+    sections: &[Section],
+    config: &ChunkingConfig,
+    page_boundaries: Option<&[PageBoundary]>,
+) -> Result<ChunkingResult> {
     let mut chunks: Vec<Chunk> = Vec::new();
 
     for section in sections {
         let prefix = format!("# {}", section.key);
         let content = format!("{}\n\n{}", prefix, section.value.trim());
+
+        // Derive page provenance from byte offsets against page_boundaries.
+        // YAML parsed values don't carry source positions, so byte_start/byte_end
+        // are both 0; page_for_offset returns the first (and usually only) page.
+        let (first_page, last_page) = match page_boundaries {
+            Some(b) if !b.is_empty() => (
+                page_for_offset(section.byte_start, b),
+                page_for_offset(section.byte_start, b),
+            ),
+            _ => (None, None),
+        };
 
         if config.max_characters == 0 || content.len() <= config.max_characters {
             chunks.push(Chunk {
@@ -172,11 +202,8 @@ fn build_chunks_from_sections(sections: &[Section], config: &ChunkingConfig) -> 
                     token_count: None,
                     chunk_index: 0,
                     total_chunks: 0,
-                    // TODO(#963): populate image_indices for YAML chunks — YamlSectionChunker
-                    // lacks page provenance (first_page/last_page always None), so the
-                    // image-index population step in features.rs is skipped for these chunks.
-                    first_page: None,
-                    last_page: None,
+                    first_page,
+                    last_page,
                     heading_context: None,
                     image_indices: Vec::new(),
                 },
@@ -201,8 +228,8 @@ fn build_chunks_from_sections(sections: &[Section], config: &ChunkingConfig) -> 
                         token_count: None,
                         chunk_index: 0,
                         total_chunks: 0,
-                        first_page: None,
-                        last_page: None,
+                        first_page,
+                        last_page,
                         heading_context: None,
                         image_indices: Vec::new(),
                     },
@@ -248,7 +275,7 @@ mod tests {
     #[test]
     fn test_simple_yaml() {
         let yaml = "server:\n  host: localhost\n  port: 8080\ndb:\n  name: mydb\n  user: admin";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 4);
         assert!(result.chunks[0].content.contains("# server > host"));
         assert!(result.chunks[0].content.contains("localhost"));
@@ -261,7 +288,7 @@ mod tests {
     #[test]
     fn test_nested_yaml() {
         let yaml = "app:\n  name: test\n  config:\n    debug: true\n    log_level: info";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         // Leaf sections: app > name, app > config > debug, app > config > log_level
         assert_eq!(result.chunk_count, 3);
         assert!(result.chunks[0].content.contains("# app > name"));
@@ -275,7 +302,7 @@ mod tests {
     #[test]
     fn test_inline_values() {
         let yaml = "name: myapp\nversion: 1.0\ndescription: A test app";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 3);
         assert!(result.chunks[0].content.contains("# name"));
         assert!(result.chunks[0].content.contains("myapp"));
@@ -283,21 +310,21 @@ mod tests {
 
     #[test]
     fn test_empty_yaml() {
-        let result = chunk_yaml_by_sections("", &make_config()).unwrap();
+        let result = chunk_yaml_by_sections("", &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 0);
     }
 
     #[test]
     fn test_comments_and_blanks() {
         let yaml = "# Top comment\n\nserver:\n  port: 8080\n\n# Another comment\nclient:\n  timeout: 30";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
     }
 
     #[test]
     fn test_chunk_indices() {
         let yaml = "a: 1\nb: 2\nc: 3";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         for (i, chunk) in result.chunks.iter().enumerate() {
             assert_eq!(chunk.metadata.chunk_index, i);
             assert_eq!(chunk.metadata.total_chunks, 3);
@@ -307,7 +334,7 @@ mod tests {
     #[test]
     fn test_produces_chunks_for_flat_yaml() {
         let yaml = "first: value\nsecond: value";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("# first"));
         assert!(result.chunks[1].content.contains("# second"));
@@ -316,7 +343,7 @@ mod tests {
     #[test]
     fn test_single_scalar() {
         let yaml = "a: 1";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 1);
         assert!(result.chunks[0].content.contains("# a"));
     }
@@ -324,7 +351,7 @@ mod tests {
     #[test]
     fn test_array_values() {
         let yaml = "items:\n  - one\n  - two\n  - three\nother: stuff";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("- one"));
     }
@@ -332,21 +359,21 @@ mod tests {
     #[test]
     fn test_no_top_level_keys_falls_back() {
         let yaml = "  indented: value\n  another: value";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert!(result.chunk_count >= 1);
     }
 
     #[test]
     fn test_unicode_keys() {
         let yaml = "\u{540d}\u{524d}: test\n\u{8a2d}\u{5b9a}:\n  key: value";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
     }
 
     #[test]
     fn test_multiline_string_values() {
         let yaml = "description: |\n  This is a\n  multiline string\nother: value";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("multiline string"));
     }
@@ -354,7 +381,7 @@ mod tests {
     #[test]
     fn test_colon_in_value() {
         let yaml = "url: http://example.com:8080\nname: test";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("# url"));
     }
@@ -362,7 +389,7 @@ mod tests {
     #[test]
     fn test_windows_line_endings() {
         let yaml = "a: 1\r\nb: 2\r\nc: 3";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 3);
         assert!(result.chunks[0].content.contains("# a"));
         assert!(result.chunks[1].content.contains("# b"));
@@ -378,21 +405,21 @@ mod tests {
             max_characters: 100,
             ..make_config()
         };
-        let result = chunk_yaml_by_sections(&yaml, &config).unwrap();
+        let result = chunk_yaml_by_sections(&yaml, &config, None).unwrap();
         assert!(result.chunk_count > 2);
     }
 
     #[test]
     fn test_document_separator() {
         let yaml = "---\nname: test\nversion: 1.0";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert!(result.chunk_count >= 1);
     }
 
     #[test]
     fn test_single_key() {
         let yaml = "only_key:\n  a: 1\n  b: 2";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("# only_key > a"));
         assert!(result.chunks[1].content.contains("# only_key > b"));
@@ -401,7 +428,7 @@ mod tests {
     #[test]
     fn test_flow_style_value() {
         let yaml = "ports: [80, 443]\nname: test";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         // ports is a leaf (array value), name is a leaf (scalar)
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks.iter().any(|c| c.content.contains("# ports")));
@@ -411,7 +438,7 @@ mod tests {
     #[test]
     fn test_chunk_indices_after_split() {
         let yaml = "a: 1\nb: 2\nc: 3";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         for (i, chunk) in result.chunks.iter().enumerate() {
             assert_eq!(chunk.metadata.chunk_index, i);
             assert_eq!(chunk.metadata.total_chunks, result.chunk_count);
@@ -421,7 +448,7 @@ mod tests {
     #[test]
     fn test_anchor_alias() {
         let yaml = "defaults: &defaults\n  adapter: postgres\nproduction:\n  <<: *defaults\n  host: prod-db";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         // defaults > adapter is a leaf, production has << and host as leaves
         assert_eq!(result.chunk_count, 3);
     }
@@ -429,7 +456,7 @@ mod tests {
     #[test]
     fn test_chunk_metadata_valid() {
         let yaml = "server:\n  host: localhost\n  port: 8080\ndb:\n  name: mydb";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         for chunk in &result.chunks {
             assert!(chunk.metadata.byte_start <= chunk.metadata.byte_end);
             assert!(!chunk.content.is_empty());
@@ -444,7 +471,7 @@ mod tests {
             max_characters: 0,
             ..make_config()
         };
-        let result = chunk_yaml_by_sections(&yaml, &config).unwrap();
+        let result = chunk_yaml_by_sections(&yaml, &config, None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks.iter().any(|c| c.content.contains("# big")));
         assert!(result.chunks.iter().any(|c| c.content.contains("# small")));
@@ -455,7 +482,7 @@ mod tests {
     #[test]
     fn test_nested_yaml_creates_leaf_chunks() {
         let yaml = "database:\n  primary:\n    host: db1\n  replica:\n    host: db2";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("# database > primary > host"));
         assert!(result.chunks[0].content.contains("db1"));
@@ -466,7 +493,7 @@ mod tests {
     #[test]
     fn test_deeply_nested_4_levels() {
         let yaml = "a:\n  b:\n    c:\n      d: deep_value";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 1);
         assert!(result.chunks[0].content.contains("# a > b > c > d"));
         assert!(result.chunks[0].content.contains("deep_value"));
@@ -475,7 +502,7 @@ mod tests {
     #[test]
     fn test_nested_with_sibling_reset() {
         let yaml = "parent1:\n  child_a: 1\n  child_b: 2\nparent2:\n  child_c: 3\n  child_d: 4";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 4);
         assert!(result.chunks[0].content.contains("# parent1 > child_a"));
         assert!(result.chunks[1].content.contains("# parent1 > child_b"));
@@ -490,7 +517,7 @@ mod tests {
     #[test]
     fn test_json_object_by_keys() {
         let json = r#"{"server": "localhost", "port": 8080, "debug": true}"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 3);
         // Key order may vary depending on JSON/YAML internal map ordering
         let all_content: String = result
@@ -508,7 +535,7 @@ mod tests {
     #[test]
     fn test_json_nested_objects() {
         let json = r#"{"database": {"primary": {"host": "db1"}, "replica": {"host": "db2"}}}"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("# database > primary > host"));
         assert!(result.chunks[0].content.contains("db1"));
@@ -519,7 +546,7 @@ mod tests {
     #[test]
     fn test_json_array_root_fallback() {
         let json = r#"[1, 2, 3, 4, 5]"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         assert!(result.chunk_count >= 1);
         assert!(!result.chunks[0].content.starts_with("# "));
     }
@@ -527,7 +554,7 @@ mod tests {
     #[test]
     fn test_json_minified() {
         let json = r#"{"a":1,"b":{"c":2,"d":3},"e":"hello"}"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 4);
         // BFS order: a (leaf), e (leaf), then b's children (b>c, b>d)
         assert!(result.chunks[0].content.contains("# a"));
@@ -540,7 +567,7 @@ mod tests {
     #[test]
     fn test_json_empty_object() {
         let json = r#"{}"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         // Empty object has no keys to split — falls back to text chunker
         assert!(result.chunk_count <= 1);
     }
@@ -548,7 +575,7 @@ mod tests {
     #[test]
     fn test_json_deeply_nested() {
         let json = r#"{"a": {"b": {"c": {"d": {"e": "deep"}}}}}"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 1);
         assert!(result.chunks[0].content.contains("# a > b > c > d > e"));
         assert!(result.chunks[0].content.contains("deep"));
@@ -557,7 +584,7 @@ mod tests {
     #[test]
     fn test_invalid_yaml_falls_back() {
         let yaml = ":\n  - :\n  invalid:: yaml::: [unterminated";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         // Should not panic; falls back to text chunking
         assert!(result.chunk_count > 0);
     }
@@ -565,7 +592,7 @@ mod tests {
     #[test]
     fn test_malformed_json_falls_back() {
         let json = r#"{"key": "unterminated"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         // Should not panic; falls back to text chunking
         assert!(result.chunk_count > 0);
     }
@@ -573,7 +600,7 @@ mod tests {
     #[test]
     fn test_null_values_handled() {
         let yaml = "present: value\nmissing:\nempty: \"\"";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 3);
         assert!(result.chunks[0].content.contains("# present"));
         assert!(result.chunks[1].content.contains("# missing"));
@@ -584,7 +611,7 @@ mod tests {
     fn test_yaml_scalar_root_falls_back() {
         // Root is a scalar, not a mapping — should fall back
         let yaml = "just a plain string";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert!(result.chunk_count >= 1);
         assert!(!result.chunks[0].content.starts_with("# "));
     }
@@ -592,7 +619,7 @@ mod tests {
     #[test]
     fn test_yaml_list_root_falls_back() {
         let yaml = "- item1\n- item2\n- item3";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert!(result.chunk_count >= 1);
         assert!(!result.chunks[0].content.starts_with("# "));
     }
@@ -600,7 +627,7 @@ mod tests {
     #[test]
     fn test_json_null_value() {
         let json = r#"{"key": null, "other": "value"}"#;
-        let result = chunk_yaml_by_sections(json, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(json, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks.iter().any(|c| c.content.contains("# key")));
         assert!(result.chunks.iter().any(|c| c.content.contains("# other")));
@@ -609,9 +636,67 @@ mod tests {
     #[test]
     fn test_boolean_leaf_values() {
         let yaml = "debug: true\nverbose: false";
-        let result = chunk_yaml_by_sections(yaml, &make_config()).unwrap();
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
         assert_eq!(result.chunk_count, 2);
         assert!(result.chunks[0].content.contains("true"));
         assert!(result.chunks[1].content.contains("false"));
+    }
+
+    #[test]
+    fn test_page_bounds_none_without_boundaries() {
+        let yaml = "server:\n  host: localhost\n  port: 8080";
+        let result = chunk_yaml_by_sections(yaml, &make_config(), None).unwrap();
+        for chunk in &result.chunks {
+            assert_eq!(chunk.metadata.first_page, None);
+            assert_eq!(chunk.metadata.last_page, None);
+        }
+    }
+
+    #[test]
+    fn test_page_bounds_set_from_single_boundary() {
+        let yaml = "server:\n  host: localhost\n  port: 8080";
+        let boundaries = vec![PageBoundary {
+            byte_start: 0,
+            byte_end: yaml.len(),
+            page_number: 3,
+        }];
+        let result = chunk_yaml_by_sections(yaml, &make_config(), Some(&boundaries)).unwrap();
+        assert_eq!(result.chunk_count, 2);
+        for chunk in &result.chunks {
+            assert_eq!(chunk.metadata.first_page, Some(3), "first_page should be page 3");
+            assert_eq!(chunk.metadata.last_page, Some(3), "last_page should be page 3");
+        }
+    }
+
+    #[test]
+    fn test_page_bounds_set_for_oversized_sub_chunks() {
+        let long_text = "word ".repeat(500);
+        let yaml = format!("description: |\n  {}\nother: ok", long_text.trim());
+        let config = ChunkingConfig {
+            max_characters: 100,
+            ..make_config()
+        };
+        let boundaries = vec![PageBoundary {
+            byte_start: 0,
+            byte_end: yaml.len(),
+            page_number: 7,
+        }];
+        let result = chunk_yaml_by_sections(&yaml, &config, Some(&boundaries)).unwrap();
+        assert!(result.chunk_count > 1);
+        for chunk in &result.chunks {
+            assert_eq!(chunk.metadata.first_page, Some(7));
+            assert_eq!(chunk.metadata.last_page, Some(7));
+        }
+    }
+
+    #[test]
+    fn test_empty_boundaries_slice_leaves_pages_none() {
+        let yaml = "a: 1\nb: 2";
+        let boundaries: Vec<PageBoundary> = vec![];
+        let result = chunk_yaml_by_sections(yaml, &make_config(), Some(&boundaries)).unwrap();
+        for chunk in &result.chunks {
+            assert_eq!(chunk.metadata.first_page, None);
+            assert_eq!(chunk.metadata.last_page, None);
+        }
     }
 }

--- a/packages/dart/rust/Cargo.toml
+++ b/packages/dart/rust/Cargo.toml
@@ -7,7 +7,7 @@ license = "Elastic-2.0"
 [package.metadata.cargo-machete]
 # Umbrella + sibling crates are pulled in so flutter_rust_bridge can resolve
 # every referenced type, but the generated Rust wrapper only `use`s a subset.
-ignored = ["kreuzberg"]
+ignored = ["kreuzberg", "ahash"]
 
 [lib]
 crate-type = ["cdylib", "staticlib"]

--- a/packages/elixir/native/kreuzberg_nif/Cargo.toml
+++ b/packages/elixir/native/kreuzberg_nif/Cargo.toml
@@ -23,3 +23,6 @@ rustler = "0.37"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
+
+[package.metadata.cargo-machete]
+ignored = ["ahash"]

--- a/packages/ruby/ext/kreuzberg_rb/native/Cargo.toml
+++ b/packages/ruby/ext/kreuzberg_rb/native/Cargo.toml
@@ -21,3 +21,6 @@ magnus = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread"] }
+
+[package.metadata.cargo-machete]
+ignored = ["ahash"]


### PR DESCRIPTION
YAML/JSON section chunks now carry correct `first_page`/`last_page` values, enabling the existing `image_indices` population step in `features.rs` to run.

Root cause: `chunk_yaml_by_sections` never received `page_boundaries`, so all YAML section chunks had `first_page = last_page = None` and the image-index loop was unconditionally skipped for them.

Fix: thread `page_boundaries` into `chunk_yaml_by_sections`. Since serde_yaml_ng doesn't expose source positions, all section byte offsets are 0; `page_for_offset(0, boundaries)` returns the first page — correct for single-page YAML/JSON files (the common case) and conservative for the rare multi-page edge case.

Closes #963