### PR TITLE
fix(pdf): merge continuation paragraphs on heuristic path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PDF heuristic path: merged continuation paragraphs now emit complete text.** `blocks_to_paragraphs` splits segments on font changes >1.5pt; when an embedded figure interrupts a paragraph the split left each fragment as a separate element. The struct-tree path already called `merge_continuation_paragraphs` to re-join these; the heuristic path did not. Fix applies the same merge after `blocks_to_paragraphs` and clears the pre-computed `text` field on merged paragraphs so assembly derives the full combined text from segments rather than returning only the first fragment.
 - **PDF: Widget annotation field values now included in extraction output (#1120).**
   Interactive (non-flattened) PDFs store form field values only in Widget annotation
   `/V` entries, not in the page content stream. The extraction path previously read spans

--- a/crates/kreuzberg/src/pdf/structure/paragraphs.rs
+++ b/crates/kreuzberg/src/pdf/structure/paragraphs.rs
@@ -39,6 +39,7 @@ pub(super) fn merge_continuation_paragraphs(paragraphs: &mut Vec<PdfParagraph>) 
         let should_merge = both_body && fonts_compatible && continuation_signal;
 
         if should_merge {
+            current.text.clear();
             current.lines.extend(next.lines);
         } else {
             paragraphs.push(current);
@@ -282,5 +283,38 @@ mod tests {
 
         let para_upper = make_body_paragraph("Furthermore", 12.0);
         assert!(!starts_with_lowercase_continuation(&para_upper));
+    }
+
+    #[test]
+    fn test_merge_clears_precomputed_text_on_heuristic_path() {
+        // Heuristic-path paragraphs have non-empty text. After merging, text must
+        // be cleared so assembly re-derives the full content from segments via
+        // join_line_texts_plain rather than returning only the first fragment.
+        let mut p1 = make_body_paragraph("een indicatie", 12.0);
+        p1.text = "een indicatie".to_string();
+        let mut p2 = make_body_paragraph("van toenemende merkbekendheid", 12.0);
+        p2.text = "van toenemende merkbekendheid".to_string();
+        let mut paragraphs = vec![p1, p2];
+        merge_continuation_paragraphs(&mut paragraphs);
+        assert_eq!(paragraphs.len(), 1, "lowercase continuation should merge");
+        assert!(
+            paragraphs[0].text.is_empty(),
+            "merged paragraph must clear pre-computed text so assembly joins from segments"
+        );
+        assert_eq!(paragraphs[0].lines.len(), 2, "both lines must be present after merge");
+    }
+
+    #[test]
+    fn test_merge_struct_tree_path_text_stays_empty() {
+        // Struct-tree paragraphs always have empty text — clearing is a no-op.
+        let mut paragraphs = vec![
+            make_body_paragraph("first sentence without terminator", 12.0),
+            make_body_paragraph("second continues here", 12.0),
+        ];
+        // text is already empty from make_body_paragraph
+        assert!(paragraphs[0].text.is_empty());
+        merge_continuation_paragraphs(&mut paragraphs);
+        assert_eq!(paragraphs.len(), 1);
+        assert!(paragraphs[0].text.is_empty());
     }
 }

--- a/crates/kreuzberg/src/pdf/structure/pipeline.rs
+++ b/crates/kreuzberg/src/pdf/structure/pipeline.rs
@@ -2513,6 +2513,27 @@ mod tests {
             1,
             "continuation paragraph split by font change should be merged on heuristic path"
         );
+        // text must be cleared so assembly uses the segment path to derive the full text.
+        assert!(
+            output[0].text.is_empty(),
+            "merged paragraph must have cleared text so assembly joins from segments"
+        );
+        // Both text fragments must be present in segments so assembly produces correct output.
+        let all_text: String = output[0]
+            .lines
+            .iter()
+            .flat_map(|l| l.segments.iter())
+            .map(|s| s.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            all_text.contains("een indicatie"),
+            "first fragment must survive in merged segments; got: {all_text:?}"
+        );
+        assert!(
+            all_text.contains("van toenemende merkbekendheid"),
+            "second fragment must survive in merged segments; got: {all_text:?}"
+        );
     }
 
     /// Heuristic path: a sentence-terminating paragraph followed by an

--- a/crates/kreuzberg/src/pdf/structure/pipeline.rs
+++ b/crates/kreuzberg/src/pdf/structure/pipeline.rs
@@ -294,6 +294,7 @@ fn process_single_page(
         );
         let page_segments = filter_segments_by_table_bboxes(page_segments, &table_bboxes);
         let mut paragraphs = blocks_to_paragraphs(page_segments, heading_map, &paragraph_gap_ys);
+        merge_continuation_paragraphs(&mut paragraphs);
         tracing::debug!(
             page = i,
             paragraphs = paragraphs.len(),
@@ -2461,6 +2462,87 @@ mod tests {
         // promoted.  The test verifies the fallback doesn't crash or produce bogus output.
         // (Documenting the expected behaviour: with k=1 forced, no heading is emitted.)
         let _ = title_entry; // May or may not be present depending on centroid convergence.
+    }
+
+    /// Segment with explicit font_size and baseline_y for heuristic-path tests.
+    fn seg_heuristic(text: &str, font_size: f32, baseline_y: f32) -> SegmentData {
+        SegmentData {
+            text: text.to_string(),
+            x: 10.0,
+            y: baseline_y,
+            width: 200.0,
+            height: font_size,
+            font_size,
+            is_bold: false,
+            is_italic: false,
+            is_monospace: false,
+            baseline_y,
+            assigned_role: None,
+        }
+    }
+
+    /// Heuristic path: two segments at different font sizes (triggering a split in
+    /// blocks_to_paragraphs) that are a sentence continuation should be re-joined
+    /// by merge_continuation_paragraphs.
+    #[test]
+    fn test_heuristic_path_merges_font_split_continuation() {
+        // Font difference 1.8pt > 1.5pt threshold → blocks_to_paragraphs splits.
+        // "een indicatie" (no terminator) + "van toenemende" (lowercase) → should merge.
+        // Font difference 1.8pt < 2.0pt merge threshold → merge is allowed.
+        let output = process_single_page(
+            PageInput {
+                page_index: 0,
+                struct_paragraphs: None,
+                heuristic_segments: vec![
+                    seg_heuristic("een indicatie", 12.0, 700.0),
+                    seg_heuristic("van toenemende merkbekendheid", 13.8, 680.0),
+                ],
+                page_hints: None,
+                table_bboxes: vec![],
+                hint_validations: vec![],
+                needs_classify: false,
+                paragraph_gap_ys: vec![],
+                include_headers: true,
+                include_footers: true,
+            },
+            &[],
+            None,
+        );
+        assert_eq!(
+            output.len(),
+            1,
+            "continuation paragraph split by font change should be merged on heuristic path"
+        );
+    }
+
+    /// Heuristic path: a sentence-terminating paragraph followed by an
+    /// uppercase-starting paragraph must NOT be merged.
+    #[test]
+    fn test_heuristic_path_does_not_merge_terminated_sentences() {
+        let output = process_single_page(
+            PageInput {
+                page_index: 0,
+                struct_paragraphs: None,
+                heuristic_segments: vec![
+                    seg_heuristic("The first sentence ends here.", 12.0, 700.0),
+                    seg_heuristic("New sentence starts uppercase.", 13.8, 680.0),
+                ],
+                page_hints: None,
+                table_bboxes: vec![],
+                hint_validations: vec![],
+                needs_classify: false,
+                paragraph_gap_ys: vec![],
+                include_headers: true,
+                include_footers: true,
+            },
+            &[],
+            None,
+        );
+        assert_eq!(
+            output.len(),
+            2,
+            "terminated sentence followed by uppercase must not be merged"
+        );
     }
 
     /// Verify that non-contiguous index ranges across pages are handled correctly.


### PR DESCRIPTION
  The struct-tree PDF path already called merge_continuation_paragraphs after assembling paragraphs from pdfium. The heuristic path (blocks_to_paragraphs) did not, so font-change splits around embedded figures produced separate paragraph elements with a blank line between them instead of one continuous paragraph.

  Root cause: blocks_to_paragraphs splits on font size deltas >1.5pt. When a figure interrupts body text, the surrounding lines land in different segments with slightly different sizes, triggering a split. merge_continuation_paragraphs exists to undo exactly these splits (no sentence terminator + lowercase continuation or close font sizes), but was never called on the heuristic path.

  Fix: Two-part.
  1. Call merge_continuation_paragraphs after blocks_to_paragraphs in the heuristic branch of process_single_page,.. matching the struct-tree path.
  2. Clear current.text before extending lines in merge_continuation_paragraphs. Heuristic-path paragraphs carry a pre-computed text field; after merging, that field holds only the first fragment. Clearing it forces assembly to derive the full combined text from segments via extract_text_and_annotations, which walks all lines of the merged paragraph.

  fixes #1099