### PR TITLE
feat(config): adopt alef string_shorthand for model presets

### DIFF
--- a/crates/kreuzberg/src/core/config/processing.rs
+++ b/crates/kreuzberg/src/core/config/processing.rs
@@ -391,6 +391,7 @@ impl Default for EmbeddingConfig {
 /// Embedding model types supported by Kreuzberg.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(alef, alef(string_shorthand(variant = "Preset", field = "name")))]
 pub enum EmbeddingModelType {
     /// Use a preset model configuration (recommended)
     Preset {

--- a/crates/kreuzberg/src/core/config/reranker.rs
+++ b/crates/kreuzberg/src/core/config/reranker.rs
@@ -88,6 +88,7 @@ impl Default for RerankerConfig {
 /// Since v5.0.0.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
+#[cfg_attr(alef, alef(string_shorthand(variant = "Preset", field = "name")))]
 pub enum RerankerModelType {
     /// Use a preset cross-encoder model (recommended).
     Preset {

--- a/fixtures/embed_extra/embed_texts_shorthand_preset.json
+++ b/fixtures/embed_extra/embed_texts_shorthand_preset.json
@@ -1,0 +1,18 @@
+{
+	"id": "embed_texts_shorthand_preset",
+	"category": "embed_extra",
+	"description": "Batch embed texts with a bare preset name (string_shorthand)",
+	"tags": ["embedding", "batch", "string_shorthand"],
+	"call": "embed_texts",
+	"input": {
+		"texts": ["Hello", "World"],
+		"config": {
+			"model": "balanced"
+		}
+	},
+	"assertions": [{ "type": "not_error" }],
+	"skip": {
+		"languages": ["rust", "node", "go", "elixir", "wasm", "java", "csharp", "php", "r", "dart", "kotlin_android", "swift", "zig", "homebrew"],
+		"reason": "string_shorthand (a bare preset name for the model field) is implemented for the pyo3 and magnus backends in alef 0.28.0; other backends require the explicit { type, name } form"
+	}
+}


### PR DESCRIPTION
String shorthand for model presets is now available: alef [#133](https://github.com/xberg-io/alef/pull/133) (`feat(pyo3,magnus): string_shorthand for data-variant enum constructors`) landed and shipped in alef 0.28.0, which `main` already pins. The earlier blocker is resolved.

## Problem

Passing a bare preset name to the embedding/reranker model config crashes in the bindings. `EmbeddingConfig(model="fast")` (and the reranker `model="balanced"`) fail because the generated constructor encodes the bare string as the enum tag — `{"type":"fast"}` — which serde rejects, since `fast` is not a variant. It should build `Preset { name: "fast" }`.

## Solution

Opt the two enums into alef's `string_shorthand` mechanism:

```rust
#[cfg_attr(alef, alef(string_shorthand(variant = "Preset", field = "name")))]
```

on `EmbeddingModelType` and `RerankerModelType`. Both have a single-field `Preset { name }`, which satisfies the mechanism's constraint (a bare string fills exactly one field; any others must be optional). After regeneration the constructor emits `{"type":"preset","name":"fast"}`, so a bare preset name resolves to the `Preset` variant.

## Test

`fixtures/embed_extra/embed_texts_shorthand_preset.json` constructs the embedding model from a bare preset name (`"balanced"`) instead of the explicit `{ type, name }` form. It generates to `EmbeddingModelType("balanced")` (Python) and `model: 'balanced'` (Ruby) — the two backends alef 0.28.0 implements `string_shorthand` for — and is skipped for the others. The test fails against the older bindings (bare string serializes as `{"type":"balanced"}`, which serde rejects) and passes once the pyo3/magnus constructors emit `{"type":"preset","name":<s>}`.

## Scope

Source opt-in plus the test fixture only — no regenerated bindings. The `cfg(alef)` attribute is inert in a normal build (it affects alef extraction, not the compiled crate), so both the binding behavior and the generated e2e test materialize on the next 0.28.0 binding regen, which picks up the opt-in and the fixture automatically. Verified locally: regenerating with 0.28.0 emits `{"type":"preset","name":<s>}` for pyo3 and magnus, the generated code compiles, and the fixture produces the shorthand test shown above. Other backends are unchanged until they adopt the mechanism.
