### PR TITLE
fix(llm): disambiguate liter_llm::ContentPart import

### DIFF
--- a/crates/kreuzberg/src/llm/vlm_ocr.rs
+++ b/crates/kreuzberg/src/llm/vlm_ocr.rs
@@ -10,7 +10,8 @@ use std::borrow::Cow;
 
 use async_trait::async_trait;
 use base64::Engine;
-use liter_llm::{ChatCompletionRequest, ContentPart, ImageUrl, LlmClient, Message, UserContent, UserMessage};
+use liter_llm::types::ContentPart;
+use liter_llm::{ChatCompletionRequest, ImageUrl, LlmClient, Message, UserContent, UserMessage};
 
 use crate::core::config::LlmConfig;
 use crate::plugins::{OcrBackend, OcrBackendType, Plugin};


### PR DESCRIPTION
## Summary

- liter-llm 1.6.x re-exports both `types::ContentPart` and `realtime::ContentPart` at the crate root; the realtime variant shadows the types one, breaking `ContentPart::ImageUrl` resolution under the rc.18 dep graph.
- Cherry-picked from `feat/candle-rebased` (e4b56394aa). Use the explicit `liter_llm::types::ContentPart` path so `ImageUrl` resolves correctly.
- Manifests as `error[E0308]: mismatched types` + `error[E0599]: no variant named 'ImageUrl'` when downstream consumers (e.g. the PHP extension build, which `cargo install`s `kreuzberg-5.0.0-rc.18` from crates.io with `liter-llm` enabled) compile rc.18.

## Test plan

- [x] `cargo check -p kreuzberg --features liter-llm` clean
- [ ] PHP extension builds across all matrix cells on next publish run
- [ ] CI green