### PR TITLE
fix(ner): build GLiNER ONNX backend against ort 2.0.0-rc.12

### DIFF
--- a/crates/xberg-gliner/src/lib.rs
+++ b/crates/xberg-gliner/src/lib.rs
@@ -317,15 +317,13 @@ impl Tokenizer for HFTokenizer {
 #[derive(Debug)]
 struct Prompt {
     tokens: Vec<String>,
-    text_length: usize,
     entities_length: usize,
 }
 
 impl Prompt {
-    fn new(tokens: Vec<String>, text_length: usize, entities_length: usize) -> Self {
+    fn new(tokens: Vec<String>, entities_length: usize) -> Self {
         Self {
             tokens,
-            text_length,
             entities_length,
         }
     }
@@ -372,7 +370,7 @@ impl PromptInput {
             let mut prompt = Vec::with_capacity(entities_prompt.len() + tokens.len());
             prompt.extend(entities_prompt.clone());
             prompt.extend(tokens.iter().map(|token| token.text().to_string()));
-            prompts.push(Prompt::new(prompt, tokens.len(), entities_prompt.len()));
+            prompts.push(Prompt::new(prompt, entities_prompt.len()));
             text_lengths.push(tokens.len());
             num_words = num_words.max(tokens.len());
         }
@@ -781,9 +779,13 @@ impl Gliner {
 }
 
 fn build_session<P: AsRef<Path>>(model_path: P, runtime: &RuntimeConfig) -> Result<Session> {
+    // ort 2.0.0-rc.12 builder option methods return `ort::Error<SessionBuilder>`; flatten to the
+    // plain `ort::Error` the `Ort` variant accepts (matches the other ORT session sites in xberg).
     let session = Session::builder()?
-        .with_optimization_level(GraphOptimizationLevel::All)?
-        .with_intra_threads(runtime.intra_threads)?
+        .with_optimization_level(GraphOptimizationLevel::All)
+        .map_err(|e| ort::Error::new(e.message()))?
+        .with_intra_threads(runtime.intra_threads)
+        .map_err(|e| ort::Error::new(e.message()))?
         .commit_from_file(model_path)?;
     Ok(session)
 }
@@ -988,8 +990,8 @@ mod tests {
         assert_eq!(prepared.prompts.len(), 2);
         assert_eq!(prepared.prompts[0].tokens.len(), 10);
         assert_eq!(prepared.prompts[1].tokens.len(), 11);
-        assert_eq!(prepared.prompts[0].text_length, 5);
-        assert_eq!(prepared.prompts[1].text_length, 6);
+        assert_eq!(prepared.text_lengths[0], 5);
+        assert_eq!(prepared.text_lengths[1], 6);
         assert_eq!(prepared.prompts[0].tokens[0], "<<ENT>>");
         assert_eq!(prepared.prompts[0].tokens[1], "Person");
         assert_eq!(prepared.prompts[0].tokens[2], "<<ENT>>");
@@ -997,6 +999,16 @@ mod tests {
         assert_eq!(prepared.prompts[0].tokens[4], "<<SEP>>");
         assert_eq!(prepared.prompts[1].tokens[5], "This");
         assert_eq!(prepared.num_words, 6);
+    }
+
+    #[test]
+    fn build_session_surfaces_missing_model_as_error() {
+        // Exercises the ort 2.0.0-rc.12 `SessionBuilder` option chain (the part the
+        // rc.12 bump broke) and confirms a missing model file surfaces as a
+        // `GlinerError` instead of panicking.
+        let err = build_session("/nonexistent/gliner-model.onnx", &RuntimeConfig::default())
+            .expect_err("missing model file must error");
+        assert!(matches!(err, GlinerError::Ort(_)), "expected Ort error, got {err:?}");
     }
 
     #[test]
@@ -1032,9 +1044,16 @@ mod tests {
         assert_eq!(span_idx[[0, 1, 0]], 0);
         assert_eq!(span_idx[[0, 1, 1]], 1);
         assert!(span_mask[[0, 1]]);
-        assert_eq!(span_idx[[0, 11, 0]], 3);
-        assert_eq!(span_idx[[0, 11, 1]], 3);
-        assert!(span_mask[[0, 11]]);
+        // Last valid span for a 4-word text is the single-word span (3, 3), at
+        // dimension `start * max_width + width` = 3 * 3 + 0 = 9.
+        assert_eq!(span_idx[[0, 9, 0]], 3);
+        assert_eq!(span_idx[[0, 9, 1]], 3);
+        assert!(span_mask[[0, 9]]);
+        // Dimension 11 (start 3, width 2 -> span end 5) runs past the text, so it
+        // stays zeroed and masked out.
+        assert_eq!(span_idx[[0, 11, 0]], 0);
+        assert_eq!(span_idx[[0, 11, 1]], 0);
+        assert!(!span_mask[[0, 11]]);
     }
 
     #[test]

--- a/crates/xberg/src/text/ner/gline.rs
+++ b/crates/xberg/src/text/ner/gline.rs
@@ -1,12 +1,12 @@
-//! kreuzberg-gliner-rs ONNX backend for named-entity recognition.
+//! GLiNER ONNX backend for named-entity recognition.
 //!
-//! Wraps the `kreuzberg-gliner-rs` crate (a Xberg fork of upstream gline-rs,
-//! see <https://crates.io/crates/kreuzberg-gliner-rs>) to run
-//! [GLiNER](https://github.com/urchade/GLiNER) span-mode models. The default
-//! model is `urchade/gliner_multi-v2.1` — a 100 MB multilingual checkpoint that
-//! covers PERSON / ORGANIZATION / LOCATION / DATE / EMAIL out of the box.
+//! Wraps the in-tree [`xberg_gliner`] crate (a hand-written port of
+//! [GLiNER](https://github.com/urchade/GLiNER) span-mode inference) to detect
+//! entities locally. The default model is `urchade/gliner_multi-v2.1` — a 100 MB
+//! multilingual checkpoint that covers PERSON / ORGANIZATION / LOCATION / DATE /
+//! EMAIL out of the box.
 //!
-//! The fork pins `ort = "=2.0.0-rc.12"`, matching the rest of the xberg
+//! `xberg_gliner` runs on `ort 2.0.0-rc.12`, matching the rest of the xberg
 //! workspace (paddle-ocr, layout-detection, embeddings, auto-rotate,
 //! doc_orientation).
 //!
@@ -17,11 +17,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
-use gliner::model::GLiNER;
-use gliner::model::input::text::TextInput;
-use gliner::model::params::Parameters;
-use gliner::model::pipeline::span::SpanMode;
-use orp::params::RuntimeParameters;
+use xberg_gliner::{Gliner, Parameters, RuntimeConfig, TextInput};
 
 use crate::Result;
 use crate::types::entity::{Entity, EntityCategory};
@@ -89,7 +85,7 @@ pub fn download_model(repo_id: &str, _cache_dir: Option<PathBuf>) -> Result<Path
     tracing::info!(
         model_path = %model_path.display(),
         tokenizer_path = %tokenizer_path.display(),
-        "kreuzberg-gliner-rs model downloaded"
+        "GLiNER model downloaded"
     );
     Ok(model_path)
 }
@@ -128,11 +124,11 @@ fn label_to_category(class: &str) -> EntityCategory {
     }
 }
 
-/// kreuzberg-gliner-rs ONNX backend wrapper.
+/// GLiNER ONNX backend wrapper.
 ///
-/// Holds an initialised [`GLiNER<SpanMode>`] behind an `Arc<Mutex<...>>` so the
-/// model can be safely shared across async tasks (inference is synchronous and
-/// serialised internally by the mutex).
+/// Holds an initialised [`Gliner`] behind an `Arc<Mutex<...>>` so the model can
+/// be safely shared across async tasks (inference is synchronous and serialised
+/// by the mutex).
 pub struct GlineBackend {
     /// HuggingFace repository ID used to load this model (e.g. `"urchade/gliner_multi-v2.1"`).
     pub repo_id: String,
@@ -140,10 +136,9 @@ pub struct GlineBackend {
     pub model_path: PathBuf,
     /// Local path to the cached tokenizer file.
     pub tokenizer_path: PathBuf,
-    // SAFETY: GLiNER<SpanMode> is Send (all sub-fields are Send). The Mutex
-    // serialises concurrent inference calls, which is required by the
-    // underlying ort::Session API (Session::run requires &mut self).
-    model: Arc<Mutex<GLiNER<SpanMode>>>,
+    // `Gliner` is Send and serialises its own ONNX session internally; the Mutex
+    // here lets the initialised model be shared across async inference tasks.
+    model: Arc<Mutex<Gliner>>,
 }
 
 impl GlineBackend {
@@ -160,9 +155,9 @@ impl GlineBackend {
                 plugin_name: "ner-gline".to_string(),
             }
         })?;
-        let gliner = GLiNER::<SpanMode>::new(
+        let gliner = Gliner::with_runtime(
             Parameters::default(),
-            RuntimeParameters::default(),
+            RuntimeConfig::default(),
             &tokenizer_path,
             &model_path,
         )


### PR DESCRIPTION
## Problem

`ner-onnx` — pulled by `full`, and therefore by the Python wheel — stopped compiling against `ort 2.0.0-rc.12`. Two things the crate rebrand left inconsistent:

**`xberg-gliner` doesn't build against rc.12.** `build_session` applies `?` to the `SessionBuilder` option methods (`with_optimization_level`, `with_intra_threads`). Under rc.12 those return `ort::Error<SessionBuilder>` instead of `ort::Error`, so the `?` conversion into `GlinerError` no longer compiles. (#1160)

**The consumer still targets the removed crate.** `text::ner::gline` (`#[cfg(feature = "ner-onnx")]`) still imports the external `gline-rs` crates (`gliner`, `orp`) that the rebrand replaced with the in-tree `xberg-gliner`. Neither is a dependency anymore, so the feature also fails with unresolved-crate errors — which the `cargo check -p xberg-gliner` repro in #1160 hides, since it stops at the first failing crate.

## Solution

**Builder error.** Map the rc.12 `SessionBuilder` error into the plain `ort::Error` the `Ort` variant already accepts (`.map_err(|e| ort::Error::new(e.message()))`) — the same idiom the embeddings, transcription, reranking, layout, and doc_orientation session sites already use.

**Consumer.** Port `gline` to the `xberg_gliner` API. It's a drop-in: same `inference() -> SpanOutput`, same `Span` accessors, so only the imports and the constructor change.

**Test suite.** Compiling the crate for the first time since the rebrand ran its (until now dark) tests and surfaced two problems:

- A dead `Prompt::text_length` field — it duplicates `PromptInput::text_lengths` and fails `clippy --all-targets -- -D warnings`. Removed; the builder test now asserts the live field.
- `span_tensors_include_valid_span_indices_and_masks` asserted an impossible slot. For a 4-word text with `max_width = 3`, the last valid span `(3, 3)` sits at dimension `start * max_width + width` = 9; dimension 11 is the out-of-range span `(3, 5)` that `make_span_tensors` correctly leaves zeroed and masked. The test is corrected to check the real last valid span plus the padding — `make_span_tensors` matches GLiNER span-mode and is unchanged.

Also adds a `build_session` regression test: it exercises the rc.12 builder chain and confirms a missing model surfaces as `GlinerError` rather than panicking.

Verified with `cargo check -p xberg-py` (full), `cargo test -p xberg -p xberg-gliner --features full,ner-onnx --lib` (xberg 4399 passed, xberg-gliner 10 passed), and `cargo clippy -D warnings` on the affected scopes.

Closes #1160.
