### PR TITLE
fix(rc30): pin C++17 for Tesseract shim + default OcrConfig() crash

### DIFF
--- a/crates/kreuzberg-py/src/lib.rs
+++ b/crates/kreuzberg-py/src/lib.rs
@@ -11817,7 +11817,7 @@ impl ImageOutputFormat {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid ImageOutputFormat: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -12535,7 +12535,7 @@ impl VlmFallbackPolicy {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "mode": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid VlmFallbackPolicy: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -12802,7 +12802,7 @@ impl ChunkSizing {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid ChunkSizing: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -12933,7 +12933,7 @@ impl EmbeddingModelType {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid EmbeddingModelType: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -13100,7 +13100,7 @@ impl RerankerModelType {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid RerankerModelType: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -14485,7 +14485,7 @@ impl AnnotationKind {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "annotation_type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid AnnotationKind: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -15539,7 +15539,7 @@ impl FormatMetadata {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "format_type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid FormatMetadata: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -16660,7 +16660,7 @@ impl DiffLine {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "kind": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid DiffLine: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -16870,7 +16870,7 @@ impl RevisionAnchor {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid RevisionAnchor: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -17289,7 +17289,7 @@ impl EnrichStatus {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "status": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid EnrichStatus: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -17492,7 +17492,7 @@ impl ChunkingDecision {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid ChunkingDecision: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -17626,7 +17626,7 @@ impl NoChunkingReason {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid NoChunkingReason: {e}")))?
             } else {
                 let json_mod = py.import("json")?;
@@ -17827,7 +17827,7 @@ impl ChunkingReason {
         // serde_json can deserialize into the tagged enum.
         let json_str: String = if let Some(v) = value {
             if let Ok(s) = v.extract::<String>() {
-                serde_json::to_string(&s)
+                serde_json::to_string(&serde_json::json!({ "type": s }))
                     .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("Invalid ChunkingReason: {e}")))?
             } else {
                 let json_mod = py.import("json")?;

--- a/crates/kreuzberg-tesseract/build.rs
+++ b/crates/kreuzberg-tesseract/build.rs
@@ -734,6 +734,12 @@ mod build_tesseract {
         cc::Build::new()
             .file("src/shim.cpp")
             .cpp(true)
+            // Pin C++17 (the standard the rest of the build already uses, see
+            // get_os_specific_config) rather than relying on the compiler's default.
+            // The vendored Tesseract 5.x headers require C++17; toolchains whose
+            // default dialect is lower (Apple clang, older GCC/clang) fail to compile
+            // the shim. It builds on CI only because GCC there defaults to C++17.
+            .std("c++17")
             .include(tesseract_install_dir.join("include"))
             .compile("kreuzberg_shim");
 

--- a/packages/ruby/ext/kreuzberg_rb/src/lib.rs
+++ b/packages/ruby/ext/kreuzberg_rb/src/lib.rs
@@ -20451,6 +20451,7 @@ impl magnus::TryConvert for ImageOutputFormat {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -20806,6 +20807,7 @@ impl magnus::TryConvert for VlmFallbackPolicy {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "mode": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -20953,6 +20955,7 @@ impl magnus::TryConvert for ChunkSizing {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -21014,6 +21017,7 @@ impl magnus::TryConvert for EmbeddingModelType {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -21086,6 +21090,7 @@ impl magnus::TryConvert for RerankerModelType {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -21825,6 +21830,7 @@ impl magnus::TryConvert for NodeContent {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "node_type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -21892,6 +21898,7 @@ impl magnus::TryConvert for AnnotationKind {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "annotation_type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -22392,6 +22399,7 @@ impl magnus::TryConvert for FormatMetadata {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "format_type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -22781,6 +22789,7 @@ impl magnus::TryConvert for OcrBoundingGeometry {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -23046,6 +23055,7 @@ impl magnus::TryConvert for DiffLine {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "kind": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -23175,6 +23185,7 @@ impl magnus::TryConvert for RevisionAnchor {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -23418,6 +23429,7 @@ impl magnus::TryConvert for EnrichStatus {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "status": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -23522,6 +23534,7 @@ impl magnus::TryConvert for ChunkingDecision {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -23600,6 +23613,7 @@ impl magnus::TryConvert for NoChunkingReason {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)
@@ -23661,6 +23675,7 @@ impl magnus::TryConvert for ChunkingReason {
         // If that fails, try treating it as a plain string value and wrap in quotes
         // If both fail, try as Custom variant (for untagged enum support)
         serde_json::from_str(&json_str)
+            .or_else(|_| serde_json::from_value(serde_json::json!({ "type": json_str })))
             .or_else(|_| serde_json::from_str(&format!("\"{json_str}\"")))
             .or_else(|_| {
                 // Try as a JSON string for Custom variant (untagged enums accept any remaining value)


### PR DESCRIPTION
> **Blocked by** https://github.com/kreuzberg-dev/alef/pull/133 — the Python/Ruby binding changes here are regenerated from that alef fix and must land (and be pinned in `alef.toml`) first.

## Problem

Two issues block v5.0.0-rc.30.

**The Tesseract C++ shim isn't built with a pinned C++ standard.** `build.rs` compiles the shim with the compiler's default C++ dialect. The vendored Tesseract 5.x headers require C++17, so the shim fails to compile wherever the default is lower — Apple clang on macOS, older GCC/clang — with `unknown type name 'constexpr'`. It builds on CI only because GCC there defaults to C++17, which is why it slipped through. The workaround was `CXXFLAGS=-std=c++17`.

**A default `OcrConfig()` crashes.** Passing a default config to `extract_file` raises `ValueError: invalid type: string "disabled", expected internally tagged enum VlmFallbackPolicy`. The binding sends the enum's default as the bare string `"disabled"`, but the underlying enum only accepts the tagged form `{"mode": "disabled"}`. Every default `OcrConfig()` was unusable without the `vlm_fallback=None` workaround, and the same crash was latent for other tagged enums (e.g. `sizing="characters"` in chunking).

## Solution

**Build:** pin the shim's `cc` build to C++17, matching the standard the rest of `build.rs` already uses for the vendored tesseract/leptonica build. The `CXXFLAGS` workaround is no longer needed.

**Config:** the real cause is the binding generator (alef), which encoded a bare enum string as a plain JSON string instead of the tagged form. Fixed in kreuzberg-dev/alef#133 and regenerated here — the Python and Ruby enum constructors now wrap a bare variant name as `{"<tag>": value}`, so `"disabled"` and every other unit-variant string parses. A cross-language audit confirmed only Python and Ruby were affected.

Closes #1150, #1151.