### PR TITLE
fix(ffi): drop kreuzberg/full from heic-pulling feature passthrough

### DIFF
--- a/crates/kreuzberg-ffi/Cargo.toml
+++ b/crates/kreuzberg-ffi/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [features]
 default = ["full", "pdf", "ocr", "paddle-ocr", "paddle-ocr-types", "layout-detection", "layout-types", "embeddings", "embedding-presets", "reranker", "reranker-presets", "chunking", "keywords-yake", "keywords-rake", "language-detection", "html", "tree-sitter", "office", "email", "archives", "stopwords", "auto-rotate", "auto-rotate-types", "tokio-runtime", "api", "api-types", "mcp", "liter-llm", "quality", "svg", "transcription", "transcription-types", "classification", "captioning", "ner-onnx", "ner-llm", "diff", "redaction"]
-full = ["kreuzberg/full"]
+full = []
 pdf = ["kreuzberg/pdf"]
 ocr = ["kreuzberg/ocr"]
 paddle-ocr = ["kreuzberg/paddle-ocr"]


### PR DESCRIPTION
## Summary

- `kreuzberg-ffi`'s `full = ["kreuzberg/full"]` was unconditionally forwarding the `heic` feature graph through Cargo feature unification, defeating the target-conditional `android-target` / `windows-target` deps. libheif-sys's pkg-config-based build script then broke CI Mobile, the Swift artifact bundle, and Kotlin/Dart Android natives on Publish Release.
- Fix: `full = []`. The desktop kreuzberg dep entry already enumerates the full feature surface explicitly, so no desktop capability regresses.

## Test plan

- [x] `cargo check -p kreuzberg-ffi --target aarch64-apple-ios` clean
- [x] `cargo check -p kreuzberg-ffi` (host) clean
- [ ] CI Mobile (Android arm64-v8a, Android x86_64, iOS sim, iOS) green
- [ ] CI Rust + CI Lint + CI E2E green

Once green this can land and rc.19 will pick it up.