### PR TITLE
docs(ocr): fix custom OCR backend example so it registers and runs

### DIFF
--- a/docs/snippets/python/ocr/cloud_ocr_backend.md
+++ b/docs/snippets/python/ocr/cloud_ocr_backend.md
@@ -1,5 +1,5 @@
 ```python title="Python"
-from xberg import register_ocr_backend
+from xberg import register_ocr_backend, OcrBackendType, OcrConfig
 import httpx
 
 class CloudOcrBackend:
@@ -16,15 +16,31 @@ class CloudOcrBackend:
     def supported_languages(self) -> list[str]:
         return self.langs
 
-    def process_image(self, image_bytes: bytes, config: dict) -> dict:
+    def supports_language(self, language: str) -> bool:
+        return language in self.langs
+
+    def backend_type(self) -> OcrBackendType:
+        return OcrBackendType.CUSTOM
+
+    def process_image(self, image_bytes: bytes, config: OcrConfig) -> dict:
+        # `config` is an OcrConfig; `config.language` is a list of language codes.
+        language = config.language[0] if config.language else "eng"
         with httpx.Client() as client:
             response = client.post(
                 "https://api.example.com/ocr",
                 files={"image": image_bytes},
-                json={"language": config.get("language", "eng")},
+                json={"language": language},
             )
             text: str = response.json()["text"]
-            return {"content": text, "mime_type": "text/plain"}
+        # The return is deserialized into an ExtractionResult; the required
+        # fields are content, mime_type, metadata, and tables. Everything else
+        # (chunks, images, detected_languages, …) is optional.
+        return {
+            "content": text,
+            "mime_type": "text/plain",
+            "metadata": {},
+            "tables": [],
+        }
 
     def initialize(self) -> None:
         pass


### PR DESCRIPTION
## Problem

The custom OCR backend example in `docs/snippets/python/ocr/cloud_ocr_backend.md` defines `name`, `version`, `supported_languages`, `process_image`, `initialize`, and `shutdown` — but not `supports_language` or `backend_type`. `register_ocr_backend` requires those, so copying the documented example verbatim fails before any OCR runs:

```
AttributeError: Backend missing required method: supports_language
```

It also returns only `{"content", "mime_type"}`. `process_image`'s return is deserialized into an `ExtractionResult`, whose required fields are `content`, `mime_type`, `metadata`, and `tables`, so the bridge rejects the short shape:

```
RuntimeError: Plugin 'cloud-ocr' method 'process_image' returned a value that does not match the expected return
```

So a reader following the official example hits two failures back to back.

## Solution

Add `supports_language` and `backend_type`, and return the required `ExtractionResult` shape (the optional fields can be omitted).

## Before / after

```python
    def supported_languages(self) -> list[str]:
        return self.langs

+   def supports_language(self, language: str) -> bool:
+       return language in self.langs
+
+   def backend_type(self) -> str:
+       return "custom"
+
    def process_image(self, image_bytes: bytes, config: dict) -> dict:
        ...
        text: str = response.json()["text"]
-       return {"content": text, "mime_type": "text/plain"}
+       return {
+           "content": text,
+           "mime_type": "text/plain",
+           "metadata": {},
+           "tables": [],
+       }
```

Verified end to end against a freshly built wheel: the corrected backend registers, and a real `extract_bytes` of a PNG routed through `OcrConfig(backend="cloud-ocr")` calls `process_image` and accepts the returned shape (`content` comes back as expected). The `{content, mime_type, metadata, tables}` set is the verified minimum — dropping `tables` reproduces the deserialization error.

Closes #1155.
