### PR TITLE
feat: expose list_supported_formats() in all language bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`list_supported_formats()` is now part of the public crate root and
+  every language binding.** Returns every file extension Kreuzberg
+  recognizes with its corresponding MIME type, so callers can derive
+  ingestion policy from the library instead of maintaining their own
+  extension whitelists. The function already backed the CLI
+  (`kreuzberg formats`), REST API (`GET /formats`), and MCP server; it
+  is now exported from the crate root and exposed in every binding via
+  the alef catalog. ([#1091](https://github.com/kreuzberg-dev/kreuzberg/issues/1091))
+
 - **[v5.0.0] reranking: cross-encoder reordering with optional liter-llm wiring.**
   New top-level `rerank` / `rerank_async` API, `RerankerConfig` with
   Preset/Custom/Llm/Plugin variants, `RerankerBackend` plugin trait +

--- a/alef.toml
+++ b/alef.toml
@@ -1347,6 +1347,15 @@ async = false
 returns_result = true
 args = [{ name = "mime_type", field = "input.mime_type", type = "string" }]
 
+[crates.e2e.calls.list_supported_formats]
+result_is_simple = true
+result_is_array = true
+function = "list_supported_formats"
+module = "kreuzberg"
+async = false
+returns_result = false
+args = []
+
 [crates.e2e.calls.batch_extract_files]
 function = "batch_extract_files"
 module = "kreuzberg"

--- a/crates/kreuzberg/src/core/mime.rs
+++ b/crates/kreuzberg/src/core/mime.rs
@@ -904,10 +904,16 @@ pub fn get_extensions_for_mime(mime_type: &str) -> Result<Vec<String>> {
 
 /// List all supported document formats.
 ///
-/// Returns a list of all file extensions and their corresponding MIME types
-/// that Kreuzberg can process. Derived from the centralized [`FORMATS`] registry.
+/// Returns every file extension Kreuzberg recognizes together with its
+/// corresponding MIME type, derived from the central format registry.
+/// Formats that have no registered file extension (such as source code,
+/// which is detected dynamically) are not included.
 ///
 /// The list is sorted alphabetically by file extension.
+///
+/// # Returns
+///
+/// A vector of [`SupportedFormat`] entries sorted by extension.
 ///
 /// # Example
 ///
@@ -918,7 +924,6 @@ pub fn get_extensions_for_mime(mime_type: &str) -> Result<Vec<String>> {
 /// assert!(!formats.is_empty());
 /// assert!(formats.iter().any(|f| f.extension == "pdf"));
 /// ```
-#[cfg_attr(alef, alef(skip))]
 pub fn list_supported_formats() -> Vec<SupportedFormat> {
     let mut formats: Vec<SupportedFormat> = EXT_TO_MIME
         .iter()

--- a/crates/kreuzberg/src/lib.rs
+++ b/crates/kreuzberg/src/lib.rs
@@ -365,8 +365,8 @@ pub use tree_sitter_language_pack::{
     SymbolInfo, SymbolKind, process as process_code,
 };
 
-// ── MIME / Format Info — public API (3 functions) ────────────────────────────
-pub use core::mime::{SupportedFormat, detect_mime_type_from_bytes, get_extensions_for_mime};
+// ── MIME / Format Info — public API (4 functions + 1 type) ───────────────────
+pub use core::mime::{SupportedFormat, detect_mime_type_from_bytes, get_extensions_for_mime, list_supported_formats};
 
 /// Detect the MIME type of a file at the given path.
 ///


### PR DESCRIPTION
Refs #1091.

## Problem

Bindings can validate a given MIME type or map one to extensions, but nothing enumerates what kreuzberg supports, so downstream tools keep hand-maintained extension whitelists that drift whenever kreuzberg adds a format. The enumeration already exists in core — `list_supported_formats()` backs the CLI, REST API, and MCP server — it just isn't exported to the bindings.

## Solution

Remove the `alef(skip)` attribute from `list_supported_formats()`, re-export it from the crate root, and regenerate with the pinned alef 0.23.75. All 15 bindings now expose the function, each with a generated e2e test asserting a non-empty result (new `plugin_api` fixture plus an e2e call block in `alef.toml`).

Notes for review:

- The e2e call block uses the `result_is_simple + result_is_array` shape; `result_is_vec` makes the Go emitter generate an error-pattern test that fails on success.
- The rustdoc was tightened while un-skipping: the list is what kreuzberg recognizes by extension (extension-less, dynamically detected formats aren't included), and it no longer references the private `FORMATS` static since alef copies doc text into binding docs.
- `types::document_structure::tests::test_skip_serializing_empty_fields` fails on main under `--features full` too; not introduced here.

Verified locally with cargo fmt, workspace clippy (`-D warnings`), the full `--features full` test suite, and `alef verify --exit-code`. Cross-language runtime suites run in the CI e2e matrix.