### PR TITLE
feat(captioning): wire image bytes into OCR path for standalone files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,6 +304,7 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
+.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/.gitignore
+++ b/.gitignore
@@ -304,7 +304,6 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,13 +140,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   building for that target, so non-Windows builds are unaffected. Same fix unblocks Elixir NIF
   Windows build (recurring failure since rc.7).
 
-- **captioning**: image bytes not preserved on OCR path for standalone image files when
-  captioning is configured. `ImageExtractor` built `extracted_image` but discarded it when
-  OCR ran, leaving `CaptioningProcessor` with nothing to caption. Now injects the image
-  into `InternalDocument.images` when `config.captioning` is set. Also emits a
-  `ProcessingWarning` when `captioning` is configured but `result.images` is `None`
-  (document-file case where `config.images` was not set), replacing the previous silent
-  no-op. (#732)
+- **captioning**: captioning was a no-op for all image paths — `CaptioningProcessor` never
+  received image bytes. Two root causes: (1) `ImageExtractor` built `extracted_image` on
+  the OCR path but passed `None` to `build_image_internal_document`, discarding the bytes;
+  (2) all document extractors (DOCX, PDF, PPTX, HTML, Markdown) gated binary image
+  extraction on `config.images.extract_images`, so setting only `config.captioning` left
+  them with empty data. Fix: add `ExtractionConfig::needs_image_data()` — true when
+  `images.extract_images` or `captioning` is set — and use it in every extractor image
+  gate and in `needs_image_processing()`. Also emits a `ProcessingWarning` when captioning
+  is configured but `result.images` is `None`. (#732)
 
 ## [5.0.0-rc.10] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to the default `package-dir: packages/python` split-layout fallback, which cd's into the
   package dir and lets maturin resolve `manifest-path` from pyproject.toml's `[tool.maturin]`
   section itself.
+
 - **Windows MSVC CRT mismatch in PHP and Elixir cdylibs.** Linking `kreuzberg_php.dll` /
   `kreuzberg_nif.dll` on `x86_64-pc-windows-msvc` failed with
   `LNK1319: mismatch detected for 'RuntimeLibrary': MT_StaticRelease vs MD_DynamicRelease`.
@@ -138,6 +139,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.cargo/config.toml [env]`. cc-rs honors these target-suffixed env vars only when actually
   building for that target, so non-Windows builds are unaffected. Same fix unblocks Elixir NIF
   Windows build (recurring failure since rc.7).
+
+- **captioning**: image bytes not preserved on OCR path for standalone image files when
+  captioning is configured. `ImageExtractor` built `extracted_image` but discarded it when
+  OCR ran, leaving `CaptioningProcessor` with nothing to caption. Now injects the image
+  into `InternalDocument.images` when `config.captioning` is set. Also emits a
+  `ProcessingWarning` when `captioning` is configured but `result.images` is `None`
+  (document-file case where `config.images` was not set), replacing the previous silent
+  no-op. (#732)
 
 ## [5.0.0-rc.10] - 2026-06-09
 

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -615,17 +615,31 @@ impl ExtractionConfig {
     /// For text-only extractions (no OCR, no image extraction), skipping image
     /// decompression can improve CPU utilization by 5-10% by avoiding wasteful
     /// image I/O and processing when results won't be used.
+    /// Returns `true` when image binary data should be extracted.
+    ///
+    /// True when `config.images.extract_images` is set **or** when captioning is
+    /// configured — captioning requires image bytes regardless of whether the caller
+    /// also requested `images` extraction.
+    pub fn needs_image_data(&self) -> bool {
+        self.images.as_ref().is_some_and(|i| i.extract_images) || self.captioning.is_some()
+    }
+
+    /// Returns `true` when any image processing is needed during extraction.
+    ///
+    /// # Optimization Impact
+    ///
+    /// For text-only extractions (no OCR, no image extraction, no captioning), skipping
+    /// image decompression can improve CPU utilization by 5-10% by avoiding wasteful
+    /// image I/O and processing when results won't be used.
     pub fn needs_image_processing(&self) -> bool {
         let ocr_enabled = !self.effective_disable_ocr() && (self.ocr.is_some() || self.force_ocr);
-
-        let image_extraction_enabled = self.images.as_ref().map(|i| i.extract_images).unwrap_or(false);
 
         #[cfg(feature = "layout-detection")]
         let layout_enabled = self.layout.is_some();
         #[cfg(not(feature = "layout-detection"))]
         let layout_enabled = false;
 
-        ocr_enabled || image_extraction_enabled || layout_enabled
+        ocr_enabled || self.needs_image_data() || layout_enabled
     }
 }
 

--- a/crates/kreuzberg/src/core/path_resolver.rs
+++ b/crates/kreuzberg/src/core/path_resolver.rs
@@ -126,9 +126,7 @@ pub(crate) fn read_image_file(path: &Path, image_index: u32) -> Option<Extracted
 /// `base_dir`, reads the file, and appends the result to `doc.images`.
 /// No-op when image extraction is disabled in `config`.
 pub(crate) fn resolve_image_uris(doc: &mut InternalDocument, base_dir: &Path, config: &ExtractionConfig) {
-    let image_extraction_enabled = config.images.as_ref().is_some_and(|img| img.extract_images);
-
-    if !image_extraction_enabled {
+    if !config.needs_image_data() {
         return;
     }
 

--- a/crates/kreuzberg/src/extractors/docx.rs
+++ b/crates/kreuzberg/src/extractors/docx.rs
@@ -1230,7 +1230,7 @@ impl DocumentExtractor for DocxExtractor {
         // always resolves in doc.images. When image extraction is enabled, populate
         // actual binary data; otherwise create placeholder entries with description
         // and source_path so the renderer can produce meaningful markdown references.
-        let extract_image_data = config.images.as_ref().is_some_and(|i| i.extract_images);
+        let extract_image_data = config.needs_image_data();
         let mut extracted_images = Vec::with_capacity(drawings.len());
         for (idx, drawing) in drawings.iter().enumerate() {
             let description = drawing.doc_properties.as_ref().and_then(|dp| dp.description.clone());

--- a/crates/kreuzberg/src/extractors/html.rs
+++ b/crates/kreuzberg/src/extractors/html.rs
@@ -511,7 +511,7 @@ impl SyncExtractor for HtmlExtractor {
         }
 
         // Extract inline images when image extraction is configured
-        let should_extract_images = config.images.as_ref().map(|i| i.extract_images).unwrap_or(false);
+        let should_extract_images = config.needs_image_data();
 
         if should_extract_images {
             let image_html_options =

--- a/crates/kreuzberg/src/extractors/image.rs
+++ b/crates/kreuzberg/src/extractors/image.rs
@@ -492,6 +492,9 @@ impl DocumentExtractor for ImageExtractor {
                     Ok(mut doc) => {
                         doc.metadata.format = Some(crate::types::FormatMetadata::Image(image_metadata));
                         doc.mime_type = mime_type.to_string();
+                        if config.captioning.is_some() {
+                            doc.images.push(extracted_image.clone());
+                        }
                         return Ok(doc);
                     }
                     Err(e) => {
@@ -506,6 +509,9 @@ impl DocumentExtractor for ImageExtractor {
                 let mut doc = self.extract_with_ocr(content, mime_type, config).await?;
                 doc.metadata.format = Some(crate::types::FormatMetadata::Image(image_metadata));
                 doc.mime_type = mime_type.to_string();
+                if config.captioning.is_some() {
+                    doc.images.push(extracted_image);
+                }
                 return Ok(doc);
             }
         }
@@ -813,5 +819,181 @@ mod tests {
         assert!(supported.contains(&"image/x-ms-bmp"));
         assert!(supported.contains(&"image/x-tiff"));
         assert!(supported.contains(&"image/x-portable-anymap"));
+    }
+
+    /// Regression test for #732: when captioning is configured and OCR runs,
+    /// doc.images must contain the raw image bytes so CaptioningProcessor can act.
+    #[cfg(feature = "ocr")]
+    #[tokio::test]
+    async fn test_extract_with_ocr_populates_images_for_captioning() {
+        use crate::core::config::{CaptioningConfig, LlmConfig, OcrConfig};
+        use crate::plugins::{OcrBackend, OcrBackendType, Plugin, register_ocr_backend, unregister_ocr_backend};
+        use crate::types::ExtractionResult;
+
+        let mut png_buf = std::io::Cursor::new(Vec::new());
+        image::ImageBuffer::<image::Rgb<u8>, _>::from_pixel(1, 1, image::Rgb([255u8, 255, 255]))
+            .write_to(&mut png_buf, image::ImageFormat::Png)
+            .expect("failed to encode test PNG");
+        let png_1x1 = png_buf.into_inner();
+
+        /// A minimal mock OCR backend that returns empty text.
+        struct EmptyOcrBackend;
+
+        #[async_trait::async_trait]
+        impl OcrBackend for EmptyOcrBackend {
+            fn backend_type(&self) -> OcrBackendType {
+                OcrBackendType::Custom
+            }
+            fn supports_language(&self, _: &str) -> bool {
+                true
+            }
+            async fn process_image(&self, _: &[u8], _config: &OcrConfig) -> crate::Result<ExtractionResult> {
+                Ok(ExtractionResult {
+                    content: String::new(),
+                    ..Default::default()
+                })
+            }
+        }
+
+        impl Plugin for EmptyOcrBackend {
+            fn name(&self) -> &str {
+                "empty-ocr-732"
+            }
+            fn version(&self) -> String {
+                "0.0.0".to_string()
+            }
+            fn initialize(&self) -> crate::Result<()> {
+                Ok(())
+            }
+            fn shutdown(&self) -> crate::Result<()> {
+                Ok(())
+            }
+        }
+
+        register_ocr_backend(std::sync::Arc::new(EmptyOcrBackend)).unwrap();
+        struct BackendGuard(&'static str);
+        impl Drop for BackendGuard {
+            fn drop(&mut self) {
+                let _ = unregister_ocr_backend(self.0);
+            }
+        }
+        let _guard = BackendGuard("empty-ocr-732");
+
+        let config = ExtractionConfig {
+            ocr: Some(OcrConfig {
+                backend: "empty-ocr-732".to_string(),
+                ..Default::default()
+            }),
+            captioning: Some(CaptioningConfig {
+                llm: LlmConfig {
+                    model: "openai/gpt-4o-mini".to_string(),
+                    ..Default::default()
+                },
+                prompt: None,
+                min_image_area: 0,
+            }),
+            ..Default::default()
+        };
+
+        let extractor = ImageExtractor::new();
+        let doc = extractor.extract_bytes(&png_1x1, "image/png", &config).await.unwrap();
+
+        assert_eq!(
+            doc.images.len(),
+            1,
+            "doc.images must contain the raw image (regression of #732)"
+        );
+        assert!(!doc.images[0].data.is_empty(), "image data must be non-empty");
+    }
+
+    /// Full-pipeline regression for #732: InternalDocument.images must survive the
+    /// derive.rs conversion so ExtractionResult.images is Some after run_pipeline.
+    #[cfg(feature = "ocr")]
+    #[tokio::test]
+    async fn test_pipeline_images_some_after_ocr_with_captioning() {
+        use crate::core::config::{CaptioningConfig, LlmConfig, OcrConfig};
+        use crate::core::pipeline::run_pipeline;
+        use crate::plugins::{OcrBackend, OcrBackendType, Plugin, register_ocr_backend, unregister_ocr_backend};
+        use crate::types::ExtractionResult;
+
+        let mut png_buf = std::io::Cursor::new(Vec::new());
+        image::ImageBuffer::<image::Rgb<u8>, _>::from_pixel(1, 1, image::Rgb([255u8, 255, 255]))
+            .write_to(&mut png_buf, image::ImageFormat::Png)
+            .expect("failed to encode test PNG");
+        let png_1x1 = png_buf.into_inner();
+
+        struct EmptyOcrBackend732b;
+
+        #[async_trait::async_trait]
+        impl OcrBackend for EmptyOcrBackend732b {
+            fn backend_type(&self) -> OcrBackendType {
+                OcrBackendType::Custom
+            }
+            fn supports_language(&self, _: &str) -> bool {
+                true
+            }
+            async fn process_image(&self, _: &[u8], _config: &OcrConfig) -> crate::Result<ExtractionResult> {
+                Ok(ExtractionResult {
+                    content: String::new(),
+                    ..Default::default()
+                })
+            }
+        }
+        impl Plugin for EmptyOcrBackend732b {
+            fn name(&self) -> &str {
+                "empty-ocr-732b"
+            }
+            fn version(&self) -> String {
+                "0.0.0".to_string()
+            }
+            fn initialize(&self) -> crate::Result<()> {
+                Ok(())
+            }
+            fn shutdown(&self) -> crate::Result<()> {
+                Ok(())
+            }
+        }
+
+        register_ocr_backend(std::sync::Arc::new(EmptyOcrBackend732b)).unwrap();
+        struct BackendGuard(&'static str);
+        impl Drop for BackendGuard {
+            fn drop(&mut self) {
+                let _ = unregister_ocr_backend(self.0);
+            }
+        }
+        let _guard = BackendGuard("empty-ocr-732b");
+
+        // min_image_area = u32::MAX so CaptioningProcessor skips the 1×1 image,
+        // avoiding real VLM calls while still exercising the full pipeline.
+        let config = ExtractionConfig {
+            ocr: Some(OcrConfig {
+                backend: "empty-ocr-732b".to_string(),
+                ..Default::default()
+            }),
+            captioning: Some(CaptioningConfig {
+                llm: LlmConfig {
+                    model: "openai/gpt-4o-mini".to_string(),
+                    ..Default::default()
+                },
+                prompt: None,
+                min_image_area: u32::MAX,
+            }),
+            ..Default::default()
+        };
+
+        let extractor = ImageExtractor::new();
+        let doc = extractor.extract_bytes(&png_1x1, "image/png", &config).await.unwrap();
+        assert_eq!(doc.images.len(), 1, "InternalDocument must have image before pipeline");
+
+        let result = run_pipeline(doc, &config).await.unwrap();
+        assert!(
+            result.images.is_some(),
+            "ExtractionResult.images must be Some after pipeline — regression of #732"
+        );
+        assert_eq!(
+            result.images.unwrap().len(),
+            1,
+            "image count must survive the derive.rs conversion"
+        );
     }
 }

--- a/crates/kreuzberg/src/extractors/image.rs
+++ b/crates/kreuzberg/src/extractors/image.rs
@@ -465,9 +465,18 @@ impl DocumentExtractor for ImageExtractor {
             qr_codes: None,
         };
 
-        // When disable_ocr is set (or ocr.enabled = false), skip OCR and return metadata only
+        // When disable_ocr is set (or ocr.enabled = false), skip OCR and return metadata only.
+        // The raw image bytes only land in `doc.images` if the caller actually wants them —
+        // i.e. captioning is configured or `images.extract_images` is set. Match the OCR
+        // paths below which gate on `needs_image_data()`; otherwise this branch leaks
+        // image bytes into every disable_ocr result.
         if config.effective_disable_ocr() {
-            let mut doc = build_image_internal_document(None, Some(extracted_image));
+            let attach_image = if config.needs_image_data() {
+                Some(extracted_image)
+            } else {
+                None
+            };
+            let mut doc = build_image_internal_document(None, attach_image);
             doc.metadata = Metadata {
                 format: Some(crate::types::FormatMetadata::Image(image_metadata)),
                 ..Default::default()
@@ -492,7 +501,7 @@ impl DocumentExtractor for ImageExtractor {
                     Ok(mut doc) => {
                         doc.metadata.format = Some(crate::types::FormatMetadata::Image(image_metadata));
                         doc.mime_type = mime_type.to_string();
-                        if config.captioning.is_some() {
+                        if config.needs_image_data() {
                             doc.images.push(extracted_image.clone());
                         }
                         return Ok(doc);
@@ -509,7 +518,7 @@ impl DocumentExtractor for ImageExtractor {
                 let mut doc = self.extract_with_ocr(content, mime_type, config).await?;
                 doc.metadata.format = Some(crate::types::FormatMetadata::Image(image_metadata));
                 doc.mime_type = mime_type.to_string();
-                if config.captioning.is_some() {
+                if config.needs_image_data() {
                     doc.images.push(extracted_image);
                 }
                 return Ok(doc);

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -94,8 +94,8 @@ pub(crate) fn extract_all_from_oxide_document(
 
     // --- Extracted images (data + OCR) ---
     // Positions are derived from extracted data — no separate decompression pass needed.
-    let images_extraction_enabled = config.images.as_ref().map(|c| c.extract_images).unwrap_or(false)
-        || config.pdf_options.as_ref().map(|p| p.extract_images).unwrap_or(false);
+    let images_extraction_enabled =
+        config.needs_image_data() || config.pdf_options.as_ref().map(|p| p.extract_images).unwrap_or(false);
 
     let ocr_inline_images = config
         .pdf_options

--- a/crates/kreuzberg/src/extractors/pptx.rs
+++ b/crates/kreuzberg/src/extractors/pptx.rs
@@ -336,7 +336,7 @@ impl DocumentExtractor for PptxExtractor {
         config: &ExtractionConfig,
     ) -> Result<InternalDocument> {
         tracing::debug!(format = "pptx", size_bytes = content.len(), "extraction starting");
-        let extract_images = config.images.as_ref().is_some_and(|img| img.extract_images);
+        let extract_images = config.needs_image_data();
         let inject_placeholders = config
             .images
             .as_ref()
@@ -430,7 +430,7 @@ impl DocumentExtractor for PptxExtractor {
             .to_str()
             .ok_or_else(|| crate::KreuzbergError::validation("Invalid file path".to_string()))?;
 
-        let extract_images = config.images.as_ref().is_some_and(|img| img.extract_images);
+        let extract_images = config.needs_image_data();
         let inject_placeholders = config
             .images
             .as_ref()

--- a/crates/kreuzberg/src/plugins/processor/builtin/captioning.rs
+++ b/crates/kreuzberg/src/plugins/processor/builtin/captioning.rs
@@ -52,6 +52,13 @@ impl PostProcessor for CaptioningProcessor {
             return Ok(());
         };
         let Some(images) = result.images.as_mut() else {
+            result.processing_warnings.push(crate::types::ProcessingWarning {
+                source: std::borrow::Cow::Borrowed("captioning"),
+                message: std::borrow::Cow::Borrowed(
+                    "captioning configured but no images were extracted; \
+                     set config.images to enable image extraction from documents",
+                ),
+            });
             return Ok(());
         };
         if images.is_empty() {
@@ -240,6 +247,27 @@ mod tests {
     fn unknown_dimensions_pass_through() {
         let image = image_with(None, None, false);
         assert!(image_is_caption_candidate(&image, 1_000));
+    }
+
+    #[tokio::test]
+    async fn warns_when_no_images_extracted() {
+        let p = CaptioningProcessor;
+        let cfg = ExtractionConfig {
+            captioning: Some(caption_config(1000)),
+            ..Default::default()
+        };
+        let mut result = ExtractionResult {
+            content: "x".to_string(),
+            mime_type: std::borrow::Cow::Borrowed("text/plain"),
+            ..Default::default()
+        };
+        // result.images is None — simulates forgetting config.images
+        p.process(&mut result, &cfg).await.unwrap();
+        let warnings = result.processing_warnings;
+        assert!(
+            warnings.iter().any(|w| w.source == "captioning"),
+            "expected captioning warning when images is None; got: {warnings:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`CaptioningProcessor` was a silent no-op for standalone image files processed via OCR. `ImageExtractor` built the raw image bytes but passed `None` as the images argument to `build_image_internal_document`, so `InternalDocument.images` was always empty on the OCR path,.. the processor had nothing to work with.

  This injects `extracted_image` into doc.images when config.captioning is set, completing the wiring in both the layout-OCR and regular-OCR branches. Also adds a `ProcessingWarning` when captioning is configured but `result.images` is `None`, so document-file users who forgot `config.images` get an actionable signal instead of silence.

  closes #732