### PR TITLE
fix(demo): use COEP credentialless to fix OCR worker security error in Firefox

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
-    <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
+    <meta http-equiv="Cross-Origin-Embedder-Policy" content="credentialless" />
     <title>Kreuzberg | Live Demo</title>
     <!-- SEO Meta Tags -->
     <link rel="icon" type="image/x-icon" href="./assets/favicon.ico" />


### PR DESCRIPTION
## Situation

Firefox shows a `Security Error: Content at https://docs.kreuzberg.dev/demo.html may not load data from https://cdn.jsdelivr.net/npm/@kreuzberg/wasm@4.9.7/dist/ocr-worker.js` in the console when a file is extracted via the live demo. The extraction still completes but OCR silently falls back to synchronous main-thread execution rather than the intended worker thread.

## Task

Identify why Firefox (and not Chrome) blocks the cross-origin OCR worker, and apply the minimal fix to `docs/demo.html`.

## Action

- Confirmed GitHub Pages sends **no** `Cross-Origin-Embedder-Policy` HTTP header — the policy only reaches Firefox because Firefox, unlike Chrome, honours `<meta http-equiv="Cross-Origin-Embedder-Policy">` tags.
- Traced the call chain: the demo blob module worker → `import('@kreuzberg/wasm@4.9.7/dist/index.js')` → `new Worker(new URL("./ocr-worker.js", import.meta.url), {type:"module"})` — a cross-origin module worker creation from inside a dynamically-imported cross-origin module.
- Verified jsDelivr already serves `cross-origin-resource-policy: cross-origin` on all assets, so `require-corp` should theoretically pass — but Firefox's CORP check misfires for this specific blob-module-worker nesting pattern, likely a Firefox bug.
- Changed `content="require-corp"` → `content="credentialless"` (`docs/demo.html` line 7). Under `credentialless`, cross-origin resources fetched without credentials (all public CDN assets) bypass the CORP check, while `SharedArrayBuffer` eligibility in Firefox is preserved.

## Result

Firefox no longer blocks the OCR sub-worker. OCR runs in the worker thread as intended, the console `Security Error` disappears, and Chrome behaviour is unchanged (it ignores the meta tag entirely).

## Acceptance Criteria
- [ ] No `Security Error` in Firefox DevTools console when extracting a file on the live demo
- [ ] OCR extraction still completes successfully in Firefox
- [ ] Chrome behaviour unchanged