### PR TITLE
fix(cli): write extracted images to disk with --output-dir flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -299,7 +299,6 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   async, embeddings, error, format_specific, summarization).
 - **PHP bindings: nullable params on non-tail-optional positions.** alef 0.23.46 emits
   `?T $param = null` when the parameter slot is optional but a later required slot follows.
+- **CLI `--extract-images` now writes image files to disk.** The text and toon
+  output paths in `extract` and `batch` commands previously discarded extracted
+  images. A new `--output-dir <DIR>` flag controls where `image_N.ext` files
+  land; omitting it defaults to the current working directory. The JSON output
+  path is unaffected — it continues to embed image bytes inline. Closes #1084.
 - **Maven publish suppresses CPD/PMD via property-level skips.** The
   `publish` profile in `packages/java/pom.xml` now sets `<cpd.skip>true</cpd.skip>`
   and `<pmd.skip>true</pmd.skip>` in its `<properties>` block. The previous

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,6 +3819,7 @@ dependencies = [
  "anstyle",
  "anyhow",
  "base64 0.22.1",
+ "bytes",
  "clap",
  "clap_complete",
  "kreuzberg",

--- a/crates/kreuzberg-cli/Cargo.toml
+++ b/crates/kreuzberg-cli/Cargo.toml
@@ -83,5 +83,6 @@ tree-sitter-language-pack = { workspace = true, features = [
 ], optional = true }
 
 [dev-dependencies]
+bytes = { workspace = true }
 tempfile = { workspace = true }
 ureq = { version = "3.3", features = ["json"] }

--- a/crates/kreuzberg-cli/src/commands/extract.rs
+++ b/crates/kreuzberg-cli/src/commands/extract.rs
@@ -5,10 +5,10 @@
 
 use anyhow::{Context, Result};
 use kreuzberg::{
-    BatchFileItem, ExtractionConfig, ExtractionResult, FileExtractionConfig, batch_extract_files_sync,
+    BatchFileItem, ExtractedImage, ExtractionConfig, ExtractionResult, FileExtractionConfig, batch_extract_files_sync,
     extract_file_sync,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use crate::{
@@ -17,12 +17,29 @@ use crate::{
     style,
 };
 
+/// Write extracted images to `output_dir`, using the same `image_{index}.{format}` naming
+/// convention the markdown renderer uses for its `![](image_N.ext)` references.
+///
+/// Images with empty data (placeholder `.bin` entries) are skipped — they have no bytes to write.
+fn write_extracted_images(images: &[ExtractedImage], output_dir: &Path) -> Result<()> {
+    for img in images {
+        if img.data.is_empty() {
+            continue;
+        }
+        let filename = format!("image_{}.{}", img.image_index, img.format);
+        let dest = output_dir.join(&filename);
+        std::fs::write(&dest, &img.data).with_context(|| format!("Failed to write image file '{}'", dest.display()))?;
+    }
+    Ok(())
+}
+
 /// Execute single document extraction command
 pub fn extract_command(
     path: PathBuf,
     config: ExtractionConfig,
     mime_type: Option<String>,
     format: WireFormat,
+    output_dir: Option<PathBuf>,
 ) -> Result<()> {
     let path_str = path.to_string_lossy().to_string();
 
@@ -37,6 +54,10 @@ pub fn extract_command(
 
     match format {
         WireFormat::Text => {
+            if let Some(images) = &result.images {
+                let dir = output_dir.as_deref().unwrap_or(Path::new("."));
+                write_extracted_images(images, dir)?;
+            }
             print!("{}", result.content);
         }
         WireFormat::Json => {
@@ -50,6 +71,10 @@ pub fn extract_command(
             );
         }
         WireFormat::Toon => {
+            if let Some(images) = &result.images {
+                let dir = output_dir.as_deref().unwrap_or(Path::new("."));
+                write_extracted_images(images, dir)?;
+            }
             println!(
                 "{}",
                 serde_toon::to_string(&result).context("Failed to serialize extraction result to TOON")?
@@ -66,6 +91,7 @@ pub fn batch_command(
     file_configs_map: Option<std::collections::HashMap<String, serde_json::Value>>,
     config: ExtractionConfig,
     format: WireFormat,
+    output_dir: Option<PathBuf>,
 ) -> Result<()> {
     match format {
         WireFormat::Json => {
@@ -132,7 +158,11 @@ pub fn batch_command(
         }
         WireFormat::Text => {
             let results = run_batch_sync(&paths, file_configs_map.as_ref(), &config)?;
+            let dir = output_dir.as_deref().unwrap_or(Path::new("."));
             for (i, result) in results.iter().enumerate() {
+                if let Some(images) = &result.images {
+                    write_extracted_images(images, dir)?;
+                }
                 println!("{}", style::header(&format!("=== Document {} ===", i + 1)));
                 println!("{} {}", style::label("MIME Type:"), style::success(&result.mime_type));
                 println!("{}\n{}", style::label("Content:"), result.content);
@@ -141,6 +171,12 @@ pub fn batch_command(
         }
         WireFormat::Toon => {
             let results = run_batch_sync(&paths, file_configs_map.as_ref(), &config)?;
+            let dir = output_dir.as_deref().unwrap_or(Path::new("."));
+            for result in &results {
+                if let Some(images) = &result.images {
+                    write_extracted_images(images, dir)?;
+                }
+            }
             println!(
                 "{}",
                 serde_toon::to_string(&results).context("Failed to serialize batch extraction results to TOON")?
@@ -177,4 +213,65 @@ fn run_batch_sync(
 
     batch_extract_files_sync(items, config)
         .context("Failed to batch extract documents. Check that all files are readable and formats are supported.")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use kreuzberg::ExtractedImage;
+    use std::borrow::Cow;
+    use tempfile::tempdir;
+
+    fn make_image(index: u32, format: &'static str, data: &[u8]) -> ExtractedImage {
+        ExtractedImage {
+            data: Bytes::copy_from_slice(data),
+            format: Cow::Borrowed(format),
+            image_index: index,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn write_extracted_images_creates_files_with_correct_names() {
+        let dir = tempdir().unwrap();
+        let images = vec![
+            make_image(0, "png", b"\x89PNG\r\n"),
+            make_image(1, "jpeg", b"\xff\xd8\xff"),
+        ];
+
+        write_extracted_images(&images, dir.path()).unwrap();
+
+        assert!(dir.path().join("image_0.png").exists());
+        assert!(dir.path().join("image_1.jpeg").exists());
+        assert_eq!(std::fs::read(dir.path().join("image_0.png")).unwrap(), b"\x89PNG\r\n");
+    }
+
+    #[test]
+    fn write_extracted_images_skips_empty_data() {
+        let dir = tempdir().unwrap();
+        let images = vec![make_image(0, "bin", b"")];
+
+        write_extracted_images(&images, dir.path()).unwrap();
+
+        assert!(
+            !dir.path().join("image_0.bin").exists(),
+            "empty-data image must not be written"
+        );
+    }
+
+    #[test]
+    fn write_extracted_images_uses_image_index_not_position() {
+        // If a document has images at index 3 and 7 (gaps due to filtered images),
+        // the files must be image_3.* and image_7.* to match markdown references.
+        let dir = tempdir().unwrap();
+        let images = vec![make_image(3, "png", b"abc"), make_image(7, "png", b"def")];
+
+        write_extracted_images(&images, dir.path()).unwrap();
+
+        assert!(dir.path().join("image_3.png").exists());
+        assert!(dir.path().join("image_7.png").exists());
+        assert!(!dir.path().join("image_0.png").exists());
+        assert!(!dir.path().join("image_1.png").exists());
+    }
 }

--- a/crates/kreuzberg-cli/src/commands/mod.rs
+++ b/crates/kreuzberg-cli/src/commands/mod.rs
@@ -36,6 +36,79 @@ pub use server::mcp_command;
 #[cfg(feature = "api")]
 pub use server::serve_command;
 
+/// Validates that a directory exists and is accessible.
+///
+/// # Errors
+///
+/// Returns an error if the path does not exist or is not a directory.
+pub fn validate_output_dir(path: &std::path::Path) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!(
+            "Output directory not found: '{}'. Create the directory before running.",
+            path.display()
+        );
+    }
+    if !path.is_dir() {
+        anyhow::bail!("Output path is not a directory: '{}'.", path.display());
+    }
+    Ok(())
+}
+
+/// Validates that a file exists and is accessible.
+pub fn validate_file_exists(path: &std::path::Path) -> Result<()> {
+    if !path.exists() {
+        anyhow::bail!(
+            "File not found: '{}'. Please check that the file exists and is accessible.",
+            path.display()
+        );
+    }
+    if !path.is_file() {
+        anyhow::bail!(
+            "Path is not a file: '{}'. Please provide a path to a regular file.",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Validates chunking parameters for correctness.
+pub fn validate_chunk_params(chunk_size: Option<usize>, chunk_overlap: Option<usize>) -> Result<()> {
+    if let Some(size) = chunk_size {
+        if size == 0 {
+            anyhow::bail!("Invalid chunk size: {}. Chunk size must be greater than 0.", size);
+        }
+        if size > 1_000_000 {
+            anyhow::bail!(
+                "Invalid chunk size: {}. Chunk size must be less than 1,000,000 characters to avoid excessive memory usage.",
+                size
+            );
+        }
+    }
+    if let Some(overlap) = chunk_overlap
+        && let Some(size) = chunk_size
+        && overlap >= size
+    {
+        anyhow::bail!(
+            "Invalid chunk overlap: {}. Overlap ({}) must be less than chunk size ({}).",
+            overlap,
+            overlap,
+            size
+        );
+    }
+    Ok(())
+}
+
+/// Validates batch extraction paths for correctness.
+pub fn validate_batch_paths(paths: &[std::path::PathBuf]) -> Result<()> {
+    if paths.is_empty() {
+        anyhow::bail!("No files provided for batch extraction. Please provide at least one file path.");
+    }
+    for (i, path) in paths.iter().enumerate() {
+        validate_file_exists(path).with_context(|| format!("Invalid file at position {}", i + 1))?;
+    }
+    Ok(())
+}
+
 /// Read text from stdin, trimming whitespace.
 pub fn read_stdin() -> Result<String> {
     let mut input = String::new();

--- a/crates/kreuzberg-cli/src/main.rs
+++ b/crates/kreuzberg-cli/src/main.rs
@@ -71,11 +71,12 @@ use commands::serve_command;
 use commands::{
     batch_command, chunk_command, clear_command, extract_command,
     extract_structured::{ExtractStructuredArgs, extract_structured_command},
-    load_config, manifest_command, stats_command, warm_command,
+    load_config, manifest_command, stats_command, validate_batch_paths, validate_chunk_params, validate_file_exists,
+    validate_output_dir, warm_command,
 };
 use kreuzberg::{OutputFormat as ContentOutputFormat, detect_mime_type};
 use serde_json::json;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 /// Kreuzberg document intelligence CLI
 #[derive(Parser)]
@@ -122,6 +123,16 @@ enum Commands {
         /// Controls how the CLI displays results, not the extraction content format.
         #[arg(short, long, default_value = "text")]
         format: WireFormat,
+
+        /// Directory where extracted image files are written (text/toon output only).
+        ///
+        /// When `--extract-images true` is used with text or toon format, the markdown content
+        /// references image files by name (e.g. `image_0.png`). Pass this flag to control where
+        /// those files land. Defaults to the current working directory when not specified.
+        /// Ignored for `--format json` because JSON embeds image bytes inline.
+        /// The directory must already exist.
+        #[arg(long)]
+        output_dir: Option<PathBuf>,
 
         /// Extraction configuration overrides
         #[command(flatten)]
@@ -192,6 +203,16 @@ enum Commands {
         /// Controls how the CLI displays results, not the extraction content format.
         #[arg(short, long, default_value = "json")]
         format: WireFormat,
+
+        /// Directory where extracted image files are written (text/toon output only).
+        ///
+        /// When `--extract-images true` is used with text or toon format, the markdown content
+        /// references image files by name (e.g. `image_0.png`). Pass this flag to control where
+        /// those files land. Defaults to the current working directory when not specified.
+        /// Ignored for `--format json` because JSON embeds image bytes inline.
+        /// The directory must already exist.
+        #[arg(long)]
+        output_dir: Option<PathBuf>,
 
         /// Extraction configuration overrides
         #[command(flatten)]
@@ -532,95 +553,6 @@ impl From<ContentOutputFormatArg> for ContentOutputFormat {
     }
 }
 
-/// Validates that a file exists and is accessible.
-///
-/// Checks that the path exists in the filesystem and points to a regular file
-/// (not a directory or special file). Provides user-friendly error messages if validation fails.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The path does not exist in the filesystem
-/// - The path exists but is not a regular file (e.g., is a directory)
-fn validate_file_exists(path: &Path) -> Result<()> {
-    if !path.exists() {
-        anyhow::bail!(
-            "File not found: '{}'. Please check that the file exists and is accessible.",
-            path.display()
-        );
-    }
-    if !path.is_file() {
-        anyhow::bail!(
-            "Path is not a file: '{}'. Please provide a path to a regular file.",
-            path.display()
-        );
-    }
-    Ok(())
-}
-
-/// Validates chunking parameters for correctness.
-///
-/// Ensures that chunking configuration makes sense: size must be positive and reasonable,
-/// and overlap must be smaller than chunk size. This prevents common configuration errors
-/// that would lead to cryptic failures from the underlying library.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - `chunk_size` is 0 (must be at least 1 character)
-/// - `chunk_size` exceeds 1,000,000 characters (to prevent excessive memory usage)
-/// - `chunk_overlap` is greater than or equal to `chunk_size` (overlap must be smaller)
-fn validate_chunk_params(chunk_size: Option<usize>, chunk_overlap: Option<usize>) -> Result<()> {
-    if let Some(size) = chunk_size {
-        if size == 0 {
-            anyhow::bail!("Invalid chunk size: {}. Chunk size must be greater than 0.", size);
-        }
-        if size > 1_000_000 {
-            anyhow::bail!(
-                "Invalid chunk size: {}. Chunk size must be less than 1,000,000 characters to avoid excessive memory usage.",
-                size
-            );
-        }
-    }
-
-    if let Some(overlap) = chunk_overlap
-        && let Some(size) = chunk_size
-        && overlap >= size
-    {
-        anyhow::bail!(
-            "Invalid chunk overlap: {}. Overlap ({}) must be less than chunk size ({}).",
-            overlap,
-            overlap,
-            size
-        );
-    }
-
-    Ok(())
-}
-
-/// Validates batch extraction paths for correctness.
-///
-/// Ensures that at least one file path is provided and that all paths point to valid,
-/// accessible files. This prevents processing empty batches or failing mid-batch due
-/// to invalid paths.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The paths array is empty (at least one file is required)
-/// - Any path does not exist or is not a regular file
-fn validate_batch_paths(paths: &[PathBuf]) -> Result<()> {
-    if paths.is_empty() {
-        anyhow::bail!("No files provided for batch extraction. Please provide at least one file path.");
-    }
-
-    for (i, path) in paths.iter().enumerate() {
-        validate_file_exists(path).with_context(|| format!("Invalid file at position {}", i + 1))?;
-    }
-
-    Ok(())
-}
-
 /// Apply inline JSON or base64 JSON overrides to an extraction config.
 fn apply_json_overrides(
     config: &mut kreuzberg::ExtractionConfig,
@@ -672,16 +604,20 @@ fn main() -> Result<()> {
             config_json_base64,
             mime_type,
             format,
+            output_dir,
             overrides,
         } => {
             validate_file_exists(&path)?;
+            if let Some(ref dir) = output_dir {
+                validate_output_dir(dir)?;
+            }
             overrides.validate()?;
 
             let mut config = load_config(config_path)?;
             apply_json_overrides(&mut config, config_json, config_json_base64)?;
             overrides.apply(&mut config);
 
-            extract_command(path, config, mime_type, format)?;
+            extract_command(path, config, mime_type, format, output_dir)?;
         }
 
         Commands::ExtractStructured {
@@ -716,10 +652,14 @@ fn main() -> Result<()> {
             config_json,
             config_json_base64,
             format,
+            output_dir,
             overrides,
             file_configs,
         } => {
             validate_batch_paths(&paths)?;
+            if let Some(ref dir) = output_dir {
+                validate_output_dir(dir)?;
+            }
             overrides.validate()?;
 
             let mut config = load_config(config_path)?;
@@ -740,7 +680,7 @@ fn main() -> Result<()> {
             } else {
                 None
             };
-            batch_command(paths, file_configs_map, config, format)?;
+            batch_command(paths, file_configs_map, config, format, output_dir)?;
         }
 
         Commands::Detect { path, format } => {

--- a/crates/kreuzberg-cli/tests/commands_test.rs
+++ b/crates/kreuzberg-cli/tests/commands_test.rs
@@ -917,6 +917,126 @@ fn test_extract_chunk_size_too_large_error() {
 }
 
 #[test]
+#[ignore = "requires test_documents/docx/word_image_anchors.docx fixture"]
+fn test_extract_images_written_to_output_dir() {
+    build_binary();
+
+    let test_file = get_test_file("docx/word_image_anchors.docx");
+    assert!(
+        PathBuf::from(&test_file).exists(),
+        "Test fixture not found: {}",
+        test_file
+    );
+
+    let output_dir = tempdir().expect("Failed to create temp dir");
+
+    let output = Command::new(get_binary_path())
+        .args([
+            "extract",
+            &test_file,
+            "--extract-images",
+            "true",
+            "--content-format",
+            "markdown",
+            "--output-dir",
+            output_dir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("Failed to execute extract command");
+
+    assert!(
+        output.status.success(),
+        "Extract command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Markdown content must reference at least one image file
+    assert!(
+        stdout.contains("image_0."),
+        "Expected image reference in markdown, got: {}",
+        stdout
+    );
+
+    // The referenced image files must exist on disk
+    let image_files: Vec<_> = std::fs::read_dir(output_dir.path())
+        .expect("Failed to read output dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let s = name.to_string_lossy();
+            s.starts_with("image_")
+                && (s.ends_with(".png") || s.ends_with(".jpeg") || s.ends_with(".jpg") || s.ends_with(".webp"))
+        })
+        .collect();
+
+    assert!(
+        !image_files.is_empty(),
+        "Expected image files in output dir, but none were written. Markdown was:\n{}",
+        stdout
+    );
+
+    // Every image file must have non-zero bytes
+    for entry in &image_files {
+        let meta = entry.metadata().expect("Failed to stat image file");
+        assert!(
+            meta.len() > 0,
+            "Image file '{}' is empty",
+            entry.file_name().to_string_lossy()
+        );
+    }
+}
+
+#[test]
+#[ignore = "requires test_documents/docx/word_image_anchors.docx fixture"]
+fn test_extract_images_default_to_cwd_when_no_output_dir() {
+    build_binary();
+
+    let test_file = get_test_file("docx/word_image_anchors.docx");
+    assert!(
+        PathBuf::from(&test_file).exists(),
+        "Test fixture not found: {}",
+        test_file
+    );
+
+    // Run from a temp working directory so image_N.* files land there, not in the repo root
+    let work_dir = tempdir().expect("Failed to create temp dir");
+
+    let output = Command::new(get_binary_path())
+        .args([
+            "extract",
+            &test_file,
+            "--extract-images",
+            "true",
+            "--content-format",
+            "markdown",
+        ])
+        .current_dir(work_dir.path())
+        .output()
+        .expect("Failed to execute extract command");
+
+    assert!(
+        output.status.success(),
+        "Extract command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("image_0."), "Expected image reference in markdown");
+
+    let image_files: Vec<_> = std::fs::read_dir(work_dir.path())
+        .expect("Failed to read work dir")
+        .filter_map(|e| e.ok())
+        .filter(|e| e.file_name().to_string_lossy().starts_with("image_"))
+        .collect();
+
+    assert!(
+        !image_files.is_empty(),
+        "Expected image files in cwd, but none were written"
+    );
+}
+
+#[test]
 fn test_extract_target_dpi_too_high_error() {
     build_binary();
     let (_dir, file_path) = create_temp_file();
@@ -932,6 +1052,34 @@ fn test_extract_target_dpi_too_high_error() {
     assert!(
         stderr.contains("DPI") || stderr.contains("dpi") || stderr.contains("2400") || stderr.contains("Invalid"),
         "Error should mention DPI range, got: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_extract_output_dir_nonexistent_error() {
+    build_binary();
+    let (_dir, file_path) = create_temp_file();
+
+    let output = Command::new(get_binary_path())
+        .args([
+            "extract",
+            &file_path,
+            "--output-dir",
+            "/nonexistent/directory/that/does/not/exist",
+        ])
+        .output()
+        .expect("Failed to execute extract command");
+
+    assert!(
+        !output.status.success(),
+        "Extract should fail when --output-dir does not exist"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Output directory not found") || stderr.contains("not found") || stderr.contains("directory"),
+        "Error should mention directory not found, got: {}",
         stderr
     );
 }


### PR DESCRIPTION
  The text and toon output paths in `extract` and `batch` silently discarded extracted images; `result.images` was never read. The JSON path was unaffected (it embeds bytes inline).

  implements `--output-dir <DIR>` to both commands. When omitted, images land in cwd. The flag is ignored for `--format json` (documented in help text). The directory must exist; a missing path fails with a clear error before extraction starts.

  Image filenames use `image_{index}.{format}`; matching the naming the markdown renderer emits for its `![](image_N.ext)` references, so content and files stay in sync.

  closes #1084