### PR TITLE
docs: surface v5.0.0-rc.3 version badges on enrichment config fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,7 +304,6 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ homepage = "https://kreuzberg.dev"
 
 [workspace.lints.rust]
 unsafe_code = "deny"
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(alef)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(alef)', 'cfg(feature, values("alef-meta"))'] }
 
 [workspace.lints.clippy]
 all = "warn"

--- a/crates/kreuzberg/src/core/config/captioning.rs
+++ b/crates/kreuzberg/src/core/config/captioning.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the VLM captioning post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
 pub struct CaptioningConfig {
     /// LLM configuration used for the VLM call.
     pub llm: super::llm::LlmConfig,

--- a/crates/kreuzberg/src/core/config/captioning.rs
+++ b/crates/kreuzberg/src/core/config/captioning.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the VLM captioning post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
 pub struct CaptioningConfig {
     /// LLM configuration used for the VLM call.
     pub llm: super::llm::LlmConfig,

--- a/crates/kreuzberg/src/core/config/classification.rs
+++ b/crates/kreuzberg/src/core/config/classification.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the page-classification post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
 pub struct PageClassificationConfig {
     /// Minijinja prompt template. Receives `{{ labels }}` (joined list), `{{ page_text }}`
     /// and `{{ multi_label }}` variables. `None` lets the backend pick a sensible default.

--- a/crates/kreuzberg/src/core/config/classification.rs
+++ b/crates/kreuzberg/src/core/config/classification.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the page-classification post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
 pub struct PageClassificationConfig {
     /// Minijinja prompt template. Receives `{{ labels }}` (joined list), `{{ page_text }}`
     /// and `{{ multi_label }}` variables. `None` lets the backend pick a sensible default.

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -313,45 +313,45 @@ pub struct ExtractionConfig {
     /// Named-entity recognition configuration. When set, the NER post-processor runs at
     /// the Middle stage and populates `ExtractionResult::entities`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub ner: Option<super::super::ner::NerConfig>,
 
     /// Redaction / anonymisation configuration. When set, the redaction post-processor
     /// runs at the Late stage and rewrites every textual field in `ExtractionResult`,
     /// emitting an audit trail in `ExtractionResult::redaction_report`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub redaction: Option<super::super::redaction::RedactionConfig>,
 
     /// Summarisation configuration. When set, the summarisation post-processor runs at
     /// the Middle stage and populates `ExtractionResult::summary`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub summarization: Option<super::super::summarization::SummarizationConfig>,
 
     /// Translation configuration. When set, the translation post-processor runs at the
     /// Middle stage and populates `ExtractionResult::translation`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub translation: Option<super::super::translation::TranslationConfig>,
 
     /// Per-page classification configuration. When set, the classification post-processor
     /// runs at the Middle stage and populates `ExtractionResult::page_classifications`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub page_classification: Option<super::super::classification::PageClassificationConfig>,
 
     /// VLM captioning configuration for extracted images. When set, the captioning
     /// post-processor runs at the Middle stage and writes a caption into each
     /// `ExtractedImage::caption`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub captioning: Option<super::super::captioning::CaptioningConfig>,
 
     /// Enable QR-code detection in extracted images. When `true`, the QR post-processor
     /// runs at the Middle stage and populates `ExtractedImage::qr_codes`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
     pub qr_codes: Option<bool>,
 
     /// Cancellation token for this extraction (None = no external cancellation).

--- a/crates/kreuzberg/src/core/config/extraction/core.rs
+++ b/crates/kreuzberg/src/core/config/extraction/core.rs
@@ -313,38 +313,45 @@ pub struct ExtractionConfig {
     /// Named-entity recognition configuration. When set, the NER post-processor runs at
     /// the Middle stage and populates `ExtractionResult::entities`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub ner: Option<super::super::ner::NerConfig>,
 
     /// Redaction / anonymisation configuration. When set, the redaction post-processor
     /// runs at the Late stage and rewrites every textual field in `ExtractionResult`,
     /// emitting an audit trail in `ExtractionResult::redaction_report`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub redaction: Option<super::super::redaction::RedactionConfig>,
 
     /// Summarisation configuration. When set, the summarisation post-processor runs at
     /// the Middle stage and populates `ExtractionResult::summary`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub summarization: Option<super::super::summarization::SummarizationConfig>,
 
     /// Translation configuration. When set, the translation post-processor runs at the
     /// Middle stage and populates `ExtractionResult::translation`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub translation: Option<super::super::translation::TranslationConfig>,
 
     /// Per-page classification configuration. When set, the classification post-processor
     /// runs at the Middle stage and populates `ExtractionResult::page_classifications`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub page_classification: Option<super::super::classification::PageClassificationConfig>,
 
     /// VLM captioning configuration for extracted images. When set, the captioning
     /// post-processor runs at the Middle stage and writes a caption into each
     /// `ExtractedImage::caption`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub captioning: Option<super::super::captioning::CaptioningConfig>,
 
     /// Enable QR-code detection in extracted images. When `true`, the QR post-processor
     /// runs at the Middle stage and populates `ExtractedImage::qr_codes`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
     pub qr_codes: Option<bool>,
 
     /// Cancellation token for this extraction (None = no external cancellation).

--- a/crates/kreuzberg/src/core/config/ner.rs
+++ b/crates/kreuzberg/src/core/config/ner.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the NER post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
 #[derive(Default)]
 pub struct NerConfig {
     /// Backend that runs the entity detection.

--- a/crates/kreuzberg/src/core/config/ner.rs
+++ b/crates/kreuzberg/src/core/config/ner.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the NER post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
 #[derive(Default)]
 pub struct NerConfig {
     /// Backend that runs the entity detection.

--- a/crates/kreuzberg/src/core/config/redaction.rs
+++ b/crates/kreuzberg/src/core/config/redaction.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 /// Configuration for the redaction post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
 pub struct RedactionConfig {
     /// Categories to redact. Empty means "every category supported by the engine."
     #[serde(default)]

--- a/crates/kreuzberg/src/core/config/redaction.rs
+++ b/crates/kreuzberg/src/core/config/redaction.rs
@@ -14,6 +14,7 @@ use std::collections::HashSet;
 /// Configuration for the redaction post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
 pub struct RedactionConfig {
     /// Categories to redact. Empty means "every category supported by the engine."
     #[serde(default)]

--- a/crates/kreuzberg/src/core/config/summarization.rs
+++ b/crates/kreuzberg/src/core/config/summarization.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the summarisation post-processor.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
 pub struct SummarizationConfig {
     /// Summarisation strategy.
     #[serde(default)]

--- a/crates/kreuzberg/src/core/config/summarization.rs
+++ b/crates/kreuzberg/src/core/config/summarization.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the summarisation post-processor.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
 pub struct SummarizationConfig {
     /// Summarisation strategy.
     #[serde(default)]

--- a/crates/kreuzberg/src/core/config/translation.rs
+++ b/crates/kreuzberg/src/core/config/translation.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the translation post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
-#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0"))]
 pub struct TranslationConfig {
     /// BCP-47 language tag for the target language (e.g. `"de"`, `"fr-CA"`).
     pub target_lang: String,

--- a/crates/kreuzberg/src/core/config/translation.rs
+++ b/crates/kreuzberg/src/core/config/translation.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 /// Configuration for the translation post-processor.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]
 pub struct TranslationConfig {
     /// BCP-47 language tag for the target language (e.g. `"de"`, `"fr-CA"`).
     pub target_lang: String,

--- a/docs/reference/api-c.md
+++ b/docs/reference/api-c.md
@@ -1159,7 +1159,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### KreuzbergCaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3013,7 +3013,7 @@ NER backend trait (stub for Android x86_64).
 
 #### KreuzbergNerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3577,7 +3577,7 @@ Classification result for a single page.
 
 #### KreuzbergPageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4227,7 +4227,7 @@ the type in their own code.
 
 #### KreuzbergRedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4589,7 +4589,7 @@ returning structured data that conforms to the schema.
 
 #### KreuzbergSummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4901,7 +4901,7 @@ than duplicated here.
 
 #### KreuzbergTranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-c.md
+++ b/docs/reference/api-c.md
@@ -1159,6 +1159,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### KreuzbergCaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3011,6 +3013,8 @@ NER backend trait (stub for Android x86_64).
 
 #### KreuzbergNerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3572,6 +3576,8 @@ Classification result for a single page.
 ---
 
 #### KreuzbergPageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4221,6 +4227,8 @@ the type in their own code.
 
 #### KreuzbergRedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4581,6 +4589,8 @@ returning structured data that conforms to the schema.
 
 #### KreuzbergSummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4890,6 +4900,8 @@ than duplicated here.
 ---
 
 #### KreuzbergTranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-csharp.md
+++ b/docs/reference/api-csharp.md
@@ -1159,7 +1159,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3013,7 +3013,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3577,7 +3577,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4227,7 +4227,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4589,7 +4589,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4901,7 +4901,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-csharp.md
+++ b/docs/reference/api-csharp.md
@@ -1159,6 +1159,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3011,6 +3013,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3572,6 +3576,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4221,6 +4227,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4581,6 +4589,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4890,6 +4900,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-dart.md
+++ b/docs/reference/api-dart.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3059,7 +3059,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3623,7 +3623,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4273,7 +4273,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4635,7 +4635,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4947,7 +4947,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-dart.md
+++ b/docs/reference/api-dart.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3057,6 +3059,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3618,6 +3622,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4267,6 +4273,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4627,6 +4635,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4936,6 +4946,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-elixir.md
+++ b/docs/reference/api-elixir.md
@@ -1098,7 +1098,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -2952,7 +2952,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3516,7 +3516,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4166,7 +4166,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4528,7 +4528,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4840,7 +4840,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-elixir.md
+++ b/docs/reference/api-elixir.md
@@ -1098,6 +1098,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -2950,6 +2952,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3511,6 +3515,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4160,6 +4166,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4520,6 +4528,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4829,6 +4839,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-go.md
+++ b/docs/reference/api-go.md
@@ -1159,7 +1159,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3013,7 +3013,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3577,7 +3577,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4227,7 +4227,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4589,7 +4589,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4901,7 +4901,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-go.md
+++ b/docs/reference/api-go.md
@@ -1159,6 +1159,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3011,6 +3013,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3572,6 +3576,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4221,6 +4227,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4581,6 +4589,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4890,6 +4900,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-java.md
+++ b/docs/reference/api-java.md
@@ -1159,7 +1159,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3013,7 +3013,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3577,7 +3577,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4227,7 +4227,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4589,7 +4589,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4901,7 +4901,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-java.md
+++ b/docs/reference/api-java.md
@@ -1159,6 +1159,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3011,6 +3013,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3572,6 +3576,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4221,6 +4227,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4581,6 +4589,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4890,6 +4900,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-kotlin-android.md
+++ b/docs/reference/api-kotlin-android.md
@@ -1169,7 +1169,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3043,7 +3043,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3613,7 +3613,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4270,7 +4270,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4640,7 +4640,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4957,7 +4957,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-kotlin-android.md
+++ b/docs/reference/api-kotlin-android.md
@@ -1169,6 +1169,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3041,6 +3043,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3608,6 +3612,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4264,6 +4270,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4632,6 +4640,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4946,6 +4956,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-php.md
+++ b/docs/reference/api-php.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3059,7 +3059,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3623,7 +3623,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4273,7 +4273,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4635,7 +4635,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4947,7 +4947,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-php.md
+++ b/docs/reference/api-php.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3057,6 +3059,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3618,6 +3622,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4267,6 +4273,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4627,6 +4635,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4936,6 +4946,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-python.md
+++ b/docs/reference/api-python.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3074,7 +3074,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3641,7 +3641,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4295,7 +4295,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4663,7 +4663,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4980,7 +4980,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-python.md
+++ b/docs/reference/api-python.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3072,6 +3074,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3636,6 +3640,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4289,6 +4295,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4655,6 +4663,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4969,6 +4979,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-r.md
+++ b/docs/reference/api-r.md
@@ -1229,7 +1229,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3083,7 +3083,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3647,7 +3647,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4297,7 +4297,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4659,7 +4659,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4971,7 +4971,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-r.md
+++ b/docs/reference/api-r.md
@@ -1229,6 +1229,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3081,6 +3083,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3642,6 +3646,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4291,6 +4297,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4651,6 +4659,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4960,6 +4970,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-ruby.md
+++ b/docs/reference/api-ruby.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3059,7 +3059,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3623,7 +3623,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4273,7 +4273,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4635,7 +4635,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4947,7 +4947,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-ruby.md
+++ b/docs/reference/api-ruby.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3057,6 +3059,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3618,6 +3622,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4267,6 +4273,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4627,6 +4635,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4936,6 +4946,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-rust.md
+++ b/docs/reference/api-rust.md
@@ -1229,7 +1229,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3083,7 +3083,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3647,7 +3647,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4297,7 +4297,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4659,7 +4659,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4971,7 +4971,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-rust.md
+++ b/docs/reference/api-rust.md
@@ -1229,6 +1229,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3081,6 +3083,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3642,6 +3646,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4291,6 +4297,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4651,6 +4659,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4960,6 +4970,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-swift.md
+++ b/docs/reference/api-swift.md
@@ -1134,7 +1134,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -2988,7 +2988,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3552,7 +3552,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4202,7 +4202,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4564,7 +4564,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4876,7 +4876,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-swift.md
+++ b/docs/reference/api-swift.md
@@ -1134,6 +1134,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -2986,6 +2988,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3547,6 +3551,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4196,6 +4202,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4556,6 +4564,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4865,6 +4875,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-typescript.md
+++ b/docs/reference/api-typescript.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3059,7 +3059,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3623,7 +3623,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4273,7 +4273,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4635,7 +4635,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4947,7 +4947,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-typescript.md
+++ b/docs/reference/api-typescript.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3057,6 +3059,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3618,6 +3622,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4267,6 +4273,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4627,6 +4635,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4936,6 +4946,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-wasm.md
+++ b/docs/reference/api-wasm.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3059,7 +3059,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3623,7 +3623,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4273,7 +4273,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4635,7 +4635,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4947,7 +4947,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-wasm.md
+++ b/docs/reference/api-wasm.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3057,6 +3059,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3618,6 +3622,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4267,6 +4273,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4627,6 +4635,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4936,6 +4946,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-zig.md
+++ b/docs/reference/api-zig.md
@@ -1205,7 +1205,7 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the VLM captioning post-processor.
 
@@ -3059,7 +3059,7 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the NER post-processor.
 
@@ -3623,7 +3623,7 @@ Classification result for a single page.
 
 #### PageClassificationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the page-classification post-processor.
 
@@ -4273,7 +4273,7 @@ the type in their own code.
 
 #### RedactionConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the redaction post-processor.
 
@@ -4635,7 +4635,7 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the summarisation post-processor.
 
@@ -4947,7 +4947,7 @@ than duplicated here.
 
 #### TranslationConfig
 
-**Since:** `v5.0.0-rc.3`
+**Since:** `v5.0.0`
 
 Configuration for the translation post-processor.
 

--- a/docs/reference/api-zig.md
+++ b/docs/reference/api-zig.md
@@ -1205,6 +1205,8 @@ Aggregate statistics for a kreuzberg cache directory.
 
 #### CaptioningConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the VLM captioning post-processor.
 
 | Field | Type | Default | Description |
@@ -3057,6 +3059,8 @@ NER backend trait (stub for Android x86_64).
 
 #### NerConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the NER post-processor.
 
 | Field | Type | Default | Description |
@@ -3618,6 +3622,8 @@ Classification result for a single page.
 ---
 
 #### PageClassificationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the page-classification post-processor.
 
@@ -4267,6 +4273,8 @@ the type in their own code.
 
 #### RedactionConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the redaction post-processor.
 
 | Field | Type | Default | Description |
@@ -4627,6 +4635,8 @@ returning structured data that conforms to the schema.
 
 #### SummarizationConfig
 
+**Since:** `v5.0.0-rc.3`
+
 Configuration for the summarisation post-processor.
 
 | Field | Type | Default | Description |
@@ -4936,6 +4946,8 @@ than duplicated here.
 ---
 
 #### TranslationConfig
+
+**Since:** `v5.0.0-rc.3`
 
 Configuration for the translation post-processor.
 


### PR DESCRIPTION
  `ner`, `redaction`, `summarization`, `translation`, `page_classification`, `captioning`, and `qr_codes` in `ExtractionConfig` were introduced in v5 but had no version signal in docs or source. Users on 4.x images who added these fields to kreuzberg.yml hit a config-validation error with no indication that the fields require v5; this was reported in #1076.

   Uses the #[alef(since)] annotation mechanism from kreuzberg-dev/alef#122. Each config struct and its ExtractionConfig field now carries #[cfg_attr(feature = "alef-meta", alef(since = "5.0.0-rc.3"))]. The alef-meta feature is intentionally not declared in [features]; cfg(feature, values("alef-meta")) is added to the workspace check-cfg allowlist so the permanently-false cfg_attr compiles cleanly (same pattern documented in alef PR #122). All 18 language API reference pages are regenerated under alef 0.23.75;  alef docs && git diff --exit-code docs/reference/ is clean at the current pin.

  Note:
  - api-kotlin.md shows 0 badges; the Kotlin JVM binding doesn't expose enrichment types (NerConfig, RedactionConfig, etc.), consistent with it being a thinner binding than Kotlin Android. Not a gap.
  - The .gitignore hunk (removing .ai-rulez/.generated-manifest.json from the # BEGIN  ai-rulez managed block) is written by the ai-rulez generate pre-commit hook on eveey  commit; identical pattern to alef PR #122, not a merge artifact.

 resolves #1076