### PR TITLE
feat(pdf): add pdf_page_count for cheap PDF page counting

### DIFF
--- a/crates/kreuzberg/src/lib.rs
+++ b/crates/kreuzberg/src/lib.rs
@@ -447,7 +447,7 @@ pub fn detect_mime_type(path: String, check_exists: bool) -> crate::Result<Strin
 
 // ── PDF Rendering ─────────────────────────────────────────────────────────────
 #[cfg(feature = "pdf")]
-pub use pdf::render::render_pdf_page_to_png;
+pub use pdf::render::{pdf_page_count, render_pdf_page_to_png};
 
 // ── Plugin Lifecycle — public API ────────────────────────────────────────────
 // Alef extracts plugin-lifecycle fns via the `plugins::{trait_snake}::` alias modules

--- a/crates/kreuzberg/src/pdf/render.rs
+++ b/crates/kreuzberg/src/pdf/render.rs
@@ -129,6 +129,40 @@ pub fn render_pdf_page_to_png(
     Ok(rendered.data)
 }
 
+/// Count the pages in a PDF without rendering any of them.
+///
+/// Opens the document and returns its page count from the PDF structure. No page
+/// is rasterized, so this is cheap relative to `render_pdf_page_to_png` — use it
+/// when you only need the count (e.g. to drive a render loop over the pages).
+///
+/// # Arguments
+///
+/// * `pdf_bytes` - Raw PDF file bytes
+/// * `password` - Optional password for encrypted PDFs
+///
+/// # Errors
+///
+/// Returns `KreuzbergError::Parsing` if the PDF cannot be opened, authenticated,
+/// or its page count read.
+pub fn pdf_page_count(pdf_bytes: &[u8], password: Option<&str>) -> Result<usize> {
+    let doc = pdf_oxide::PdfDocument::from_bytes(pdf_bytes.to_vec()).map_err(|e| KreuzbergError::Parsing {
+        message: format!("Failed to open PDF: {e}"),
+        source: None,
+    })?;
+
+    if let Some(pwd) = password {
+        doc.authenticate(pwd.as_bytes()).map_err(|e| KreuzbergError::Parsing {
+            message: format!("Failed to authenticate PDF: {e}"),
+            source: None,
+        })?;
+    }
+
+    doc.page_count().map_err(|e| KreuzbergError::Parsing {
+        message: format!("Failed to read page count: {e}"),
+        source: None,
+    })
+}
+
 /// Build a minimal valid single-page PDF with the given MediaBox (in points).
 /// Used to test the wide-page / extreme-dimension safeguard in the renderer.
 /// Note: the generated PDF has no content stream or /Resources. It is sufficient
@@ -197,6 +231,22 @@ mod tests {
             res.is_ok(),
             "wide page render should succeed thanks to safeguard, got: {:?}",
             res.err()
+        );
+    }
+
+    #[test]
+    fn test_pdf_page_count_single_page() {
+        let pdf = build_minimal_pdf_with_mediabox(612.0, 792.0);
+        let count = pdf_page_count(&pdf, None).expect("page count should succeed for a valid PDF");
+        assert_eq!(count, 1, "minimal single-page PDF must report 1 page");
+    }
+
+    #[test]
+    fn test_pdf_page_count_invalid_pdf_errors() {
+        let err = pdf_page_count(b"not a pdf", None).expect_err("invalid PDF bytes must error");
+        assert!(
+            matches!(err, KreuzbergError::Parsing { .. }),
+            "expected a Parsing error, got: {err:?}"
         );
     }
 }


### PR DESCRIPTION
## Problem

5.x removed `PdfPageIterator`, which had given a cheap page count without rasterizing. The only PDF page API now is `render_pdf_page_to_png(bytes, page_index, dpi)`, so counting pages means render-probing each index until a `RuntimeError` ("page index out of range") — rasterizing every page. There is no exported page-count function. (#1153)

## Solution

Add a public `pdf_page_count(pdf_bytes, password) -> usize` that opens the document and returns its page count from the PDF structure without rendering any page. It mirrors `render_pdf_page_to_png`'s signature and error handling; the underlying `pdf_oxide` document already exposes the count cheaply (`render_pdf_page_to_png` uses it internally for its range check). Re-exported from `lib.rs` alongside the renderer, with tests for a known single-page count and the invalid-PDF error path.

## Bindings

This PR is the Rust core API. Exposing it across the language bindings is an `alef generate` regeneration, which I've verified clean 0.26.4 does correctly (pyo3 `#[pyfunction]`, the FFI export, and the high-level `__init__`/`.pyi`/Go/Java/etc. wrappers). I deliberately left the regenerated bindings out of this PR: the committed bindings are currently out of sync with the pinned alef 0.26.4 (a clean regen rewrites ~80k lines across the native binding crates), so binding regeneration belongs in a dedicated 0.26.4 resync rather than piecemeal in a feature PR.