### PR TITLE
fix(pdf): render image-only pages pdf_oxide can't rasterize instead of blank (#1158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PDF**: JPEG 2000 (`/JPXDecode`) pages no longer render blank. `pdf_oxide` has no JPEG 2000 decoder, so it dropped the image and rasterized the page to white; scanned PDFs stored as full-page JPEG 2000 images then produced zero OCR output across every backend, with no error. Pages whose dominant image XObject uses a filter `pdf_oxide` cannot rasterize are now decoded directly via the in-tree decoder set (`hayro-jpeg2000`), with a safety net for images `pdf_oxide` renders blank and a warning when a page image cannot be decoded at all (instead of a silent blank). Applies to `render_pdf_page_to_png`, the OCR pipeline, and the layout runner. JPEG 2000 was the only image format pdfium handled that `pdf_oxide` could not, so this closes the image-rendering gap from the pdfium → pdf_oxide migration. (#1158)
 - **build/node-musl**: the Alpine musl Node binding build sets `CC_/CXX_<target>=gcc/g++` so `cc-rs` (used by `ring`, tesseract) finds a compiler on napi-rs's cross path. It previously failed with `error occurred in cc-rs: failed to find tool "aarch64-linux-musl-gcc"` — the cargo `*_LINKER` vars were set but `cc-rs` resolves the *compiler* via its own per-target `CC_`/`CXX_` lookup. (`docker/Dockerfile.musl-node`)
 - **Ruby gem now ships precompiled platform binaries.** `ruby-gem` only ran `rake build`, emitting a
   source-only gem on every matrix leg, so `gem install kreuzberg` compiled the native extension from

--- a/crates/kreuzberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/kreuzberg/src/extractors/pdf/layout_runner.rs
@@ -73,21 +73,11 @@ pub(super) fn run_layout_for_pdf_pages(
             .map(|(llx, lly, urx, ury)| ((urx - llx).abs(), (ury - lly).abs()))
             .unwrap_or((612.0, 792.0)); // Letter fallback
 
-        let rendered = crate::pdf::render::render_page_with_safeguards(&doc, page_idx, 150).map_err(|e| {
-            KreuzbergError::Parsing {
-                message: format!("layout runner: failed to render page {}: {e}", page_idx + 1),
-                source: None,
-            }
-        })?;
-
-        // Decode to DynamicImage, convert to RGB immediately, then drop DynamicImage
-        // so its pixel buffer is freed before processing the next page.
-        let rgb = image::load_from_memory(&rendered.data)
-            .map_err(|e| KreuzbergError::Parsing {
-                message: format!("layout runner: failed to decode page {} PNG: {e}", page_idx + 1),
-                source: None,
-            })?
-            .into_rgb8();
+        // Render via pdf_oxide, with the image-only-page fast path / safety net for
+        // pages pdf_oxide cannot rasterize (JPEG 2000 scans — see render.rs). Convert
+        // to RGB immediately and drop the DynamicImage so its pixel buffer is freed
+        // before processing the next page.
+        let rgb = crate::pdf::render::render_page_dynamic_image(&doc, page_idx, 150)?.into_rgb8();
 
         page_data.push((page_width_pts, page_height_pts, rgb));
     }

--- a/crates/kreuzberg/src/extractors/pdf/ocr.rs
+++ b/crates/kreuzberg/src/extractors/pdf/ocr.rs
@@ -392,17 +392,9 @@ pub(crate) fn render_selected_pages_for_ocr(
             );
             continue;
         }
-        let rendered = crate::pdf::render::render_page_with_safeguards(&doc, idx, 150).map_err(|e| {
-            crate::KreuzbergError::Parsing {
-                message: format!("Failed to render PDF page {}: {}", idx + 1, e),
-                source: None,
-            }
-        })?;
-        // rendered.data is PNG-encoded; decode back to DynamicImage for OCR.
-        let img = image::load_from_memory(&rendered.data).map_err(|e| crate::KreuzbergError::Parsing {
-            message: format!("Failed to decode rendered page {}: {}", idx + 1, e),
-            source: None,
-        })?;
+        // Renders via pdf_oxide, with the image-only-page fast path / safety net for
+        // pages pdf_oxide cannot rasterize (JPEG 2000 scans — see render.rs).
+        let img = crate::pdf::render::render_page_dynamic_image(&doc, idx, 150)?;
         images.push((idx, img));
     }
 
@@ -913,15 +905,10 @@ pub(crate) async fn extract_with_ocr(
                 let mut batch_encoded: Vec<(usize, Arc<Vec<u8>>, u32, u32)> =
                     Vec::with_capacity(batch_end - batch_start);
                 for i in batch_start..batch_end {
-                    let rendered = crate::pdf::render::render_page_with_safeguards(&doc, i, 150).map_err(|e| {
-                        crate::KreuzbergError::Parsing {
-                            message: format!("Failed to render page {} for OCR: {:?}", i, e),
-                            source: None,
-                        }
-                    })?;
-                    // rendered.data is PNG-encoded; width and height are available directly.
-                    batch_encoded.push((i, Arc::new(rendered.data), rendered.width, rendered.height));
-                    // `rendered` is dropped here after extracting the fields.
+                    // render_page_png returns PNG bytes + dims, with the image-only-page
+                    // fast path for JPEG 2000 scans pdf_oxide cannot rasterize (see render.rs).
+                    let (data, width, height) = crate::pdf::render::render_page_png(&doc, i, 150)?;
+                    batch_encoded.push((i, Arc::new(data), width, height));
                 }
                 batch_encoded
             };

--- a/crates/kreuzberg/src/pdf/oxide/image_page.rs
+++ b/crates/kreuzberg/src/pdf/oxide/image_page.rs
@@ -1,72 +1,46 @@
-//! Pure-Rust rendering of image-only PDF pages.
+//! Direct rendering of image-only pages.
 //!
-//! pdf_oxide's rasterizer has no JPEG 2000 decoder: `extract_image_from_xobject`
-//! returns `UnsupportedFilter` for `/JPXDecode`, so the rasterizer drops the image
-//! and the page comes out blank. Scanned PDFs that store each page as a full-page
-//! JPEG 2000 image therefore rasterize to white, and every OCR backend extracts
-//! nothing (issue #1158).
-//!
-//! kreuzberg already bundles pure-Rust decoders for these formats
-//! (`hayro-jpeg2000`, `hayro-jbig2`) for standalone image extraction. This module
-//! reuses them, via [`crate::extraction::image::load_image_for_ocr`], to render an
-//! image-only page directly from its image XObject — bypassing the rasterizer for
-//! exactly the pages pdf_oxide cannot handle.
-//!
-//! Scope: the page must be image-composable — its drawing dominated by a single
-//! full-page image XObject (the scanned-page case). pdf_oxide keeps doing all page
-//! composition (CTM, masks, vector, text); this module only substitutes the
-//! image-decode step pdf_oxide lacks. Pages mixing such an image with significant
-//! vector/text content are recovered best-effort (dominant image only); perfectly
-//! compositing them would mean re-implementing pdf_oxide's rasterizer.
+//! pdf_oxide has no JPEG 2000 decoder, so it drops `/JPXDecode` image XObjects and
+//! rasterizes the page blank (#1158). For a page whose content is a single
+//! full-page image, we decode that image directly via the in-tree decoders
+//! ([`crate::extraction::image::load_image_for_ocr`]) instead. pdf_oxide still
+//! handles every other page (vector, text, multi-image composition).
 
 use image::DynamicImage;
 use pdf_oxide::PdfDocument;
 use pdf_oxide::object::Object;
 
-/// Image filters pdf_oxide's rasterizer cannot decode: it errors and drops the
-/// image, blanking the page. Mirrors pdf_oxide's own `image_has_unsupported_filter`
-/// gate in `rendering/separation_renderer.rs` (JPEG 2000 — no pure-Rust decoder is
-/// bundled in pdf_oxide). `J2` is the ISO 32000 abbreviation for `JPXDecode`.
+/// Image filters pdf_oxide's rasterizer errors on (dropping the image, blanking
+/// the page). Mirrors pdf_oxide's `image_has_unsupported_filter`; `J2` is the
+/// ISO 32000 abbreviation for `JPXDecode`.
 const RENDERER_UNSUPPORTED_FILTERS: &[&str] = &["JPXDecode", "J2"];
 
-/// An image XObject discovered on a page, with the metadata needed to decide
-/// whether and how to decode it ourselves.
 struct PageImage {
-    /// Raw (encoded) stream bytes. For `/JPXDecode` these are the JPEG 2000
-    /// codestream verbatim, which is exactly what the JP2 decoder consumes.
+    /// Raw stream bytes. For `/JPXDecode` this is the JPEG 2000 codestream.
     raw: bytes::Bytes,
-    /// `/Filter` chain names in array order.
-    filters: Vec<String>,
-    /// Pixel area (`/Width` * `/Height`), used to pick the dominant image.
+    /// Whether `/Filter` includes a filter pdf_oxide can't rasterize.
+    unsupported_filter: bool,
+    /// `/Width` * `/Height`, used to pick the dominant image.
     area: i128,
 }
 
-impl PageImage {
-    fn has_unsupported_filter(&self) -> bool {
-        self.filters
-            .iter()
-            .any(|f| RENDERER_UNSUPPORTED_FILTERS.contains(&f.as_str()))
+/// Whether `/Filter` (a `Name` or an `Array` of `Name`s) contains a filter
+/// pdf_oxide can't rasterize.
+fn has_unsupported_filter(dict: &std::collections::HashMap<String, Object>) -> bool {
+    let Some(filter) = dict.get("Filter") else {
+        return false;
+    };
+    if let Some(name) = filter.as_name() {
+        return RENDERER_UNSUPPORTED_FILTERS.contains(&name);
     }
+    filter.as_array().is_some_and(|arr| {
+        arr.iter()
+            .filter_map(Object::as_name)
+            .any(|n| RENDERER_UNSUPPORTED_FILTERS.contains(&n))
+    })
 }
 
-/// Read the `/Filter` entry (a `Name` or an `Array` of `Name`s) as a list of
-/// filter names, in order.
-fn read_filters(dict: &std::collections::HashMap<String, Object>) -> Vec<String> {
-    match dict.get("Filter") {
-        Some(f) => {
-            if let Some(name) = f.as_name() {
-                vec![name.to_string()]
-            } else if let Some(arr) = f.as_array() {
-                arr.iter().filter_map(|o| o.as_name().map(str::to_string)).collect()
-            } else {
-                Vec::new()
-            }
-        }
-        None => Vec::new(),
-    }
-}
-
-/// Read a dictionary integer entry (e.g. `/Width`), tolerating a `Real` value.
+/// Read an integer dictionary entry, tolerating a `Real`.
 fn read_dim(dict: &std::collections::HashMap<String, Object>, key: &str) -> i128 {
     match dict.get(key) {
         Some(Object::Integer(i)) => *i as i128,
@@ -75,20 +49,14 @@ fn read_dim(dict: &std::collections::HashMap<String, Object>, key: &str) -> i128
     }
 }
 
-/// Collect every image XObject directly referenced by the page's resource
-/// dictionary, with the metadata needed to decide whether to decode it ourselves.
-///
-/// Inline images (`BI`/`EI`) and images nested inside Form XObjects are not
-/// covered — those are rare for the scanned-page case this module targets, and a
-/// page that needs them simply falls through to pdf_oxide's rasterizer.
+/// Image XObjects referenced directly by the page's resource dictionary. Inline
+/// images and images nested in Form XObjects are not covered; such pages fall
+/// through to pdf_oxide's rasterizer.
 fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
     let resources = match doc.get_page_resources(page_index) {
         Ok(r) => r,
         Err(e) => {
-            tracing::debug!(
-                page = page_index + 1,
-                "image-only render: get_page_resources failed: {e}"
-            );
+            tracing::debug!(page = page_index + 1, "get_page_resources failed: {e}");
             return Vec::new();
         }
     };
@@ -99,7 +67,7 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
         return Vec::new();
     };
 
-    // The /XObject value may be an indirect reference to the dictionary.
+    // /XObject may be an indirect reference to the dictionary.
     let xobj_owned;
     let xobj_obj = if let Some(r) = xobj_entry.as_reference() {
         match doc.load_object(r) {
@@ -108,10 +76,7 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
                 &xobj_owned
             }
             Err(e) => {
-                tracing::debug!(
-                    page = page_index + 1,
-                    "image-only render: load XObject dict failed: {e}"
-                );
+                tracing::debug!(page = page_index + 1, "load XObject dict failed: {e}");
                 return Vec::new();
             }
         }
@@ -122,7 +87,7 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
         return Vec::new();
     };
 
-    // Deterministic order so the "dominant image" choice is stable across runs.
+    // Sorted so the dominant-image choice is stable across runs.
     let mut names: Vec<&String> = xobj_dict.keys().collect();
     names.sort();
 
@@ -149,13 +114,11 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
         if dict.get("Subtype").and_then(Object::as_name) != Some("Image") {
             continue;
         }
-        // The raw stream bytes are the encoded image data. For /JPXDecode this is
-        // the JPEG 2000 codestream; pdf_oxide could not turn it into pixels.
         let Object::Stream { data, .. } = xobj else { continue };
 
         images.push(PageImage {
             raw: data.clone(),
-            filters: read_filters(dict),
+            unsupported_filter: has_unsupported_filter(dict),
             area: read_dim(dict, "Width") * read_dim(dict, "Height"),
         });
     }
@@ -163,20 +126,16 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
     images
 }
 
-/// Render an image-only page directly from its dominant image XObject, using
-/// kreuzberg's pure-Rust decoders.
+/// Decode an image-only page's dominant image XObject directly.
 ///
-/// `require_unsupported_filter` selects the trigger:
-/// - `true` — proactive path: only fires when the dominant image uses a filter
-///   pdf_oxide cannot rasterize (JPEG 2000). Call this *before* rasterizing to skip
-///   a render that pdf_oxide would blank.
-/// - `false` — safety-net path: fires for any image-only page. Call this *after* a
-///   blank pdf_oxide render to recover an image pdf_oxide silently dropped.
+/// With `require_unsupported_filter` true (the proactive path), only fires when an
+/// image uses a filter pdf_oxide can't rasterize (JPEG 2000) — call it before
+/// rasterizing. With false (the safety net), fires for any image-only page — call
+/// it after a blank render to recover a dropped image.
 ///
-/// Returns `None` when the page has no usable image, the trigger condition is not
-/// met, or no image could be decoded. A decode failure on a page that does carry an
-/// unsupported-filter image is logged at `warn`, so the blank page never passes
-/// silently to OCR.
+/// `None` when the page has no usable image, the trigger isn't met, or decoding
+/// fails. A decode failure on a page that does carry an unsupported-filter image is
+/// logged at `warn` so the blank never reaches OCR silently.
 pub(crate) fn render_image_only_page(
     doc: &PdfDocument,
     page_index: usize,
@@ -187,13 +146,11 @@ pub(crate) fn render_image_only_page(
         return None;
     }
 
-    let has_unsupported = images.iter().any(PageImage::has_unsupported_filter);
+    let has_unsupported = images.iter().any(|img| img.unsupported_filter);
     if require_unsupported_filter && !has_unsupported {
         return None;
     }
 
-    // The dominant image is the largest by pixel area — for a scanned page that is
-    // the full-page scan. Ties resolve to the first in deterministic name order.
     let dominant = images.iter().max_by_key(|img| img.area)?;
 
     match crate::extraction::image::load_image_for_ocr(dominant.raw.as_ref()) {
@@ -202,25 +159,23 @@ pub(crate) fn render_image_only_page(
                 tracing::debug!(
                     page = page_index + 1,
                     image_count = images.len(),
-                    "image-only render: page has multiple images; rendered the largest one"
+                    "rendered the largest of multiple page images"
                 );
             }
             Some(img)
         }
+        // Warn only when pdf_oxide genuinely couldn't render the page; otherwise its
+        // normal rasterization is correct and this is just a safety-net miss.
+        Err(e) if has_unsupported => {
+            tracing::warn!(
+                page = page_index + 1,
+                "page image uses a filter pdf_oxide cannot rasterize (e.g. JPEG 2000) and could not be \
+                 decoded; the page may be blank: {e}"
+            );
+            None
+        }
         Err(e) => {
-            // Only escalate to a warning when pdf_oxide genuinely could not render
-            // this page (it carries an unsupported-filter image). Otherwise the
-            // caller's normal rasterization is the right result and this is just a
-            // safety-net miss.
-            if has_unsupported {
-                tracing::warn!(
-                    page = page_index + 1,
-                    "page image uses a filter pdf_oxide cannot rasterize (e.g. JPEG 2000) and could \
-                     not be decoded for rendering/OCR; the page may be blank: {e}"
-                );
-            } else {
-                tracing::debug!(page = page_index + 1, "image-only render: decode failed: {e}");
-            }
+            tracing::debug!(page = page_index + 1, "image-only decode failed: {e}");
             None
         }
     }

--- a/crates/kreuzberg/src/pdf/oxide/image_page.rs
+++ b/crates/kreuzberg/src/pdf/oxide/image_page.rs
@@ -1,0 +1,221 @@
+//! Pure-Rust rendering of image-only PDF pages.
+//!
+//! pdf_oxide's rasterizer has no JPEG 2000 decoder: `extract_image_from_xobject`
+//! returns `UnsupportedFilter` for `/JPXDecode`, so the rasterizer drops the image
+//! and the page comes out blank. Scanned PDFs that store each page as a full-page
+//! JPEG 2000 image therefore rasterize to white, and every OCR backend extracts
+//! nothing (issue #1158).
+//!
+//! kreuzberg already bundles pure-Rust decoders for these formats
+//! (`hayro-jpeg2000`, `hayro-jbig2`) for standalone image extraction. This module
+//! reuses them, via [`crate::extraction::image::load_image_for_ocr`], to render an
+//! image-only page directly from its image XObject — bypassing the rasterizer for
+//! exactly the pages pdf_oxide cannot handle.
+//!
+//! Scope: the page must be image-composable — its drawing dominated by a single
+//! full-page image XObject (the scanned-page case). pdf_oxide keeps doing all page
+//! composition (CTM, masks, vector, text); this module only substitutes the
+//! image-decode step pdf_oxide lacks. Pages mixing such an image with significant
+//! vector/text content are recovered best-effort (dominant image only); perfectly
+//! compositing them would mean re-implementing pdf_oxide's rasterizer.
+
+use image::DynamicImage;
+use pdf_oxide::PdfDocument;
+use pdf_oxide::object::Object;
+
+/// Image filters pdf_oxide's rasterizer cannot decode: it errors and drops the
+/// image, blanking the page. Mirrors pdf_oxide's own `image_has_unsupported_filter`
+/// gate in `rendering/separation_renderer.rs` (JPEG 2000 — no pure-Rust decoder is
+/// bundled in pdf_oxide). `J2` is the ISO 32000 abbreviation for `JPXDecode`.
+const RENDERER_UNSUPPORTED_FILTERS: &[&str] = &["JPXDecode", "J2"];
+
+/// An image XObject discovered on a page, with the metadata needed to decide
+/// whether and how to decode it ourselves.
+struct PageImage {
+    /// Raw (encoded) stream bytes. For `/JPXDecode` these are the JPEG 2000
+    /// codestream verbatim, which is exactly what the JP2 decoder consumes.
+    raw: bytes::Bytes,
+    /// `/Filter` chain names in array order.
+    filters: Vec<String>,
+    /// Pixel area (`/Width` * `/Height`), used to pick the dominant image.
+    area: i128,
+}
+
+impl PageImage {
+    fn has_unsupported_filter(&self) -> bool {
+        self.filters
+            .iter()
+            .any(|f| RENDERER_UNSUPPORTED_FILTERS.contains(&f.as_str()))
+    }
+}
+
+/// Read the `/Filter` entry (a `Name` or an `Array` of `Name`s) as a list of
+/// filter names, in order.
+fn read_filters(dict: &std::collections::HashMap<String, Object>) -> Vec<String> {
+    match dict.get("Filter") {
+        Some(f) => {
+            if let Some(name) = f.as_name() {
+                vec![name.to_string()]
+            } else if let Some(arr) = f.as_array() {
+                arr.iter().filter_map(|o| o.as_name().map(str::to_string)).collect()
+            } else {
+                Vec::new()
+            }
+        }
+        None => Vec::new(),
+    }
+}
+
+/// Read a dictionary integer entry (e.g. `/Width`), tolerating a `Real` value.
+fn read_dim(dict: &std::collections::HashMap<String, Object>, key: &str) -> i128 {
+    match dict.get(key) {
+        Some(Object::Integer(i)) => *i as i128,
+        Some(Object::Real(r)) => *r as i128,
+        _ => 0,
+    }
+}
+
+/// Collect every image XObject directly referenced by the page's resource
+/// dictionary, with the metadata needed to decide whether to decode it ourselves.
+///
+/// Inline images (`BI`/`EI`) and images nested inside Form XObjects are not
+/// covered — those are rare for the scanned-page case this module targets, and a
+/// page that needs them simply falls through to pdf_oxide's rasterizer.
+fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
+    let resources = match doc.get_page_resources(page_index) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::debug!(page = page_index + 1, "image-only render: get_page_resources failed: {e}");
+            return Vec::new();
+        }
+    };
+    let Some(res_dict) = resources.as_dict() else {
+        return Vec::new();
+    };
+    let Some(xobj_entry) = res_dict.get("XObject") else {
+        return Vec::new();
+    };
+
+    // The /XObject value may be an indirect reference to the dictionary.
+    let xobj_owned;
+    let xobj_obj = if let Some(r) = xobj_entry.as_reference() {
+        match doc.load_object(r) {
+            Ok(o) => {
+                xobj_owned = o;
+                &xobj_owned
+            }
+            Err(e) => {
+                tracing::debug!(page = page_index + 1, "image-only render: load XObject dict failed: {e}");
+                return Vec::new();
+            }
+        }
+    } else {
+        xobj_entry
+    };
+    let Some(xobj_dict) = xobj_obj.as_dict() else {
+        return Vec::new();
+    };
+
+    // Deterministic order so the "dominant image" choice is stable across runs.
+    let mut names: Vec<&String> = xobj_dict.keys().collect();
+    names.sort();
+
+    let mut images = Vec::new();
+    for name in names {
+        let Some(val) = xobj_dict.get(name.as_str()) else {
+            continue;
+        };
+
+        let loaded;
+        let xobj = if let Some(r) = val.as_reference() {
+            match doc.load_object(r) {
+                Ok(o) => {
+                    loaded = o;
+                    &loaded
+                }
+                Err(_) => continue,
+            }
+        } else {
+            val
+        };
+
+        let Some(dict) = xobj.as_dict() else { continue };
+        if dict.get("Subtype").and_then(Object::as_name) != Some("Image") {
+            continue;
+        }
+        // The raw stream bytes are the encoded image data. For /JPXDecode this is
+        // the JPEG 2000 codestream; pdf_oxide could not turn it into pixels.
+        let Object::Stream { data, .. } = xobj else { continue };
+
+        images.push(PageImage {
+            raw: data.clone(),
+            filters: read_filters(dict),
+            area: read_dim(dict, "Width") * read_dim(dict, "Height"),
+        });
+    }
+
+    images
+}
+
+/// Render an image-only page directly from its dominant image XObject, using
+/// kreuzberg's pure-Rust decoders.
+///
+/// `require_unsupported_filter` selects the trigger:
+/// - `true` — proactive path: only fires when the dominant image uses a filter
+///   pdf_oxide cannot rasterize (JPEG 2000). Call this *before* rasterizing to skip
+///   a render that pdf_oxide would blank.
+/// - `false` — safety-net path: fires for any image-only page. Call this *after* a
+///   blank pdf_oxide render to recover an image pdf_oxide silently dropped.
+///
+/// Returns `None` when the page has no usable image, the trigger condition is not
+/// met, or no image could be decoded. A decode failure on a page that does carry an
+/// unsupported-filter image is logged at `warn`, so the blank page never passes
+/// silently to OCR.
+pub(crate) fn render_image_only_page(
+    doc: &PdfDocument,
+    page_index: usize,
+    require_unsupported_filter: bool,
+) -> Option<DynamicImage> {
+    let images = collect_page_images(doc, page_index);
+    if images.is_empty() {
+        return None;
+    }
+
+    let has_unsupported = images.iter().any(PageImage::has_unsupported_filter);
+    if require_unsupported_filter && !has_unsupported {
+        return None;
+    }
+
+    // The dominant image is the largest by pixel area — for a scanned page that is
+    // the full-page scan. Ties resolve to the first in deterministic name order.
+    let dominant = images.iter().max_by_key(|img| img.area)?;
+
+    match crate::extraction::image::load_image_for_ocr(dominant.raw.as_ref()) {
+        Ok(img) => {
+            if images.len() > 1 {
+                tracing::debug!(
+                    page = page_index + 1,
+                    image_count = images.len(),
+                    "image-only render: page has multiple images; rendered the largest one"
+                );
+            }
+            Some(img)
+        }
+        Err(e) => {
+            // Only escalate to a warning when pdf_oxide genuinely could not render
+            // this page (it carries an unsupported-filter image). Otherwise the
+            // caller's normal rasterization is the right result and this is just a
+            // safety-net miss.
+            if has_unsupported {
+                tracing::warn!(
+                    page = page_index + 1,
+                    "page image uses a filter pdf_oxide cannot rasterize (e.g. JPEG 2000) and could \
+                     not be decoded for rendering/OCR; the page may be blank: {e}"
+                );
+            } else {
+                tracing::debug!(page = page_index + 1, "image-only render: decode failed: {e}");
+            }
+            None
+        }
+    }
+}

--- a/crates/kreuzberg/src/pdf/oxide/image_page.rs
+++ b/crates/kreuzberg/src/pdf/oxide/image_page.rs
@@ -85,7 +85,10 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
     let resources = match doc.get_page_resources(page_index) {
         Ok(r) => r,
         Err(e) => {
-            tracing::debug!(page = page_index + 1, "image-only render: get_page_resources failed: {e}");
+            tracing::debug!(
+                page = page_index + 1,
+                "image-only render: get_page_resources failed: {e}"
+            );
             return Vec::new();
         }
     };
@@ -105,7 +108,10 @@ fn collect_page_images(doc: &PdfDocument, page_index: usize) -> Vec<PageImage> {
                 &xobj_owned
             }
             Err(e) => {
-                tracing::debug!(page = page_index + 1, "image-only render: load XObject dict failed: {e}");
+                tracing::debug!(
+                    page = page_index + 1,
+                    "image-only render: load XObject dict failed: {e}"
+                );
                 return Vec::new();
             }
         }

--- a/crates/kreuzberg/src/pdf/oxide/image_page.rs
+++ b/crates/kreuzberg/src/pdf/oxide/image_page.rs
@@ -164,13 +164,12 @@ pub(crate) fn render_image_only_page(
             }
             Some(img)
         }
-        // Warn only when pdf_oxide genuinely couldn't render the page; otherwise its
-        // normal rasterization is correct and this is just a safety-net miss.
+        // Warn only when the page's only renderable content is this image; otherwise
+        // the normal render is correct and this is just a safety-net miss.
         Err(e) if has_unsupported => {
             tracing::warn!(
                 page = page_index + 1,
-                "page image uses a filter pdf_oxide cannot rasterize (e.g. JPEG 2000) and could not be \
-                 decoded; the page may be blank: {e}"
+                "could not decode this page's JPEG 2000 image; the page may be empty in the output: {e}"
             );
             None
         }

--- a/crates/kreuzberg/src/pdf/oxide/mod.rs
+++ b/crates/kreuzberg/src/pdf/oxide/mod.rs
@@ -7,6 +7,10 @@
 pub(crate) mod annotations;
 pub(crate) mod forms;
 pub(crate) mod hierarchy;
+/// Pure-Rust rendering of image-only pages whose image uses a filter pdf_oxide
+/// cannot rasterize (JPEG 2000). Requires a JPEG 2000 decoder (`ocr` feature).
+#[cfg(feature = "ocr")]
+pub(crate) mod image_page;
 pub(crate) mod images;
 pub(crate) mod metadata;
 pub(crate) mod table;

--- a/crates/kreuzberg/src/pdf/render.rs
+++ b/crates/kreuzberg/src/pdf/render.rs
@@ -355,3 +355,121 @@ mod tests {
         );
     }
 }
+
+/// Build a minimal single-page PDF whose only content is one full-page image
+/// XObject encoded with `/JPXDecode` (JPEG 2000). pdf_oxide cannot rasterize such a
+/// page (it has no JPEG 2000 decoder), so this reproduces the #1158 blank-page bug.
+#[cfg(all(test, feature = "pdf", feature = "ocr"))]
+fn build_minimal_pdf_with_jpx_image(jp2: &[u8], w: u32, h: u32) -> Vec<u8> {
+    let mut buf = Vec::<u8>::new();
+    let mut offsets = [0usize; 6]; // indices 1..=5
+
+    buf.extend_from_slice(b"%PDF-1.5\n");
+
+    offsets[1] = buf.len();
+    buf.extend_from_slice(b"1 0 obj\n<</Type /Catalog /Pages 2 0 R>>\nendobj\n");
+
+    offsets[2] = buf.len();
+    buf.extend_from_slice(b"2 0 obj\n<</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n");
+
+    offsets[3] = buf.len();
+    buf.extend_from_slice(
+        format!(
+            "3 0 obj\n<</Type /Page /Parent 2 0 R /MediaBox [0 0 {w} {h}] \
+             /Resources <</XObject <</Im0 4 0 R>>>> /Contents 5 0 R>>\nendobj\n"
+        )
+        .as_bytes(),
+    );
+
+    // Image XObject: raw JPEG 2000 codestream under /JPXDecode.
+    offsets[4] = buf.len();
+    buf.extend_from_slice(
+        format!(
+            "4 0 obj\n<</Type /XObject /Subtype /Image /Width {w} /Height {h} \
+             /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /JPXDecode /Length {}>>\nstream\n",
+            jp2.len()
+        )
+        .as_bytes(),
+    );
+    buf.extend_from_slice(jp2);
+    buf.extend_from_slice(b"\nendstream\nendobj\n");
+
+    // Content stream draws the image scaled to the page box.
+    let content = format!("q {w} 0 0 {h} 0 0 cm /Im0 Do Q\n");
+    offsets[5] = buf.len();
+    buf.extend_from_slice(
+        format!("5 0 obj\n<</Length {}>>\nstream\n{content}endstream\nendobj\n", content.len()).as_bytes(),
+    );
+
+    let xref_offset = buf.len();
+    buf.extend_from_slice(b"xref\n0 6\n");
+    buf.extend_from_slice(b"0000000000 65535 f \n");
+    for offset in &offsets[1..=5] {
+        buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    buf.extend_from_slice(
+        format!("trailer\n<</Size 6 /Root 1 0 R>>\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes(),
+    );
+
+    buf
+}
+
+#[cfg(all(test, feature = "pdf", feature = "ocr"))]
+mod jpx_tests {
+    use super::*;
+
+    /// A small tracked JPEG 2000 fixture (decodes to a dark logo, so any correct
+    /// render is far from blank white).
+    fn jp2_fixture() -> Vec<u8> {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../test_documents/images/rust-logo-512x512-blk.jp2");
+        std::fs::read(&path).unwrap_or_else(|e| panic!("jp2 fixture {} missing: {e}", path.display()))
+    }
+
+    /// The #1158 repro: a full-page JPEG 2000 page must render with real content
+    /// through the public API, not a blank white bitmap.
+    #[test]
+    fn jpx_page_renders_non_blank_via_public_api() {
+        let pdf = build_minimal_pdf_with_jpx_image(&jp2_fixture(), 512, 512);
+        let png = render_pdf_page_to_png(&pdf, 0, Some(150), None).expect("JPEG 2000 page should render");
+        let luma = image::load_from_memory(&png).expect("output is a valid image").to_luma8();
+        let min = luma.iter().copied().min().unwrap_or(255);
+        let max = luma.iter().copied().max().unwrap_or(255);
+        assert!(
+            min != 255 || max != 255,
+            "JPEG 2000 page rendered blank white (min={min}, max={max}); pdf_oxide dropped the image and recovery did not fire"
+        );
+    }
+
+    /// The proactive path fires for the unsupported (JPEG 2000) filter and decodes
+    /// the page image directly.
+    #[test]
+    fn render_image_only_page_recovers_jpx() {
+        let pdf = build_minimal_pdf_with_jpx_image(&jp2_fixture(), 512, 512);
+        let doc = pdf_oxide::PdfDocument::from_bytes(pdf).expect("doc opens");
+        let img = crate::pdf::oxide::image_page::render_image_only_page(&doc, 0, true)
+            .expect("proactive recovery should decode the JPEG 2000 page image");
+        assert!(img.width() > 0 && img.height() > 0);
+    }
+
+    /// A page with no image XObject must never trigger recovery, under either
+    /// trigger, so normal vector/text pages are untouched.
+    #[test]
+    fn render_image_only_page_skips_non_image_page() {
+        let pdf = build_minimal_pdf_with_mediabox(612.0, 792.0);
+        let doc = pdf_oxide::PdfDocument::from_bytes(pdf).expect("doc opens");
+        assert!(crate::pdf::oxide::image_page::render_image_only_page(&doc, 0, true).is_none());
+        assert!(crate::pdf::oxide::image_page::render_image_only_page(&doc, 0, false).is_none());
+    }
+
+    /// Parity with the removed `PdfPageIterator`: `pdf_page_count` +
+    /// `render_pdf_page_to_png` together cover page-count and per-page rasterization
+    /// (what lilbee's `rasterize_pdf` relied on), including for JPEG 2000 scans.
+    #[test]
+    fn page_count_and_render_cover_page_iterator_usage() {
+        let pdf = build_minimal_pdf_with_jpx_image(&jp2_fixture(), 512, 512);
+        assert_eq!(pdf_page_count(&pdf, None).expect("page count"), 1);
+        let png = render_pdf_page_to_png(&pdf, 0, Some(150), None).expect("render");
+        assert!(!png.is_empty(), "per-page PNG must not be empty");
+    }
+}

--- a/crates/kreuzberg/src/pdf/render.rs
+++ b/crates/kreuzberg/src/pdf/render.rs
@@ -120,19 +120,15 @@ pub fn render_pdf_page_to_png(
     }
 
     let render_dpi = dpi.unwrap_or(150).max(1) as u32;
-    // Use the safeguarded path (wide-page fix) plus the image-only-page fast path
-    // (JPEG 2000 pages pdf_oxide cannot rasterize). See `render_page_png`.
     let (png, _w, _h) = render_page_png(&doc, page_index, render_dpi)?;
     Ok(png)
 }
 
-/// Render a page to PNG bytes for raster consumers, returning `(png, width, height)`.
+/// Render a page to PNG bytes, returning `(png, width, height)`.
 ///
-/// Fast path: image-only pages whose dominant image uses a filter pdf_oxide cannot
-/// rasterize (JPEG 2000 / `/JPXDecode`) are decoded directly via the in-tree decoder
-/// set (see [`crate::pdf::oxide::image_page`]) instead of rasterizing to a blank
-/// page. All other pages rasterize through pdf_oxide exactly as before, with no
-/// extra decode/encode work.
+/// Image-only pages whose dominant image uses a filter pdf_oxide can't rasterize
+/// (JPEG 2000) are decoded directly (see [`crate::pdf::oxide::image_page`]); every
+/// other page rasterizes through pdf_oxide with no extra work.
 #[cfg(feature = "pdf")]
 pub(crate) fn render_page_png(
     doc: &pdf_oxide::PdfDocument,
@@ -154,13 +150,9 @@ pub(crate) fn render_page_png(
 
 /// Render a page to a `DynamicImage` for the OCR / layout pipelines.
 ///
-/// Combines two recoveries for pages pdf_oxide cannot rasterize:
-/// 1. Proactive: an image-only page whose dominant image uses an unsupported filter
-///    (JPEG 2000) is decoded directly, skipping a render that would come back blank.
-/// 2. Safety net: if pdf_oxide renders an image-bearing page blank anyway (an image
-///    it silently dropped), retry the direct decode before handing OCR a blank page.
-///
-/// Normal pages rasterize through pdf_oxide unchanged.
+/// Decodes an image-only page's unsupported-filter image directly (proactive), and
+/// if pdf_oxide renders an image-bearing page blank anyway, retries the direct
+/// decode before handing OCR a blank page (safety net). Normal pages are unchanged.
 #[cfg(all(feature = "pdf", any(feature = "ocr", feature = "ocr-pipeline")))]
 pub(crate) fn render_page_dynamic_image(
     doc: &pdf_oxide::PdfDocument,
@@ -217,20 +209,16 @@ fn is_effectively_blank(img: &image::DynamicImage) -> bool {
         return true;
     }
     // ~64 samples per axis: enough to catch any real content, negligible cost.
-    let step_x = (w / 64).max(1);
-    let step_y = (h / 64).max(1);
-    let mut y = 0;
-    while y < h {
-        let mut x = 0;
-        while x < w {
+    let step_x = (w / 64).max(1) as usize;
+    let step_y = (h / 64).max(1) as usize;
+    for y in (0..h).step_by(step_y) {
+        for x in (0..w).step_by(step_x) {
             let px = img.get_pixel(x, y);
             // Opaque and not near-white on any channel => real content.
             if px[3] > 10 && (px[0] < 250 || px[1] < 250 || px[2] < 250) {
                 return false;
             }
-            x += step_x;
         }
-        y += step_y;
     }
     true
 }

--- a/crates/kreuzberg/src/pdf/render.rs
+++ b/crates/kreuzberg/src/pdf/render.rs
@@ -120,13 +120,118 @@ pub fn render_pdf_page_to_png(
     }
 
     let render_dpi = dpi.unwrap_or(150).max(1) as u32;
-    // Use the safeguarded path so public API also benefits from the wide-page fix.
-    let rendered = render_page_with_safeguards(&doc, page_index, render_dpi).map_err(|e| KreuzbergError::Parsing {
-        message: format!("Failed to render page {page_index}: {e}"),
+    // Use the safeguarded path (wide-page fix) plus the image-only-page fast path
+    // (JPEG 2000 pages pdf_oxide cannot rasterize). See `render_page_png`.
+    let (png, _w, _h) = render_page_png(&doc, page_index, render_dpi)?;
+    Ok(png)
+}
+
+/// Render a page to PNG bytes for raster consumers, returning `(png, width, height)`.
+///
+/// Fast path: image-only pages whose dominant image uses a filter pdf_oxide cannot
+/// rasterize (JPEG 2000 / `/JPXDecode`) are decoded directly via the in-tree decoder
+/// set (see [`crate::pdf::oxide::image_page`]) instead of rasterizing to a blank
+/// page. All other pages rasterize through pdf_oxide exactly as before, with no
+/// extra decode/encode work.
+#[cfg(feature = "pdf")]
+pub(crate) fn render_page_png(
+    doc: &pdf_oxide::PdfDocument,
+    page_index: usize,
+    base_dpi: u32,
+) -> Result<(Vec<u8>, u32, u32)> {
+    #[cfg(feature = "ocr")]
+    {
+        if let Some(img) = crate::pdf::oxide::image_page::render_image_only_page(doc, page_index, true) {
+            return encode_dynamic_image_to_png(&img);
+        }
+    }
+    let rendered = render_page_with_safeguards(doc, page_index, base_dpi).map_err(|e| KreuzbergError::Parsing {
+        message: format!("Failed to render page {}: {e}", page_index + 1),
         source: None,
     })?;
+    Ok((rendered.data, rendered.width, rendered.height))
+}
 
-    Ok(rendered.data)
+/// Render a page to a `DynamicImage` for the OCR / layout pipelines.
+///
+/// Combines two recoveries for pages pdf_oxide cannot rasterize:
+/// 1. Proactive: an image-only page whose dominant image uses an unsupported filter
+///    (JPEG 2000) is decoded directly, skipping a render that would come back blank.
+/// 2. Safety net: if pdf_oxide renders an image-bearing page blank anyway (an image
+///    it silently dropped), retry the direct decode before handing OCR a blank page.
+///
+/// Normal pages rasterize through pdf_oxide unchanged.
+#[cfg(all(feature = "pdf", any(feature = "ocr", feature = "ocr-pipeline")))]
+pub(crate) fn render_page_dynamic_image(
+    doc: &pdf_oxide::PdfDocument,
+    page_index: usize,
+    base_dpi: u32,
+) -> Result<image::DynamicImage> {
+    #[cfg(feature = "ocr")]
+    {
+        if let Some(img) = crate::pdf::oxide::image_page::render_image_only_page(doc, page_index, true) {
+            return Ok(img);
+        }
+    }
+    let rendered = render_page_with_safeguards(doc, page_index, base_dpi).map_err(|e| KreuzbergError::Parsing {
+        message: format!("Failed to render page {}: {e}", page_index + 1),
+        source: None,
+    })?;
+    let img = image::load_from_memory(&rendered.data).map_err(|e| KreuzbergError::Parsing {
+        message: format!("Failed to decode rendered page {}: {e}", page_index + 1),
+        source: None,
+    })?;
+    #[cfg(feature = "ocr")]
+    {
+        if is_effectively_blank(&img)
+            && let Some(recovered) = crate::pdf::oxide::image_page::render_image_only_page(doc, page_index, false)
+        {
+            return Ok(recovered);
+        }
+    }
+    Ok(img)
+}
+
+/// PNG-encode a recovered page image, returning `(png, width, height)`.
+#[cfg(all(feature = "pdf", feature = "ocr"))]
+pub(crate) fn encode_dynamic_image_to_png(img: &image::DynamicImage) -> Result<(Vec<u8>, u32, u32)> {
+    let (w, h) = (img.width(), img.height());
+    let mut buf = std::io::Cursor::new(Vec::new());
+    img.write_to(&mut buf, image::ImageFormat::Png).map_err(|e| KreuzbergError::Parsing {
+        message: format!("Failed to PNG-encode recovered page image: {e}"),
+        source: None,
+    })?;
+    Ok((buf.into_inner(), w, h))
+}
+
+/// Whether a rendered page is effectively blank (uniform near-white or fully
+/// transparent). Used to trigger the image-only-page safety net. Samples a coarse
+/// grid rather than every pixel so the check stays cheap for full-resolution scans.
+#[cfg(all(feature = "pdf", feature = "ocr"))]
+fn is_effectively_blank(img: &image::DynamicImage) -> bool {
+    use image::GenericImageView;
+
+    let (w, h) = img.dimensions();
+    if w == 0 || h == 0 {
+        return true;
+    }
+    // ~64 samples per axis: enough to catch any real content, negligible cost.
+    let step_x = (w / 64).max(1);
+    let step_y = (h / 64).max(1);
+    let mut y = 0;
+    while y < h {
+        let mut x = 0;
+        while x < w {
+            let px = img.get_pixel(x, y);
+            // Opaque and not near-white on any channel => real content.
+            if px[3] > 10 && (px[0] < 250 || px[1] < 250 || px[2] < 250) {
+                return false;
+            }
+            x += step_x;
+        }
+        y += step_y;
+    }
+    true
 }
 
 /// Count the pages in a PDF without rendering any of them.

--- a/crates/kreuzberg/src/pdf/render.rs
+++ b/crates/kreuzberg/src/pdf/render.rs
@@ -191,11 +191,28 @@ pub(crate) fn encode_dynamic_image_to_png(img: &image::DynamicImage) -> Result<(
     let mut buf = std::io::Cursor::new(Vec::new());
     img.write_to(&mut buf, image::ImageFormat::Png)
         .map_err(|e| KreuzbergError::Parsing {
-            message: format!("Failed to PNG-encode recovered page image: {e}"),
+            message: format!("Failed to encode page image as PNG: {e}"),
             source: None,
         })?;
     Ok((buf.into_inner(), w, h))
 }
+
+/// Sample points per axis for the blank-page check. A grid (here 48×48 ≈ 2300
+/// points) keeps the cost constant regardless of page resolution; the safety net
+/// only needs to find one content block, and a scanned page's content covers far
+/// more than one grid cell, so real pages never read as blank.
+#[cfg(all(feature = "pdf", feature = "ocr"))]
+const BLANK_CHECK_SAMPLES_PER_AXIS: u32 = 48;
+
+/// Channel value at or above which a sample counts as white. Below 255 to tolerate
+/// the off-white background of real scans and JPEG ringing near pure white.
+#[cfg(all(feature = "pdf", feature = "ocr"))]
+const BLANK_CHECK_WHITE_LEVEL: u8 = 250;
+
+/// Minimum alpha for a sample to count as content (fully/near transparent samples
+/// are page background, not content).
+#[cfg(all(feature = "pdf", feature = "ocr"))]
+const BLANK_CHECK_MIN_ALPHA: u8 = 10;
 
 /// Whether a rendered page is effectively blank (uniform near-white or fully
 /// transparent). Used to trigger the image-only-page safety net. Samples a coarse
@@ -208,14 +225,15 @@ fn is_effectively_blank(img: &image::DynamicImage) -> bool {
     if w == 0 || h == 0 {
         return true;
     }
-    // ~64 samples per axis: enough to catch any real content, negligible cost.
-    let step_x = (w / 64).max(1) as usize;
-    let step_y = (h / 64).max(1) as usize;
+    let step_x = (w / BLANK_CHECK_SAMPLES_PER_AXIS).max(1) as usize;
+    let step_y = (h / BLANK_CHECK_SAMPLES_PER_AXIS).max(1) as usize;
     for y in (0..h).step_by(step_y) {
         for x in (0..w).step_by(step_x) {
             let px = img.get_pixel(x, y);
-            // Opaque and not near-white on any channel => real content.
-            if px[3] > 10 && (px[0] < 250 || px[1] < 250 || px[2] < 250) {
+            let opaque = px[3] >= BLANK_CHECK_MIN_ALPHA;
+            let colored =
+                px[0] < BLANK_CHECK_WHITE_LEVEL || px[1] < BLANK_CHECK_WHITE_LEVEL || px[2] < BLANK_CHECK_WHITE_LEVEL;
+            if opaque && colored {
                 return false;
             }
         }

--- a/crates/kreuzberg/src/pdf/render.rs
+++ b/crates/kreuzberg/src/pdf/render.rs
@@ -197,10 +197,11 @@ pub(crate) fn render_page_dynamic_image(
 pub(crate) fn encode_dynamic_image_to_png(img: &image::DynamicImage) -> Result<(Vec<u8>, u32, u32)> {
     let (w, h) = (img.width(), img.height());
     let mut buf = std::io::Cursor::new(Vec::new());
-    img.write_to(&mut buf, image::ImageFormat::Png).map_err(|e| KreuzbergError::Parsing {
-        message: format!("Failed to PNG-encode recovered page image: {e}"),
-        source: None,
-    })?;
+    img.write_to(&mut buf, image::ImageFormat::Png)
+        .map_err(|e| KreuzbergError::Parsing {
+            message: format!("Failed to PNG-encode recovered page image: {e}"),
+            source: None,
+        })?;
     Ok((buf.into_inner(), w, h))
 }
 
@@ -398,7 +399,11 @@ fn build_minimal_pdf_with_jpx_image(jp2: &[u8], w: u32, h: u32) -> Vec<u8> {
     let content = format!("q {w} 0 0 {h} 0 0 cm /Im0 Do Q\n");
     offsets[5] = buf.len();
     buf.extend_from_slice(
-        format!("5 0 obj\n<</Length {}>>\nstream\n{content}endstream\nendobj\n", content.len()).as_bytes(),
+        format!(
+            "5 0 obj\n<</Length {}>>\nstream\n{content}endstream\nendobj\n",
+            content.len()
+        )
+        .as_bytes(),
     );
 
     let xref_offset = buf.len();
@@ -407,9 +412,7 @@ fn build_minimal_pdf_with_jpx_image(jp2: &[u8], w: u32, h: u32) -> Vec<u8> {
     for offset in &offsets[1..=5] {
         buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
     }
-    buf.extend_from_slice(
-        format!("trailer\n<</Size 6 /Root 1 0 R>>\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes(),
-    );
+    buf.extend_from_slice(format!("trailer\n<</Size 6 /Root 1 0 R>>\nstartxref\n{xref_offset}\n%%EOF\n").as_bytes());
 
     buf
 }
@@ -432,7 +435,9 @@ mod jpx_tests {
     fn jpx_page_renders_non_blank_via_public_api() {
         let pdf = build_minimal_pdf_with_jpx_image(&jp2_fixture(), 512, 512);
         let png = render_pdf_page_to_png(&pdf, 0, Some(150), None).expect("JPEG 2000 page should render");
-        let luma = image::load_from_memory(&png).expect("output is a valid image").to_luma8();
+        let luma = image::load_from_memory(&png)
+            .expect("output is a valid image")
+            .to_luma8();
         let min = luma.iter().copied().min().unwrap_or(255);
         let max = luma.iter().copied().max().unwrap_or(255);
         assert!(


### PR DESCRIPTION
> **🚧 Draft / work in progress.** Implementation is in place and compiles; tests, CHANGELOG, and the full CI/self-review pass are still to come. Opened early for visibility — do not merge yet.

## Problem

Scanned PDFs whose pages are stored as full-page JPEG 2000 images come out blank, and every OCR backend silently extracts nothing.

The 5.x renderer is pure-Rust `pdf_oxide`, which has no JPEG 2000 decoder. For a `/JPXDecode` image XObject, `extract_image_from_xobject` returns `UnsupportedFilter`, so `pdf_oxide`'s rasterizer drops the image and the page rasterizes to white. The OCR pipeline rasterizes each page and feeds it to the backend, so tesseract/paddle/vlm/custom all receive a blank page, extract zero text, and the document is skipped as "no usable text" — with no error or warning.

Minimal repro (public API):

```python
from kreuzberg import render_pdf_page_to_png
from PIL import Image; import io
png = render_pdf_page_to_png(open("scanned.pdf","rb").read(), 0, 150, None)
print(Image.open(io.BytesIO(png)).convert("L").getextrema())  # (255, 255) == blank
```

This is a regression from the 4.x → 5.x renderer swap: 4.x rendered via **pdfium**, which decodes JPEG 2000 natively. pdfium was removed in `124ba418` ("remove pdfium, migrate to pdf_oxide as sole PDF backend"), so the JPEG 2000 capability went with it. `GitHub #1158`.

## Solution

`pdf_oxide` stays the sole backend (pure-Rust, WASM-safe — reintroducing pdfium would reverse that deliberate migration). kreuzberg already ships pure-Rust decoders for these formats (`hayro-jpeg2000`, `hayro-jbig2`) for standalone image extraction, so the fix reuses them at render time.

New module `pdf/oxide/image_page.rs` renders an image-only page directly from its dominant image XObject when `pdf_oxide` can't rasterize it:

1. **Proactive fast path** — before rasterizing, if the page's dominant image uses a filter `pdf_oxide` can't decode (`/JPXDecode`), decode the codestream directly and skip the rasterizer. No wasted render, and *faster* than today for scans.
2. **Safety net** — if `pdf_oxide` renders an image-bearing page blank anyway, retry the direct decode before handing OCR a blank page.
3. **Loud failure** — when neither path can decode an image-bearing page, log a warning instead of silently returning blank.

`pdf_oxide` keeps doing all page composition (CTM, masks, vector, text); this only substitutes the image-decode step it lacks. For the image-only/scan case that is exact; rare pages mixing a JPEG 2000 image with vector content are recovered best-effort (dominant image) with a warning.

Wired through every rasterization entry point: the public `render_pdf_page_to_png`, the OCR pipeline (force-OCR and batch), and the layout runner.

### Scope: JPEG 2000 is the only gap

`pdf_oxide` already matches pdfium on CCITT (G3 **and** G4), JBIG2, DCT/JPEG, Flate, and LZW. JPEG 2000 is the single image format it cannot decode, so this closes the image-rendering parity gap left by the pdfium removal. The safety net additionally recovers any future/edge decode failure where an alternative in-tree decoder succeeds.

## Still TODO (why this is a draft)

- [ ] Regression tests: JPEG 2000 page renders non-blank via the public API; OCR pipeline + layout runner paths; safety-net + loud-failure behaviour; parity that `pdf_page_count` + `render_pdf_page_to_png` cover everything the removed `PdfPageIterator` did.
- [ ] CHANGELOG `[Unreleased]` entry.
- [ ] Full `cargo fmt` / `clippy -D warnings` / test pass + self-review across the changed surface.
- [ ] Refresh `#1158` to reflect the post-pdfium-removal root cause and chosen architecture.
