### PR TITLE
docs: add CODE_OF_CONDUCT and sync ecosystem block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,7 +304,6 @@ packages/r/src/*.o
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+Kreuzberg is committed to a welcoming, respectful community for everyone regardless of
+background or experience level.
+
+## Expected Behaviour
+
+- Be respectful and constructive in all interactions.
+- Accept feedback graciously; give it thoughtfully.
+- Focus discussions on technical substance.
+- Assume good faith until evidence suggests otherwise.
+
+## Unacceptable Behaviour
+
+Personal attacks, sustained disruption, and discriminatory language are not tolerated.
+
+## Enforcement
+
+Report issues to **<conduct@kreuzberg.dev>**. All reports are reviewed confidentially.
+Maintainers may warn, temporarily restrict, or permanently remove contributors whose
+behaviour harms the community.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — issues, pull requests, discussions,
+Discord, and any other venue where contributors represent the project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
 - [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) — tree-sitter grammars and code-intelligence primitives.
-- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces all per-language bindings.
+- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces every per-language binding across the 5 polyglot repos.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.
 
 ## License


### PR DESCRIPTION
Adds CODE_OF_CONDUCT.md and corrects the alef entry in the ecosystem block to match canonical wording across kreuzberg-dev repos.

## Changes
- Add CODE_OF_CONDUCT.md
- Fix alef ecosystem block description to canonical wording