### PR TITLE
fix(pdf): recompute page boundaries in metadata after OCR on scanned PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,12 +78,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   implicit `Item` wrapper instead of falling back onto the bare `List`, which violated
   CommonMark's `List → Item-only` constraint and panicked in debug builds.
   ([#1096](https://github.com/kreuzberg-dev/kreuzberg/issues/1096))
-  
+
 - **pdf: `result.pages[*].isBlank` now reflects OCR content for scanned/rasterized PDFs.**
   When OCR (including VLM) wrote text into existing `PageContent` entries, `is_blank` was
   never recalculated — it retained the stale value from native text extraction, which is
   always `Some(true)` for pages with no text layer. All four write sites in the OCR
   page-assembly block now call `is_page_text_blank` after every content mutation.
+  ([#1095](https://github.com/kreuzberg-dev/kreuzberg/issues/1095))
+
+- **pdf: `metadata.pages.boundaries` now reflects `result.content` offsets after OCR.**
+  For scanned/rasterized PDFs with no embedded text layer, `PageBoundary` offsets were
+  computed against the empty native text, producing degenerate `byte_start == byte_end`
+  spans for every page. OCR wrote real content into `result.pages` but the stored
+  boundaries were never updated. The pipeline now runs `refresh_page_boundaries` before
+  chunking, re-deriving offsets against the fully rendered `result.content` string and
+  writing them back to `metadata.pages.boundaries`. This also normalises boundaries for
+  native PDFs: previously they pointed into the raw extractor string (not returned by the
+  API); they now consistently point into `result.content`.
   ([#1095](https://github.com/kreuzberg-dev/kreuzberg/issues/1095))
 
 - **reranker: `RerankError` migrated to `thiserror`.** Matches the rest

--- a/crates/kreuzberg/src/core/pipeline/features.rs
+++ b/crates/kreuzberg/src/core/pipeline/features.rs
@@ -780,6 +780,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "chunking")]
     #[test]
     fn chunks_content_matches_when_no_formatted_content_and_markdown_format() {
         // Edge: output_format=Markdown but formatted_content is None (e.g. structured extractor)

--- a/crates/kreuzberg/src/core/pipeline/features.rs
+++ b/crates/kreuzberg/src/core/pipeline/features.rs
@@ -5,7 +5,6 @@
 
 use crate::Result;
 use crate::core::config::ExtractionConfig;
-#[cfg(feature = "chunking")]
 use crate::types::PageBoundary;
 use crate::types::{ExtractionResult, ProcessingWarning};
 use std::borrow::Cow;
@@ -23,7 +22,6 @@ use std::borrow::Cow;
 ///
 /// Pages whose content cannot be found are silently skipped (the chunker will
 /// still produce output, just without page-range metadata for those pages).
-#[cfg(feature = "chunking")]
 fn recompute_boundaries_from_pages(content: &str, pages: &[crate::types::PageContent]) -> Vec<PageBoundary> {
     let mut boundaries = Vec::with_capacity(pages.len());
     let mut search_offset = 0usize;
@@ -92,6 +90,32 @@ fn recompute_boundaries_from_pages(content: &str, pages: &[crate::types::PageCon
     boundaries
 }
 
+/// Recompute page boundaries and write them back to `result.metadata.pages.boundaries`.
+///
+/// Boundaries stored during extraction are computed against the raw native text.  For
+/// scanned/rasterized PDFs that text is empty (no embedded text layer), so every
+/// boundary is a degenerate zero-length span.  After OCR fills `result.pages` with
+/// real content this function re-derives boundaries against `result.content` (the
+/// fully rendered string) and stores them so the API response and chunker both see
+/// correct byte offsets.
+///
+/// No-op when `result.pages` is `None` or `result.metadata.pages` is `None`.
+pub(super) fn refresh_page_boundaries(result: &mut ExtractionResult) {
+    let pages = match result.pages.as_deref() {
+        Some(p) if !p.is_empty() => p,
+        _ => return,
+    };
+
+    let recomputed = recompute_boundaries_from_pages(&result.content, pages);
+    if recomputed.is_empty() {
+        return;
+    }
+
+    if let Some(ref mut page_structure) = result.metadata.pages {
+        page_structure.boundaries = Some(recomputed);
+    }
+}
+
 /// Map TSLP `CodeChunk`s directly to kreuzberg `Chunk`s, bypassing text-splitter.
 ///
 /// When the extraction result contains code intelligence with non-empty chunks,
@@ -144,19 +168,10 @@ pub(super) fn execute_chunking(result: &mut ExtractionResult, config: &Extractio
         let resolved_config = chunking_config.resolve_preset();
         let chunking_config = &resolved_config;
 
-        // Recompute page boundaries against `result.content` (rendered by `render_plain`)
-        // if per-page content is available.  The boundaries stored in
-        // `result.metadata.pages.boundaries` were computed against the raw extractor text
-        // and may have different byte offsets than the rendered content.
-        let recomputed_boundaries: Option<Vec<PageBoundary>> = result
-            .pages
-            .as_deref()
-            .map(|pages| recompute_boundaries_from_pages(&result.content, pages));
-
-        let page_boundaries: Option<&[PageBoundary]> = recomputed_boundaries
-            .as_deref()
-            .filter(|s| !s.is_empty())
-            .or_else(|| result.metadata.pages.as_ref().and_then(|ps| ps.boundaries.as_deref()));
+        // refresh_page_boundaries has already recomputed and stored correct offsets;
+        // use them directly for chunk page-range attribution.
+        let page_boundaries: Option<&[PageBoundary]> =
+            result.metadata.pages.as_ref().and_then(|ps| ps.boundaries.as_deref());
 
         // When a non-plain output format is requested, formatted_content holds the
         // pre-rendered output (markdown, HTML, etc.) that will become result.content after
@@ -326,7 +341,7 @@ pub(super) fn execute_token_reduction(result: &mut ExtractionResult, config: &Ex
     Ok(())
 }
 
-#[cfg(all(test, feature = "chunking"))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::PageContent;
@@ -433,8 +448,122 @@ mod tests {
         assert_eq!(&content[boundaries[2].byte_start..boundaries[2].byte_end], p3_norm);
     }
 
+    // --- Issue #1095: degenerate page boundaries after OCR on scanned PDFs ---
+
+    fn make_scanned_pdf_result(ocr_pages: &[(&str, u32)]) -> ExtractionResult {
+        // Simulate what the pipeline produces for a scanned PDF:
+        // - result.content = concatenated OCR text
+        // - result.pages = per-page OCR content
+        // - result.metadata.pages.boundaries = stale degenerate offsets (byte_start == byte_end)
+        //   computed against the empty native text before OCR ran
+        let content = ocr_pages.iter().map(|(t, _)| *t).collect::<Vec<_>>().join("\n\n");
+
+        let pages: Vec<PageContent> = ocr_pages.iter().map(|(text, num)| make_page(*num, *text)).collect();
+
+        // Degenerate boundaries: every page has byte_start == byte_end (scanner artifact)
+        let stale_boundaries: Vec<PageBoundary> = ocr_pages
+            .iter()
+            .enumerate()
+            .map(|(i, (_, num))| PageBoundary {
+                page_number: *num,
+                byte_start: i * 2, // separator-only offsets from empty native text
+                byte_end: i * 2,
+            })
+            .collect();
+
+        let page_structure = crate::types::PageStructure {
+            total_count: ocr_pages.len() as u32,
+            unit_type: crate::types::PageUnitType::Page,
+            boundaries: Some(stale_boundaries),
+            pages: None,
+        };
+
+        ExtractionResult {
+            content,
+            pages: Some(pages),
+            metadata: crate::types::Metadata {
+                pages: Some(page_structure),
+                ..Default::default()
+            },
+            mime_type: std::borrow::Cow::Borrowed("application/pdf"),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn refresh_page_boundaries_fixes_degenerate_offsets_after_ocr() {
+        let mut result = make_scanned_pdf_result(&[
+            ("Investment and Subscription Agreement", 1),
+            ("dated 13.12.2021", 2),
+            ("entered into by and between", 3),
+        ]);
+
+        // Verify precondition: stale boundaries are degenerate (byte_start == byte_end)
+        let stale = result.metadata.pages.as_ref().unwrap().boundaries.as_ref().unwrap();
+        for b in stale {
+            assert_eq!(b.byte_start, b.byte_end, "stale boundary must be degenerate before fix");
+        }
+
+        refresh_page_boundaries(&mut result);
+
+        let updated = result.metadata.pages.as_ref().unwrap().boundaries.as_ref().unwrap();
+
+        assert_eq!(updated.len(), 3, "all pages must have a boundary");
+        for b in updated {
+            assert!(
+                b.byte_start < b.byte_end,
+                "boundary must be non-degenerate after refresh"
+            );
+        }
+        // Each boundary must point to its page content within result.content
+        assert_eq!(
+            &result.content[updated[0].byte_start..updated[0].byte_end],
+            "Investment and Subscription Agreement"
+        );
+        assert_eq!(
+            &result.content[updated[1].byte_start..updated[1].byte_end],
+            "dated 13.12.2021"
+        );
+        assert_eq!(
+            &result.content[updated[2].byte_start..updated[2].byte_end],
+            "entered into by and between"
+        );
+    }
+
+    #[test]
+    fn refresh_page_boundaries_no_op_when_pages_absent() {
+        let mut result = ExtractionResult {
+            content: "some content".to_string(),
+            pages: None,
+            mime_type: std::borrow::Cow::Borrowed("application/pdf"),
+            ..Default::default()
+        };
+        // Must not panic and metadata remains untouched
+        refresh_page_boundaries(&mut result);
+        assert!(result.metadata.pages.is_none());
+    }
+
+    #[test]
+    fn refresh_page_boundaries_no_op_when_metadata_pages_absent() {
+        let pages = vec![make_page(1, "some text")];
+        let mut result = ExtractionResult {
+            content: "some text".to_string(),
+            pages: Some(pages),
+            metadata: crate::types::Metadata {
+                pages: None,
+                ..Default::default()
+            },
+            mime_type: std::borrow::Cow::Borrowed("application/pdf"),
+            ..Default::default()
+        };
+        // Has result.pages but no metadata.pages — must not panic
+        refresh_page_boundaries(&mut result);
+        assert!(result.metadata.pages.is_none());
+    }
+
     // --- Issue #1073: chunk content must match output_format ---
 
+    #[cfg(feature = "chunking")]
     fn make_result_with_formatted(plain: &str, formatted: &str) -> ExtractionResult {
         ExtractionResult {
             content: plain.to_string(),
@@ -444,6 +573,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "chunking")]
     fn markdown_chunking_config() -> crate::core::config::ExtractionConfig {
         crate::core::config::ExtractionConfig {
             output_format: crate::core::config::OutputFormat::Markdown,
@@ -458,6 +588,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "chunking")]
     #[test]
     fn chunks_content_is_markdown_when_output_format_is_markdown() {
         let plain = "SH-001 Luca Bianchi Common Germany 3500000\nSH-002 Jeni Doe Common Singapore 2800000";
@@ -493,6 +624,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "chunking")]
     #[test]
     fn chunks_content_is_plain_when_output_format_is_plain() {
         // output_format=Plain with markdown chunker: chunks must stay plain text even when
@@ -557,6 +689,7 @@ mod tests {
         assert_eq!(chunks[0].content, plain);
     }
 
+    #[cfg(feature = "chunking")]
     #[test]
     fn chunks_content_uses_formatted_content_for_djot_output_format() {
         // Djot goes through the same != Plain branch as Markdown.
@@ -595,6 +728,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "chunking")]
     #[test]
     fn chunk_page_metadata_is_none_for_non_plain_output_format() {
         // Known limitation (#1074): when output_format != Plain, page boundaries computed

--- a/crates/kreuzberg/src/core/pipeline/features.rs
+++ b/crates/kreuzberg/src/core/pipeline/features.rs
@@ -561,6 +561,118 @@ mod tests {
         assert!(result.metadata.pages.is_none());
     }
 
+    // refresh_page_boundaries must produce identical boundaries on a second call.
+    // recompute_boundaries_from_pages is deterministic given the same content and pages,
+    // so the written-back boundaries become the source truth and re-searching them yields
+    // the same offsets.
+    #[test]
+    fn refresh_page_boundaries_is_idempotent() {
+        let mut result = make_scanned_pdf_result(&[("First page", 1), ("Second page", 2)]);
+
+        refresh_page_boundaries(&mut result);
+        let after_first = result
+            .metadata
+            .pages
+            .as_ref()
+            .unwrap()
+            .boundaries
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|b| (b.page_number, b.byte_start, b.byte_end))
+            .collect::<Vec<_>>();
+
+        refresh_page_boundaries(&mut result);
+        let after_second = result
+            .metadata
+            .pages
+            .as_ref()
+            .unwrap()
+            .boundaries
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|b| (b.page_number, b.byte_start, b.byte_end))
+            .collect::<Vec<_>>();
+
+        assert_eq!(after_first, after_second, "refresh must be idempotent");
+    }
+
+    // Native PDFs: boundaries were computed against raw extractor text; after
+    // refresh they must point into result.content (render_plain output).
+    // Simulates trailing-space pages — the typical native PDF artifact that
+    // causes raw-extractor offsets to differ from result.content offsets.
+    #[test]
+    fn refresh_page_boundaries_normalises_native_pdf_offsets_to_result_content() {
+        let p1_raw = "First page content. "; // trailing space from raw extraction
+        let p2_raw = "Second page content. "; // trailing space from raw extraction
+
+        // result.content as render_plain produces it (each paragraph trimmed)
+        let p1_clean = "First page content.";
+        let p2_clean = "Second page content.";
+        let content = format!("{p1_clean}\n\n{p2_clean}");
+
+        // Simulate raw-extractor boundaries (offsets into raw text, not result.content)
+        let mut raw = String::new();
+        let b1_start = raw.len();
+        raw.push_str(p1_raw);
+        let b1_end = raw.len();
+        raw.push_str("\n\n");
+        let b2_start = raw.len();
+        raw.push_str(p2_raw);
+        let b2_end = raw.len();
+        // Verify that raw offsets indeed differ from result.content offsets
+        assert_ne!(
+            b1_end,
+            p1_clean.len(),
+            "raw extractor end must differ from render_plain end"
+        );
+
+        let stale_boundaries = vec![
+            PageBoundary {
+                byte_start: b1_start,
+                byte_end: b1_end,
+                page_number: 1,
+            },
+            PageBoundary {
+                byte_start: b2_start,
+                byte_end: b2_end,
+                page_number: 2,
+            },
+        ];
+        let page_structure = crate::types::PageStructure {
+            total_count: 2,
+            unit_type: crate::types::PageUnitType::Page,
+            boundaries: Some(stale_boundaries),
+            pages: None,
+        };
+        let mut result = ExtractionResult {
+            content,
+            pages: Some(vec![make_page(1, p1_raw), make_page(2, p2_raw)]),
+            metadata: crate::types::Metadata {
+                pages: Some(page_structure),
+                ..Default::default()
+            },
+            mime_type: std::borrow::Cow::Borrowed("application/pdf"),
+            ..Default::default()
+        };
+
+        refresh_page_boundaries(&mut result);
+
+        let updated = result.metadata.pages.as_ref().unwrap().boundaries.as_ref().unwrap();
+        assert_eq!(updated.len(), 2);
+        assert_eq!(
+            &result.content[updated[0].byte_start..updated[0].byte_end],
+            p1_clean,
+            "page 1 boundary must point to trimmed content in result.content"
+        );
+        assert_eq!(
+            &result.content[updated[1].byte_start..updated[1].byte_end],
+            p2_clean,
+            "page 2 boundary must point to trimmed content in result.content"
+        );
+    }
+
     // --- Issue #1073: chunk content must match output_format ---
 
     #[cfg(feature = "chunking")]

--- a/crates/kreuzberg/src/core/pipeline/mod.rs
+++ b/crates/kreuzberg/src/core/pipeline/mod.rs
@@ -21,7 +21,7 @@ use crate::types::ExtractionResult;
 use crate::types::internal::InternalDocument;
 
 use execution::{execute_processors, execute_validators};
-use features::{execute_chunking, execute_language_detection, execute_token_reduction};
+use features::{execute_chunking, execute_language_detection, execute_token_reduction, refresh_page_boundaries};
 use initialization::{get_processors_from_cache, initialize_features, initialize_processor_cache};
 
 /// Run the post-processing pipeline on an `InternalDocument`.
@@ -175,6 +175,7 @@ pub async fn run_pipeline(mut doc: InternalDocument, config: &ExtractionConfig) 
         .await?;
     }
 
+    refresh_page_boundaries(&mut result);
     execute_chunking(&mut result, config)?;
 
     // Clear temporary markdown if it was only stored for chunker heading context.
@@ -315,6 +316,7 @@ pub fn run_pipeline_sync(doc: InternalDocument, config: &ExtractionConfig) -> Re
     }
 
     // 2. Run synchronous post-processing
+    refresh_page_boundaries(&mut result);
     execute_chunking(&mut result, config)?;
 
     #[cfg(feature = "chunking")]


### PR DESCRIPTION
For fully scanned/rasterized PDFs (no embedded text layer), `metadata.pages.boundaries` reported degenerate `byteStart == byteEnd` for every page. PageBoundary offsets were computed against the empty native text before OCR ran, and never updated after OCR wrote real content into result.pages.

  The pipeline now runs `refresh_page_boundaries` unconditionally before chunking. It re-derives boundaries against `result.content` (the fully rendered string returned by the API) and writes them back to `metadata.pages.boundaries`. Chunking then reads the already-correct metadata instead of recomputing a second time.

  **Side-effect for native PDFs:** boundaries previously pointed into the raw extractor string (never returned by the API). They now consistently point into `result.content`, which is the correct invariant. This is a silent but intentional improvement.

  closes  #1110 the second part of #1095 (follow-up to #1106 which fixed  `isBlank` in the same write path).

  ## Tests
  - `refresh_page_boundaries_fixes_degenerate_offsets_after_ocr` - main regression
  - `refresh_page_boundaries_normalises_native_pdf_offsets_to_result_content` - native PDF side-effect
  - `refresh_page_boundaries_is_idempotent` - calling twice yields identical boundaries
  - `refresh_page_boundaries_no_op_when_pages_absent` / `_when_metadata_pages_absent` - guard clauses