### PR TITLE
chore(docs): add robots.txt with Sitemap directive

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.kreuzberg.dev/sitemap.xml


### PR DESCRIPTION
The docs site had no `robots.txt` (`/robots.txt` returned the styled 404 page), so Googlebot had no `Sitemap:` pointer to discover the sitemap. This adds a static `docs/robots.txt` — copied to the site root by Zensical (same mechanism as `demo.html` / `llms.txt`) — that allows crawling and points to this subdomain's `sitemap.xml`.

Part of a Search Console indexing cleanup across the kreuzberg.dev docs subdomains.

**Post-deploy check:** `curl -sI <subdomain>/robots.txt` → expect `200`, `text/plain`.
