### PR TITLE
fix(ocr): prevent server abort when preprocessing config is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,6 +443,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page-assembly block now call `is_page_text_blank` after every content mutation.
   ([#1095](https://github.com/kreuzberg-dev/kreuzberg/issues/1095))
 
+- **`ImagePreprocessingConfig` default `auto_rotate` changed from `true` to `false`; server
+  no longer aborts (exit 133 / SIGTRAP) when `preprocessing` is set in the server config.**
+  The previous default caused `TessBaseAPIDetectOrientationScript` to be called on every
+  image, which can propagate a C++ exception through Tesseract's `-fno-exceptions` frames
+  into Rust's `extern "C-unwind"` boundary, triggering a runtime abort. A C++ exception-
+  barrier shim now wraps the five most dangerous Tesseract C API calls on native builds so
+  that any escaping exception is converted to a graceful error return instead of aborting the
+  process. To keep auto-rotation, set `auto_rotate: true` explicitly.
+  ([#1089](https://github.com/kreuzberg-dev/kreuzberg/issues/1089))
+
 - **reranker: `RerankError` migrated to `thiserror`.** Matches the rest
   of the library and `rust-conventions`.
 

--- a/crates/kreuzberg-tesseract/build.rs
+++ b/crates/kreuzberg-tesseract/build.rs
@@ -719,9 +719,22 @@ mod build_tesseract {
         eprintln!("Bundled tessdata dir: {:?}", bundled_tessdata_dir);
 
         println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-changed=src/shim.cpp");
         println!("cargo:rerun-if-changed={}", third_party_dir.display());
         println!("cargo:rerun-if-changed={}", leptonica_dir.display());
         println!("cargo:rerun-if-changed={}", tesseract_dir.display());
+
+        // Compile the C++ exception-barrier shim (native builds only; `cc` is not
+        // available under build-tesseract-wasm). The shim must be compiled WITH
+        // exception support (no -fno-exceptions) so catch (...) is active. It wraps
+        // the dangerous Tesseract C API calls so C++ exceptions cannot propagate
+        // into Rust's extern "C-unwind" frames and abort the process.
+        #[cfg(feature = "build-tesseract")]
+        cc::Build::new()
+            .file("src/shim.cpp")
+            .cpp(true)
+            .include(tesseract_install_dir.join("include"))
+            .compile("kreuzberg_shim");
 
         println!("cargo:rustc-link-search=native={}", leptonica_lib_dir.display());
         println!(

--- a/crates/kreuzberg-tesseract/src/api.rs
+++ b/crates/kreuzberg-tesseract/src/api.rs
@@ -399,11 +399,12 @@ impl TesseractAPI {
     /// Returns `Ok(())` if recognition is successful, otherwise returns an error.
     pub fn recognize(&self) -> Result<()> {
         let handle = self.handle.lock().map_err(|_| TesseractError::MutexLockError)?;
-        // SAFETY: TessBaseAPIRecognize() is safe because:
-        // 1. *handle is a valid pointer to an initialized Tesseract engine with an image set
-        // 2. std::ptr::null_mut() is passed as the monitor parameter, which Tesseract accepts
-        //    to indicate no progress monitoring is needed
-        // 3. The mutex ensures exclusive access during the potentially long recognition process
+        // SAFETY: The handle is valid and mutex-protected. On native builds we route through
+        // the exception-barrier shim so that C++ exceptions are caught and converted to an
+        // error return code instead of propagating into Rust frames.
+        #[cfg(all(feature = "build-tesseract", not(target_arch = "wasm32")))]
+        let result = unsafe { shim::kreuzberg_tess_recognize(*handle) };
+        #[cfg(not(all(feature = "build-tesseract", not(target_arch = "wasm32"))))]
         let result = unsafe { TessBaseAPIRecognize(*handle, std::ptr::null_mut()) };
         if result != 0 {
             Err(TesseractError::OcrError)
@@ -423,12 +424,11 @@ impl TesseractAPI {
     /// Returns the HOCR text for the specified page as a string.
     pub fn get_hocr_text(&self, page: i32) -> Result<String> {
         let handle = self.handle.lock().map_err(|_| TesseractError::MutexLockError)?;
-        // SAFETY: TessBaseAPIGetHOCRText() returns a pointer to an allocated C string.
-        // This is safe because:
-        // 1. *handle is a valid pointer to an initialized Tesseract engine
-        // 2. page is a valid page index
-        // 3. The returned pointer is either null or points to a null-terminated C string
-        //    allocated by Tesseract (must be freed with TessDeleteText)
+        // SAFETY: The handle is valid and mutex-protected. On native builds we route through
+        // the exception-barrier shim; null return indicates either OcrError or a caught exception.
+        #[cfg(all(feature = "build-tesseract", not(target_arch = "wasm32")))]
+        let text_ptr = unsafe { shim::kreuzberg_tess_get_hocr_text(*handle, page) };
+        #[cfg(not(all(feature = "build-tesseract", not(target_arch = "wasm32"))))]
         let text_ptr = unsafe { TessBaseAPIGetHOCRText(*handle, page) };
         if text_ptr.is_null() {
             return Err(TesseractError::OcrError);
@@ -769,11 +769,21 @@ impl TesseractAPI {
         let mut orient_conf = 0.0;
         let mut script_name_ptr = std::ptr::null_mut();
         let mut script_conf = 0.0;
-        // SAFETY: TessBaseAPIDetectOrientationScript() is safe because:
-        // 1. *handle is a valid pointer to an initialized Tesseract engine
-        // 2. All mutable references (&mut ...) are valid local stack variables that outlive this call
-        // 3. The function writes output values into these mutable references
-        // 4. script_name_ptr may be returned as null (meaning no script detected) or as a valid pointer
+        // SAFETY: The handle is valid and mutex-protected. All output pointers are valid stack
+        // variables that outlive this call. On native builds we route through the exception-barrier
+        // shim so that C++ exceptions (e.g. from missing osd.traineddata) are caught and returned
+        // as 0 (failure) instead of propagating into Rust frames and aborting the process.
+        #[cfg(all(feature = "build-tesseract", not(target_arch = "wasm32")))]
+        let result = unsafe {
+            shim::kreuzberg_tess_detect_orientation_script(
+                *handle,
+                &mut orient_deg,
+                &mut orient_conf,
+                &mut script_name_ptr,
+                &mut script_conf,
+            )
+        };
+        #[cfg(not(all(feature = "build-tesseract", not(target_arch = "wasm32"))))]
         let result = unsafe {
             TessBaseAPIDetectOrientationScript(
                 *handle,
@@ -1194,12 +1204,16 @@ impl TesseractAPI {
     /// Returns `Ok(())` if clearing the OCR engine is successful, otherwise returns an error.
     pub fn clear(&self) -> Result<()> {
         let handle = self.handle.lock().map_err(|_| TesseractError::MutexLockError)?;
-        // SAFETY: TessBaseAPIClear() is safe because:
-        // 1. *handle is a valid pointer to an initialized Tesseract engine
-        // 2. The function resets internal state
-        // 3. No pointer parameters are passed
-        // 4. The mutex ensures exclusive access
-        unsafe { TessBaseAPIClear(*handle) };
+        // SAFETY: The handle is valid and mutex-protected. On native builds we route through
+        // the exception-barrier shim so that any C++ exception during state reset is swallowed.
+        #[cfg(all(feature = "build-tesseract", not(target_arch = "wasm32")))]
+        unsafe {
+            shim::kreuzberg_tess_clear(*handle)
+        };
+        #[cfg(not(all(feature = "build-tesseract", not(target_arch = "wasm32"))))]
+        unsafe {
+            TessBaseAPIClear(*handle)
+        };
         Ok(())
     }
 
@@ -1574,10 +1588,11 @@ impl TesseractAPI {
             return Err(TesseractError::UninitializedError);
         }
 
-        // SAFETY: TessBaseAPIGetUTF8Text() returns a pointer to an allocated C string.
-        // This is safe because:
-        // 1. *handle is a valid pointer to an initialized Tesseract engine
-        // 2. The returned pointer is either null or a valid null-terminated C string
+        // SAFETY: The handle is valid and mutex-protected. On native builds we route through
+        // the exception-barrier shim; null return indicates either OcrError or a caught exception.
+        #[cfg(all(feature = "build-tesseract", not(target_arch = "wasm32")))]
+        let text_ptr = unsafe { shim::kreuzberg_tess_get_utf8_text(*handle) };
+        #[cfg(not(all(feature = "build-tesseract", not(target_arch = "wasm32"))))]
         let text_ptr = unsafe { TessBaseAPIGetUTF8Text(*handle) };
         if text_ptr.is_null() {
             return Err(TesseractError::OcrError);
@@ -2212,7 +2227,9 @@ ffi_extern! {
     fn TessBaseAPIGetDoubleVariable(handle: *mut c_void, name: *const c_char) -> c_double;
     fn TessBaseAPISetPageSegMode(handle: *mut c_void, mode: c_int);
     fn TessBaseAPIGetPageSegMode(handle: *mut c_void) -> c_int;
+    #[cfg(any(target_arch = "wasm32", not(feature = "build-tesseract")))]
     fn TessBaseAPIRecognize(handle: *mut c_void, monitor: *mut c_void) -> c_int;
+    #[cfg(any(target_arch = "wasm32", not(feature = "build-tesseract")))]
     fn TessBaseAPIGetHOCRText(handle: *mut c_void, page: c_int) -> *mut c_char;
 
     fn TessBaseAPIGetAltoText(handle: *mut c_void, page: c_int) -> *mut c_char;
@@ -2223,6 +2240,7 @@ ffi_extern! {
     fn TessBaseAPIGetUNLVText(handle: *mut c_void) -> *mut c_char;
     fn TessBaseAPIAllWordConfidences(handle: *mut c_void) -> *const c_int;
     fn TessBaseAPIAdaptToWordStr(handle: *mut c_void, mode: c_int, wordstr: *const c_char) -> c_int;
+    #[cfg(any(target_arch = "wasm32", not(feature = "build-tesseract")))]
     fn TessBaseAPIDetectOrientationScript(
         handle: *mut c_void,
         orient_deg: *mut c_int,
@@ -2298,7 +2316,9 @@ ffi_extern! {
     fn TessBaseAPISetImage2(handle: *mut c_void, pix: *mut c_void);
     fn TessBaseAPISetSourceResolution(handle: *mut c_void, ppi: c_int);
     fn TessBaseAPISetRectangle(handle: *mut c_void, left: c_int, top: c_int, width: c_int, height: c_int);
+    #[cfg(any(target_arch = "wasm32", not(feature = "build-tesseract")))]
     fn TessBaseAPIGetUTF8Text(handle: *mut c_void) -> *mut c_char;
+    #[cfg(any(target_arch = "wasm32", not(feature = "build-tesseract")))]
     fn TessBaseAPIClear(handle: *mut c_void);
     fn TessBaseAPIEnd(handle: *mut c_void);
     fn TessBaseAPIIsValidWord(handle: *mut c_void, word: *const c_char) -> c_int;
@@ -2349,4 +2369,27 @@ ffi_extern! {
     // boxaDestroy sets *pboxa to null after freeing, so we pass *mut *mut c_void.
     fn boxaDestroy(pboxa: *mut *mut c_void);
 
+}
+
+// Exception-barrier shims compiled from src/shim.cpp (native non-WASM builds only).
+// These wrap the five most dangerous Tesseract C API calls in try/catch (...) so that
+// C++ exceptions — including those originating in the C++ stdlib and propagating through
+// Tesseract frames built with -fno-exceptions — cannot reach Rust's extern "C-unwind"
+// frames and abort the process.
+#[cfg(all(feature = "build-tesseract", not(target_arch = "wasm32")))]
+mod shim {
+    use std::os::raw::{c_char, c_float, c_int, c_void};
+    unsafe extern "C" {
+        pub(super) fn kreuzberg_tess_recognize(handle: *mut c_void) -> c_int;
+        pub(super) fn kreuzberg_tess_get_hocr_text(handle: *mut c_void, page: c_int) -> *mut c_char;
+        pub(super) fn kreuzberg_tess_get_utf8_text(handle: *mut c_void) -> *mut c_char;
+        pub(super) fn kreuzberg_tess_clear(handle: *mut c_void);
+        pub(super) fn kreuzberg_tess_detect_orientation_script(
+            handle: *mut c_void,
+            orient_deg: *mut c_int,
+            orient_conf: *mut c_float,
+            script_name: *mut *mut c_char,
+            script_conf: *mut c_float,
+        ) -> c_int;
+    }
 }

--- a/crates/kreuzberg-tesseract/src/shim.cpp
+++ b/crates/kreuzberg-tesseract/src/shim.cpp
@@ -1,0 +1,69 @@
+// C++ exception barrier shims for Tesseract C API functions that can propagate
+// C++ exceptions into Rust FFI frames. Each function wraps the raw Tesseract call
+// in try/catch (...) so no exception can escape into the Rust call stack.
+//
+// Without these shims, a C++ exception escaping through extern "C-unwind" frames
+// causes the Rust runtime to abort with "Rust cannot catch foreign exceptions".
+//
+// These shims are compiled with exception support enabled (no -fno-exceptions),
+// so catch (...) is active even when the wrapped Tesseract library was built
+// with -fno-exceptions (where exceptions from the C++ stdlib can still propagate
+// through Tesseract frames into ours).
+#include <tesseract/capi.h>
+
+extern "C" {
+
+int kreuzberg_tess_recognize(void* handle) {
+    try {
+        return TessBaseAPIRecognize(static_cast<TessBaseAPI*>(handle), nullptr);
+    } catch (...) {
+        return -1;
+    }
+}
+
+char* kreuzberg_tess_get_hocr_text(void* handle, int page) {
+    try {
+        return TessBaseAPIGetHOCRText(static_cast<TessBaseAPI*>(handle), page);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+char* kreuzberg_tess_get_utf8_text(void* handle) {
+    try {
+        return TessBaseAPIGetUTF8Text(static_cast<TessBaseAPI*>(handle));
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void kreuzberg_tess_clear(void* handle) {
+    try {
+        TessBaseAPIClear(static_cast<TessBaseAPI*>(handle));
+    } catch (...) {}
+}
+
+int kreuzberg_tess_detect_orientation_script(
+    void* handle,
+    int* orient_deg,
+    float* orient_conf,
+    char** script_name,
+    float* script_conf
+) {
+    try {
+        // Tesseract's C API declares script_name as const char** (output read-only to caller).
+        // Rust passes *mut *mut c_char (char**); add const with a C-style cast — safe because
+        // we only add const, we do not remove it.
+        return TessBaseAPIDetectOrientationScript(
+            static_cast<TessBaseAPI*>(handle),
+            orient_deg,
+            orient_conf,
+            (const char**)script_name,
+            script_conf
+        );
+    } catch (...) {
+        return 0;
+    }
+}
+
+} // extern "C"

--- a/crates/kreuzberg/src/types/formats.rs
+++ b/crates/kreuzberg/src/types/formats.rs
@@ -284,7 +284,7 @@ impl Default for ImagePreprocessingConfig {
     fn default() -> Self {
         Self {
             target_dpi: 300,
-            auto_rotate: true,
+            auto_rotate: false,
             deskew: true,
             denoise: false,
             contrast_enhance: false,

--- a/crates/kreuzberg/tests/ocr_errors.rs
+++ b/crates/kreuzberg/tests/ocr_errors.rs
@@ -719,3 +719,71 @@ fn test_ocr_with_invalid_binarization_method() {
         }
     }
 }
+
+#[test]
+fn test_preprocessing_default_does_not_crash() {
+    if skip_if_missing("images/test_hello_world.png") {
+        return;
+    }
+
+    use kreuzberg::types::ImagePreprocessingConfig;
+
+    let file_path = get_test_file_path("images/test_hello_world.png");
+    let config = ExtractionConfig {
+        ocr: Some(OcrConfig {
+            backend: "tesseract".to_string(),
+            language: "eng".to_string(),
+            tesseract_config: Some(TesseractConfig {
+                preprocessing: Some(ImagePreprocessingConfig::default()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        force_ocr: false,
+        ..Default::default()
+    };
+
+    let result = extract_file_sync(&file_path, None, &config);
+    assert!(
+        result.is_ok(),
+        "preprocessing with default config must not crash the process: {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_auto_rotate_true_does_not_abort() {
+    if skip_if_missing("images/test_hello_world.png") {
+        return;
+    }
+
+    use kreuzberg::types::ImagePreprocessingConfig;
+
+    let file_path = get_test_file_path("images/test_hello_world.png");
+    let config = ExtractionConfig {
+        ocr: Some(OcrConfig {
+            backend: "tesseract".to_string(),
+            language: "eng".to_string(),
+            tesseract_config: Some(TesseractConfig {
+                preprocessing: Some(ImagePreprocessingConfig {
+                    auto_rotate: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        force_ocr: false,
+        ..Default::default()
+    };
+
+    // Whether osd.traineddata is present or absent, the shim catches any C++ exception
+    // from TessBaseAPIDetectOrientationScript and converts it to a graceful Err, which
+    // execution.rs then handles with a warn+continue, so OCR always completes.
+    let result = extract_file_sync(&file_path, None, &config);
+    assert!(
+        result.is_ok(),
+        "auto_rotate: true must complete extraction, not abort: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
`TessBaseAPIDetectOrientationScript` propagates a C++ exception when `osd.traineddata` is absent. The exception passes through Tesseract's `-fno-exceptions` frames and hits Rust's `extern "C-unwind"` boundary, triggering a runtime abort (exit 133 / SIGTRAP). Clients see ECONNRESET.

## What changed

**Behavioral change (`### Changed`):** `ImagePreprocessingConfig::default()` now returns `auto_rotate: false`. Callers that relied on the default enabling auto-rotation must set `auto_rotate: true` explicitly.

**Bug fix (`### Fixed`):** A C++ exception-barrier shim (`shim.cpp`, compiled with exception support) wraps `TessBaseAPIRecognize`, `GetHOCRText`, `GetUTF8Text`, `Clear`, and `DetectOrientationScript`. Any C++ exception from these calls is caught before it can reach Rust frames and converted to a graceful error return. `execution.rs` handles the graceful error with a warn-and-continue, so extraction succeeds even when OSD fails.

## Note

**System Tesseract (without `build-tesseract` feature):** the shim is compiled only when `build-tesseract` is active. On a system Tesseract install, the raw `TessBaseAPI*` calls remain exposed and the original exception propagation risk stands. This PR does not address that path.

**Stale binding defaults:** language binding packages (`python`, `java`, `csharp`, `swift`, `kotlin-android`, `php`, `wasm`) still default to `auto_rotate: true` because alef 0.24.13 (the pinned version) is not installed locally — regenerating with 0.23.70 would regress the C# `.csproj`. With the shim in place, a binding caller sending `auto_rotate=true` does not crash; OSD failure is caught, logged as a warning, and OCR continues. 

Closes #1089.

## Test plan

- [ ] `test_auto_rotate_true_does_not_abort` - explicit `auto_rotate: true` must return `Ok` (shim converts OSD exception to graceful warn+continue)
- [ ] `test_preprocessing_default_does_not_crash` - default config with preprocessing must not abort
- [ ] CI: confirm `build-tesseract` feature is active in the Tesseract CI job - otherwise both new tests are skipped and the shim is never exercised
- [ ] Follow-up: `chore: regen bindings` after installing alef 0.24.13, verify all binding defaults propagate to `false`