### PR TITLE
fix(table): replace unwrap() with unwrap_or on partial_cmp in detect_rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **table**: `detect_rows` sort comparator changed from `.unwrap()` to `.unwrap_or(Ordering::Equal)` on `partial_cmp`, eliminating a latent panic if a NaN y-center value were ever introduced. Defensive improvement; the `u32` fields of `HocrWord` cannot produce NaN today. (#1057)
 - **chunking (pptx)**: skip `<pic>` elements whose `<a:blip>` lacks `r:embed` instead of aborting the entire slide; logs a warning and preserves the rest of the slide content. (#1016)
 - **pdf/chunking**: populate `first_page`/`last_page` on every chunk from multi-page PDFs by normalising trailing whitespace in page content before locating it inside `result.content`; previously caused 7 of 24 chunks to have null page metadata. (#1013, #1004)
 - **chunking (yaml/json)**: populate `first_page`/`last_page` on YAML/JSON section chunks by threading `page_boundaries` into `chunk_yaml_by_sections`. This unblocks the image-indices population step in `features.rs` for YAML chunks. (#963)

--- a/crates/kreuzberg-ffi/tests/vtable_bytes_len.rs
+++ b/crates/kreuzberg-ffi/tests/vtable_bytes_len.rs
@@ -12,9 +12,7 @@
 /// Per-test state is passed via `user_data` — no global statics — so tests
 /// are independent and can run in parallel without interfering.
 use kreuzberg_ffi::{
-    KreuzbergDocumentExtractorBridge,
-    KreuzbergDocumentExtractorVTable,
-    KreuzbergOcrBackendBridge,
+    KreuzbergDocumentExtractorBridge, KreuzbergDocumentExtractorVTable, KreuzbergOcrBackendBridge,
     KreuzbergOcrBackendVTable,
 };
 use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
@@ -112,12 +110,12 @@ async fn ocr_backend_vtable_process_image_passes_full_length_with_embedded_nuls(
     };
 
     // SAFETY: state lives for the duration of this test and outlives the bridge.
-    let bridge = unsafe {
-        KreuzbergOcrBackendBridge::new("test-ocr-stub".to_string(), vtable, state_ptr)
-    };
+    let bridge = unsafe { KreuzbergOcrBackendBridge::new("test-ocr-stub".to_string(), vtable, state_ptr) };
 
     use kreuzberg::OcrBackend;
-    let _ = bridge.process_image(&image_bytes, &kreuzberg::OcrConfig::default()).await;
+    let _ = bridge
+        .process_image(&image_bytes, &kreuzberg::OcrConfig::default())
+        .await;
 
     assert_eq!(
         state.received_len.load(Ordering::SeqCst),
@@ -155,17 +153,15 @@ async fn document_extractor_vtable_extract_bytes_passes_full_length_with_embedde
     };
 
     // SAFETY: state lives for the duration of this test and outlives the bridge.
-    let bridge = unsafe {
-        KreuzbergDocumentExtractorBridge::new(
-            "test-extractor-stub".to_string(),
-            vtable,
-            state_ptr,
-        )
-    };
+    let bridge = unsafe { KreuzbergDocumentExtractorBridge::new("test-extractor-stub".to_string(), vtable, state_ptr) };
 
     use kreuzberg::DocumentExtractor;
     let _ = bridge
-        .extract_bytes(&content, "application/octet-stream", &kreuzberg::ExtractionConfig::default())
+        .extract_bytes(
+            &content,
+            "application/octet-stream",
+            &kreuzberg::ExtractionConfig::default(),
+        )
         .await;
 
     assert_eq!(
@@ -189,8 +185,20 @@ async fn document_extractor_vtable_extract_bytes_passes_full_length_with_embedde
 #[test]
 fn image_kind_page_raster_is_10_and_unknown_is_11() {
     // SAFETY: pure integer dispatch, no pointers.
-    assert_eq!(unsafe { kreuzberg_ffi::kreuzberg_image_kind_from_i32(10) }, 10, "PageRaster == 10");
-    assert_eq!(unsafe { kreuzberg_ffi::kreuzberg_image_kind_from_i32(11) }, 11, "Unknown == 11");
+    assert_eq!(
+        unsafe { kreuzberg_ffi::kreuzberg_image_kind_from_i32(10) },
+        10,
+        "PageRaster == 10"
+    );
+    assert_eq!(
+        unsafe { kreuzberg_ffi::kreuzberg_image_kind_from_i32(11) },
+        11,
+        "Unknown == 11"
+    );
     // Old Unknown value must now resolve to PageRaster, not Unknown.
-    assert_ne!(unsafe { kreuzberg_ffi::kreuzberg_image_kind_from_i32(10) }, -1, "10 must be valid");
+    assert_ne!(
+        unsafe { kreuzberg_ffi::kreuzberg_image_kind_from_i32(10) },
+        -1,
+        "10 must be valid"
+    );
 }

--- a/crates/kreuzberg/src/core/pipeline/features.rs
+++ b/crates/kreuzberg/src/core/pipeline/features.rs
@@ -366,6 +366,8 @@ mod tests {
             hierarchy: None,
             is_blank: None,
             layout_regions: None,
+            section_name: None,
+            speaker_notes: None,
         }
     }
 

--- a/crates/kreuzberg/src/table_core.rs
+++ b/crates/kreuzberg/src/table_core.rs
@@ -143,7 +143,7 @@ pub(crate) fn detect_rows(words: &[HocrWord], row_threshold_ratio: f64) -> Vec<u
         .filter(|group| !group.is_empty())
         .map(|group| {
             let mut sorted = group.clone();
-            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
             let mid = sorted.len() / 2;
             sorted[mid] as u32
         })
@@ -314,6 +314,37 @@ pub(crate) fn table_to_markdown(table: &[Vec<String>]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_detect_rows_zero_height_words_grouped_into_one_row() {
+        let words = vec![
+            HocrWord {
+                text: "A".to_string(),
+                left: 0,
+                top: 10,
+                width: 5,
+                height: 0,
+                confidence: 0.0,
+            },
+            HocrWord {
+                text: "B".to_string(),
+                left: 0,
+                top: 10,
+                width: 5,
+                height: 0,
+                confidence: 0.0,
+            },
+        ];
+        let rows = detect_rows(&words, 0.5);
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn test_nan_safe_sort_does_not_panic() {
+        let mut values: Vec<f64> = vec![1.0, f64::NAN, 2.0];
+        values.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        assert_eq!(values.len(), 3);
+    }
 
     #[test]
     fn test_hocr_word_methods() {


### PR DESCRIPTION
Fixes #1057.

\`detect_rows\` in \`table_core.rs\` sorted a \`Vec<f64>\` of y-center values using \`.unwrap()\` on \`partial_cmp\`. Every other float sort in the codebase uses \`.unwrap_or(Ordering::Equal)\`. This fixes the inconsistency and eliminates a latent panic if a NaN value ever reaches the sort.

**Note on NaN reachability**: with the current \`HocrWord\` fields (\`top: u32\`, \`height: u32\`), \`y_center()\` always produces a finite \`f64\` and the original \`.unwrap()\` was unreachable as a panic trigger. This is a defensive hygiene fix, not a crash fix from production data.

Verified with: \`cargo check -p kreuzberg --features full --all-targets\`

## Changes

- \`table_core.rs\`: \`.unwrap()\` → \`.unwrap_or(Ordering::Equal)\` on \`partial_cmp\` (line 146)
- \`table_core.rs\`: two new tests — zero-height word grouping and direct NaN sort guard
- \`CHANGELOG.md\`: entry under \`### Fixed\`

## Unrelated fixes included (kept to avoid follow-up debt)

- **\`pipeline/features.rs\`**: \`make_page\` test helper was missing \`section_name: None, speaker_notes: None\` — fields added to \`PageContent\` in #960. Exposed by \`--all-features --all-targets\` during hook verification. Pre-existing error, not introduced here.
- **\`kreuzberg-ffi/tests/vtable_bytes_len.rs\`**: formatting-only (import grouping + line wrapping). File landed in the commit immediately preceding this branch (\`cdfb8cb788\`) without a \`cargo fmt\` pass; the \`cargo fmt --all\` hook would have flagged it on the next touch anyway.