### PR TITLE
docs(nav): add `ecosystem` page cross-linking the sibling docs sites

### DIFF
--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,9 @@
+# Kreuzberg Ecosystem
+
+Kreuzberg is an open-source document intelligence framework with a Rust core and bindings for many languages. It's maintained by the same team as a set of related open-source projects — each a separate tool for a different job, sharing the same Rust-first engineering approach. Explore their documentation:
+
+- **[Kreuzberg Cloud](https://docs.kreuzberg.cloud/)** — managed document extraction for AI pipelines: send a PDF, image, or Office file (80+ formats) and get back text, tables, and metadata. Includes a REST API, official SDKs (Python, TypeScript, Go, Dart), webhooks, and a no-signup sandbox.
+- **[html-to-markdown](https://docs.html-to-markdown.kreuzberg.dev/)** — a high-performance, CommonMark-compliant HTML → Markdown converter.
+- **[liter-llm](https://docs.liter-llm.kreuzberg.dev/)** — a universal LLM API client for 140+ providers, with bindings across languages.
+- **[tree-sitter-language-pack](https://docs.tree-sitter-language-pack.kreuzberg.dev/)** — 300+ tree-sitter parsers with code intelligence and chunking.
+- **[Kreuzcrawl](https://docs.kreuzcrawl.kreuzberg.dev/)** — a high-performance web crawling engine with bindings for 11 languages.

--- a/zensical.toml
+++ b/zensical.toml
@@ -106,13 +106,7 @@ nav = [
     { "Contributing" = "contributing.md" },
   ] },
 
-  { "Ecosystem" = [
-    { "Kreuzberg Cloud" = "https://docs.kreuzberg.cloud/" },
-    { "html-to-markdown" = "https://docs.html-to-markdown.kreuzberg.dev/" },
-    { "liter-llm" = "https://docs.liter-llm.kreuzberg.dev/" },
-    { "tree-sitter-language-pack" = "https://docs.tree-sitter-language-pack.kreuzberg.dev/" },
-    { "Kreuzcrawl" = "https://docs.kreuzcrawl.kreuzberg.dev/" },
-  ] },
+  { "Ecosystem" = "ecosystem.md" },
 ]
 
 [project.theme]

--- a/zensical.toml
+++ b/zensical.toml
@@ -105,6 +105,14 @@ nav = [
     { "Changelog" = "CHANGELOG.md" },
     { "Contributing" = "contributing.md" },
   ] },
+
+  { "Ecosystem" = [
+    { "Kreuzberg Cloud" = "https://docs.kreuzberg.cloud/" },
+    { "html-to-markdown" = "https://docs.html-to-markdown.kreuzberg.dev/" },
+    { "liter-llm" = "https://docs.liter-llm.kreuzberg.dev/" },
+    { "tree-sitter-language-pack" = "https://docs.tree-sitter-language-pack.kreuzberg.dev/" },
+    { "Kreuzcrawl" = "https://docs.kreuzcrawl.kreuzberg.dev/" },
+  ] },
 ]
 
 [project.theme]


### PR DESCRIPTION
Adds an on-site **Ecosystem** page (linked from the nav) describing and linking the related Kreuzberg-team docs sites, forming a hub-and-spoke mesh that aids crawl discovery and passes authority to the newer subdomains.

- Page-only nav: clicking **Ecosystem** opens the overview page (no external links in the sidebar).
- The owner site is excluded from its own list; descriptions verified against each project's docs.

**Post-deploy:** the page serves at `<site>/ecosystem/` — in the sitemap, self-canonical, indexable. Part of the cross-site Search Console cleanup.
