### PR TITLE
fix(pdf): surface table extraction failures at warn level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **pdf: graphical-line table detector now emits `warn` on per-page extraction
+  failure instead of silently swallowing the error at `debug` level.**
+  `extract_tables_native` and `extract_tables_bordered` both caught
+  `pdf_oxide::extract_tables_with_config` errors at `tracing::debug!` and
+  continued, making failures invisible to operators at the default log level.
+  Upgraded to `tracing::warn!` to match the existing behaviour of the TATR and
+  SLANeXT inference paths.
+  ([#1097](https://github.com/kreuzberg-dev/kreuzberg/issues/1097))
+
 - **publish.yaml `trigger-pubdev` job: explicit `permissions: actions: write`.** Since the `a8f8597e45` migration to the `kreuzberg-dev-publisher` App-token, the `gh workflow run publish-pubdev.yaml` step has 403'd with "Resource not accessible by integration" — the App's installation token didn't carry `actions: write`. Adding job-level `permissions: { actions: write, contents: read }` covers the case where GITHUB_TOKEN is used as a fallback, and documents that the App's permissions also need `actions: write` configured on github.com.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,13 +99,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **pdf: graphical-line table detector now emits `warn` on per-page extraction
-  failure instead of silently swallowing the error at `debug` level.**
-  `extract_tables_native` and `extract_tables_bordered` both caught
-  `pdf_oxide::extract_tables_with_config` errors at `tracing::debug!` and
-  continued, making failures invisible to operators at the default log level.
-  Upgraded to `tracing::warn!` to match the existing behaviour of the TATR and
-  SLANeXT inference paths.
+- **pdf: table extraction failures are now visible at `warn` log level.**
+  `extract_tables_native` and `extract_tables_bordered` silently caught
+  `pdf_oxide::extract_tables_with_config` errors at `tracing::debug!`,
+  making per-page failures invisible at the default log level. Promoted to
+  `tracing::warn!` to match the existing behaviour of the TATR and SLANeXT
+  inference paths. The three `unwrap_or_default()` call sites in
+  `extraction.rs` that silently swallowed function-level errors are also
+  replaced with `unwrap_or_else(|e| { tracing::warn!(...); Vec::new() })`
+  so that a `page_count()` failure is equally visible.
   ([#1097](https://github.com/kreuzberg-dev/kreuzberg/issues/1097))
 
 - **publish.yaml `trigger-pubdev` job: explicit `permissions: actions: write`.** Since the `a8f8597e45` migration to the `kreuzberg-dev-publisher` App-token, the `gh workflow run publish-pubdev.yaml` step has 403'd with "Resource not accessible by integration" — the App's installation token didn't carry `actions: write`. Adding job-level `permissions: { actions: write, contents: read }` covers the case where GITHUB_TOKEN is used as a fallback, and documents that the App's permissions also need `actions: write` configured on github.com.

--- a/crates/kreuzberg/src/extractors/pdf/extraction.rs
+++ b/crates/kreuzberg/src/extractors/pdf/extraction.rs
@@ -62,7 +62,9 @@ pub(crate) fn extract_all_from_oxide_document(
     //   1. native  — strict Lines strategy (≥3 cols), high precision
     //   2. bordered — relaxed Lines strategy (≥2 cols), catches 2-column bordered tables
     //   3. heuristic — text-edge fallback for unruled tables (invoice line items, etc.)
-    // Use `unwrap_or_default` so individual failures don't block extraction.
+    // Individual tier failures must not block text extraction — each falls back to an
+    // empty vec and logs at warn so operators can diagnose missing tables without losing
+    // the rest of the document.
     // Skipped entirely when `pdf_options.extract_tables` is `false`.
     let extract_tables_flag = config.pdf_options.as_ref().is_none_or(|opts| opts.extract_tables);
     let allow_single_column = config
@@ -70,14 +72,23 @@ pub(crate) fn extract_all_from_oxide_document(
         .as_ref()
         .is_some_and(|o| o.allow_single_column_tables);
     let tables = if extract_tables_flag {
-        let mut combined = crate::pdf::oxide::table::extract_tables_native(&mut doc).unwrap_or_default();
+        let mut combined = crate::pdf::oxide::table::extract_tables_native(&mut doc).unwrap_or_else(|e| {
+            tracing::warn!("pdf_oxide native table extraction failed, skipping tables: {e}");
+            Vec::new()
+        });
         let native_pages: std::collections::HashSet<u32> = combined.iter().map(|t| t.page_number).collect();
-        let bordered = crate::pdf::oxide::table::extract_tables_bordered(&mut doc, &native_pages).unwrap_or_default();
+        let bordered = crate::pdf::oxide::table::extract_tables_bordered(&mut doc, &native_pages).unwrap_or_else(|e| {
+            tracing::warn!("pdf_oxide bordered table extraction failed, skipping tables: {e}");
+            Vec::new()
+        });
         combined.extend(bordered);
         let covered_pages: std::collections::HashSet<u32> = combined.iter().map(|t| t.page_number).collect();
         let heuristic =
             crate::pdf::oxide::table::extract_tables_heuristic(&mut doc, allow_single_column, &covered_pages)
-                .unwrap_or_default();
+                .unwrap_or_else(|e| {
+                    tracing::warn!("pdf_oxide heuristic table extraction failed, skipping tables: {e}");
+                    Vec::new()
+                });
         combined.extend(heuristic);
         combined
     } else {

--- a/crates/kreuzberg/src/pdf/oxide/table.rs
+++ b/crates/kreuzberg/src/pdf/oxide/table.rs
@@ -53,7 +53,7 @@ pub(crate) fn extract_tables_native(doc: &mut OxideDocument) -> Result<Vec<Table
         let extracted = match doc.doc.extract_tables_with_config(page_idx, config.clone()) {
             Ok(tables) => tables,
             Err(e) => {
-                tracing::debug!(page = page_idx, "pdf_oxide extract_tables failed: {e}");
+                tracing::warn!(page = page_idx, "pdf_oxide extract_tables failed: {e}");
                 continue;
             }
         };
@@ -154,7 +154,7 @@ pub(crate) fn extract_tables_bordered(doc: &mut OxideDocument, skip_pages: &Hash
         let extracted = match doc.doc.extract_tables_with_config(page_idx, config.clone()) {
             Ok(tables) => tables,
             Err(e) => {
-                tracing::debug!(page = page_idx, "pdf_oxide bordered extract_tables failed: {e}");
+                tracing::warn!(page = page_idx, "pdf_oxide bordered extract_tables failed: {e}");
                 continue;
             }
         };


### PR DESCRIPTION
  When pdf_oxide returns a per-page error from extract_tables_with_config, both extract_tables_native and extract_tables_bordered logged at tracing::debug! and continued. At the default log level (info/warn) these
  failures were completely invisible; operators had no signal that bordered or native table detection had silently failed on one or more pages.

  Promoted the two per-page error sites to tracing::warn!, matching the existing behaviour of the TATR and SLANeXT inference paths which have always used warn! for inference failures.

  Also promoted the three unwrap_or_default() call sites in extraction.rs (the tier-level callers) to unwrap_or_else with warn! so that a  function-level failure (e.g. page_count() error) is equally visible rather than silently producing an empty table list.

  Note on test coverage: the Err arm of extract_tables_with_config requires  a PDF page that causes pdf_oxide to return a parse error. No such fixture is available in test_documents for this path. The existing extract_tables_bordered_detects_two_column_bordered_table and  extract_tables_native_misses_two_column_bordered_table tests cover the Ok paths. The log-level change itself is not unit-testable in isolation.

  fixes #1097