### PR TITLE
fix(pdf): re-encode Raw PDF images to PNG to fix image_ocr probe failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **pdf**: per-page OCR fallback now targets only the specific pages that fail the native-text quality check instead of falling back to full-document OCR on the first failing page. This prevents abnormal memory growth when processing PDF pipelines containing a single scanned page.
 
+- **pdf (#1077)**: non-JPEG embedded images extracted via pdf_oxide (Raw pixel data without self-describing headers, common in Acrobat Sign/Word PDFs) are now re-encoded to PNG bytes using the PDF-provided width/height/colorspace/bits metadata before storing in ExtractedImage. This makes the data always probeable/loadable by load_image_for_ocr, extract_image_metadata, VLM etc., eliminating "image dimension probe failed: The image format could not be determined" during image_ocr. JPEG images unchanged.
+
 - **ffi/windows**: expose `LlmBackend` via new `ner-llm-types` type-only feature for Windows FFI bindings so structured extraction compiles on Windows.
 
 - **ocr**: preserve vertical spacing in paragraph baselines when filtering blank lines from OCR elements. This fixes 1.6% TF1 loss for Tesseract and 3.6% for PaddleOCR on OCR-extracted documents.

--- a/crates/kreuzberg/src/pdf/oxide/images.rs
+++ b/crates/kreuzberg/src/pdf/oxide/images.rs
@@ -7,7 +7,9 @@ use super::OxideDocument;
 use crate::cancellation::CancellationToken;
 use crate::pdf::error::{PdfError, Result};
 use bytes::Bytes;
+use image::{DynamicImage, ImageFormat};
 use std::borrow::Cow;
+use std::io::Cursor;
 
 /// Extract at most `limit` images from a page by walking its XObject resource dictionary.
 ///
@@ -142,6 +144,61 @@ fn extract_n_images_from_xobject_resources(
     Ok(images)
 }
 
+/// Re-encode raw PDF pixel data as a PNG buffer.
+///
+/// pdf_oxide emits `ImageData::Raw` without self-describing headers. Re-encoding
+/// to PNG makes the buffer probeable by `load_image_for_ocr`,
+/// `extract_image_metadata`, VLM pipelines, etc.
+///
+/// Returns `Err` if the pixel buffer length does not match `w × h × bpp` or if
+/// PNG encoding fails.
+fn raw_pixels_to_png(w: u32, h: u32, format: &pdf_oxide::extractors::PixelFormat, pixels: &[u8]) -> Result<Bytes> {
+    let dynamic = match *format {
+        pdf_oxide::extractors::PixelFormat::Grayscale => {
+            let buf = image::GrayImage::from_raw(w, h, pixels.to_vec()).ok_or_else(|| {
+                PdfError::ExtractionFailed(format!(
+                    "grayscale pixel buffer ({} bytes) does not fit {}×{} image",
+                    pixels.len(),
+                    w,
+                    h
+                ))
+            })?;
+            DynamicImage::ImageLuma8(buf)
+        }
+        pdf_oxide::extractors::PixelFormat::RGB => {
+            let buf = image::RgbImage::from_raw(w, h, pixels.to_vec()).ok_or_else(|| {
+                PdfError::ExtractionFailed(format!(
+                    "RGB pixel buffer ({} bytes) does not fit {}×{} image",
+                    pixels.len(),
+                    w,
+                    h
+                ))
+            })?;
+            DynamicImage::ImageRgb8(buf)
+        }
+        pdf_oxide::extractors::PixelFormat::CMYK => {
+            let mut rgb = Vec::with_capacity((pixels.len() / 4) * 3);
+            for chunk in pixels.chunks_exact(4) {
+                let c = chunk[0] as f32 / 255.0;
+                let m = chunk[1] as f32 / 255.0;
+                let y = chunk[2] as f32 / 255.0;
+                let k = chunk[3] as f32 / 255.0;
+                rgb.push(((1.0 - c) * (1.0 - k) * 255.0) as u8);
+                rgb.push(((1.0 - m) * (1.0 - k) * 255.0) as u8);
+                rgb.push(((1.0 - y) * (1.0 - k) * 255.0) as u8);
+            }
+            let buf = image::RgbImage::from_raw(w, h, rgb)
+                .ok_or_else(|| PdfError::ExtractionFailed(format!("CMYK→RGB buffer does not fit {}×{} image", w, h)))?;
+            DynamicImage::ImageRgb8(buf)
+        }
+    };
+    let mut png_bytes = Vec::new();
+    dynamic
+        .write_to(&mut Cursor::new(&mut png_bytes), ImageFormat::Png)
+        .map_err(|e| PdfError::ExtractionFailed(format!("PNG re-encode of raw PDF image failed: {e}")))?;
+    Ok(Bytes::from(png_bytes))
+}
+
 /// Extract full image data from all pages of a PDF.
 ///
 /// Returns a `Vec<ExtractedImage>` with complete image data and metadata.
@@ -222,8 +279,18 @@ pub(crate) fn extract_images_with_data(
                 pdf_oxide::extractors::ImageData::Jpeg(jpeg_bytes) => {
                     (Bytes::copy_from_slice(jpeg_bytes), Cow::Borrowed("jpeg"))
                 }
-                pdf_oxide::extractors::ImageData::Raw { pixels, format: _ } => {
-                    (Bytes::copy_from_slice(pixels), Cow::Borrowed("raw"))
+                pdf_oxide::extractors::ImageData::Raw { pixels, format } => {
+                    match raw_pixels_to_png(oxide_img.width(), oxide_img.height(), format, pixels) {
+                        Ok(bytes) => (bytes, Cow::Borrowed("png")),
+                        Err(e) => {
+                            tracing::warn!(
+                                page = page_number,
+                                image_index = global_index,
+                                "skipping raw PDF image that could not be re-encoded: {e}"
+                            );
+                            continue;
+                        }
+                    }
                 }
             };
 
@@ -261,6 +328,88 @@ mod tests {
     use super::*;
     use crate::cancellation::CancellationToken;
     use std::path::PathBuf;
+
+    const PNG_MAGIC: &[u8] = b"\x89PNG";
+
+    #[test]
+    fn test_raw_pixels_to_png_grayscale() {
+        // 2×2 grayscale: 4 bytes, one per pixel.
+        let pixels: Vec<u8> = vec![0x00, 0x80, 0xc0, 0xff];
+        let result = raw_pixels_to_png(2, 2, &pdf_oxide::extractors::PixelFormat::Grayscale, &pixels);
+        let bytes = result.expect("grayscale 2×2 must encode without error");
+        assert!(
+            bytes.starts_with(PNG_MAGIC),
+            "output must be a PNG; got {:02x?}",
+            &bytes[..4.min(bytes.len())]
+        );
+    }
+
+    #[test]
+    fn test_raw_pixels_to_png_rgb() {
+        // 2×2 RGB: 12 bytes, 3 per pixel.
+        let pixels: Vec<u8> = vec![
+            0xff, 0x00, 0x00, // red
+            0x00, 0xff, 0x00, // green
+            0x00, 0x00, 0xff, // blue
+            0xff, 0xff, 0xff, // white
+        ];
+        let result = raw_pixels_to_png(2, 2, &pdf_oxide::extractors::PixelFormat::RGB, &pixels);
+        let bytes = result.expect("RGB 2×2 must encode without error");
+        assert!(
+            bytes.starts_with(PNG_MAGIC),
+            "output must be a PNG; got {:02x?}",
+            &bytes[..4.min(bytes.len())]
+        );
+    }
+
+    #[test]
+    fn test_raw_pixels_to_png_cmyk_converts_to_rgb_png() {
+        // 1×2 CMYK: 8 bytes, 4 per pixel.
+        // (0,0,0,255) = pure black; (0,0,0,0) = white.
+        let pixels: Vec<u8> = vec![0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00];
+        let result = raw_pixels_to_png(1, 2, &pdf_oxide::extractors::PixelFormat::CMYK, &pixels);
+        let bytes = result.expect("CMYK 1×2 must encode without error");
+        assert!(
+            bytes.starts_with(PNG_MAGIC),
+            "output must be a PNG; got {:02x?}",
+            &bytes[..4.min(bytes.len())]
+        );
+        // Verify the PNG decodes to an RGB image (CMYK was converted to RGB before encoding).
+        let decoded = image::load_from_memory(&bytes).expect("decoded PNG must be valid");
+        assert_eq!(decoded.width(), 1);
+        assert_eq!(decoded.height(), 2);
+    }
+
+    #[test]
+    fn test_raw_pixels_to_png_size_mismatch_returns_error() {
+        // 4×4 grayscale needs 16 bytes; supply only 4 — must be an error, not a panic.
+        let pixels: Vec<u8> = vec![0x00, 0x80, 0xc0, 0xff];
+        let result = raw_pixels_to_png(4, 4, &pdf_oxide::extractors::PixelFormat::Grayscale, &pixels);
+        assert!(
+            result.is_err(),
+            "mismatched buffer size must return Err, not Ok or panic"
+        );
+    }
+
+    #[test]
+    fn test_raw_pixels_to_png_rgb_size_mismatch_returns_error() {
+        // 2×2 RGB needs 12 bytes; supply 9 (divisible by 3 but wrong total).
+        let pixels: Vec<u8> = vec![0xff; 9];
+        let result = raw_pixels_to_png(2, 2, &pdf_oxide::extractors::PixelFormat::RGB, &pixels);
+        assert!(result.is_err(), "mismatched RGB buffer must return Err");
+    }
+
+    #[test]
+    fn test_raw_pixels_to_png_cmyk_odd_length_returns_error() {
+        // 1×1 CMYK needs exactly 4 bytes; supply 3. chunks_exact(4) drops the remainder,
+        // producing an empty rgb vec. from_raw(1, 1, []) returns None → must be Err, not panic.
+        let pixels: Vec<u8> = vec![0x00, 0x00, 0x00];
+        let result = raw_pixels_to_png(1, 1, &pdf_oxide::extractors::PixelFormat::CMYK, &pixels);
+        assert!(
+            result.is_err(),
+            "CMYK buffer whose length is not a multiple of 4 must return Err, not panic"
+        );
+    }
 
     fn test_documents_dir() -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
+++ b/crates/kreuzberg/tests/pdf_image_extraction_tests.rs
@@ -1284,6 +1284,70 @@ fn test_include_page_rasters_emits_warning_on_document_level_ocr_bypass() {
     );
 }
 
+/// Regression test for #1077: PDFs containing ImageData::Raw images (non-DCT embedded
+/// images common in Acrobat Sign / Word exports) must extract without "image dimension
+/// probe failed" errors. Raw pixel buffers are re-encoded to PNG so they are probeable
+/// by load_image_for_ocr, extract_image_metadata, and VLM pipelines.
+///
+/// Fixture: user_reports/mp_axmp_rec_en.pdf — the original bug reproducer.
+#[test]
+fn test_regression_1077_raw_pdf_images_re_encoded_as_png() {
+    use kreuzberg::core::config::ImageExtractionConfig;
+
+    let path = test_documents_dir().join("user_reports/mp_axmp_rec_en.pdf");
+    if !path.exists() {
+        eprintln!("SKIP: user_reports/mp_axmp_rec_en.pdf not present");
+        return;
+    }
+
+    let config = ExtractionConfig {
+        images: Some(ImageExtractionConfig {
+            extract_images: true,
+            ..Default::default()
+        }),
+        use_cache: false,
+        ..Default::default()
+    };
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    // Before the fix this errored with
+    // "image dimension probe failed: The image format could not be determined".
+    let result = rt
+        .block_on(extract_file(&path, None, &config))
+        .expect("extraction of mp_axmp_rec_en.pdf must succeed without probe errors");
+
+    let images = result
+        .images
+        .as_ref()
+        .expect("images must be Some when extract_images=true");
+
+    assert!(
+        !images.is_empty(),
+        "mp_axmp_rec_en.pdf must yield at least one extracted image"
+    );
+
+    // At least one image must carry format="png" — that is the re-encoded Raw image.
+    // Before the fix, raw images were stored as headerless pixel dumps; after the fix
+    // they are PNG-encoded and probeable.
+    let png_images: Vec<_> = images.iter().filter(|img| img.format == "png").collect();
+    assert!(
+        !png_images.is_empty(),
+        "at least one image must have format=\"png\" (re-encoded from Raw pixel data); \
+         got formats: {:?}",
+        images.iter().map(|i| i.format.as_ref()).collect::<Vec<_>>()
+    );
+
+    // Every png-format image must start with the PNG magic bytes.
+    for img in &png_images {
+        assert!(
+            img.data.starts_with(b"\x89PNG"),
+            "image at index {} has format=\"png\" but data does not start with PNG magic bytes; \
+             first 4 bytes: {:02x?}",
+            img.image_index,
+            &img.data[..4.min(img.data.len())]
+        );
+    }
+}
+
 /// `image_indices` on chunks must be empty when image extraction is disabled.
 #[cfg(feature = "chunking")]
 #[test]


### PR DESCRIPTION
Fixes #1077

PDFs from Acrobat Sign and Word exports embed non-JPEG images as `ImageData::Raw` — raw pixel buffers with no self-describing header. These were stored as-is in `ExtractedImage.data`, which caused `load_image_for_ocr`, `extract_image_metadata`, and VLM pipelines to fail with:

```
image dimension probe failed: The image format could not be determined
```

## What changed

Adds `raw_pixels_to_png(w, h, format, pixels) -> Result<Bytes>` that re-encodes Grayscale, RGB, and CMYK raw pixel buffers to PNG before storage. JPEG images are unchanged. Mismatched pixel buffers and encoder failures return `PdfError::ExtractionFailed`; the per-image loop skips with `tracing::warn!` and continues — consistent with how other per-image decompression failures are handled in this file.

## Tests

- 6 unit tests: Grayscale→PNG, RGB→PNG, CMYK→RGB→PNG, grayscale size mismatch, RGB size mismatch, CMYK odd-length buffer (length not divisible by 4)
- Integration test against `user_reports/mp_axmp_rec_en.pdf` (original bug reproducer): asserts extraction succeeds, at least one `format="png"` image is returned, and all PNG-format images carry valid PNG magic bytes

## Performance note

Raw images now incur a PNG encode per image where previously the raw bytes were stored zero-copy. For PDFs with many large embedded raw images (e.g. full-page 300 dpi scans) this is a measurable per-image cost. Tracked as the next thing to address: evaluate whether the encode can be deferred to the point of actual OCR/VLM consumption rather than at extraction time, which would restore zero-copy storage for callers that never invoke image_ocr.