### PR TITLE
docs(llm): document Python dict workaround for LLM embedding config

### DIFF
--- a/docs/guides/llm-integration.md
+++ b/docs/guides/llm-integration.md
@@ -243,6 +243,15 @@ Use provider-hosted embedding models when you need to match your vector database
       --text "Hello world"
     ```
 
+!!! note "Python: pass the LLM model as a dict"
+
+    The typed `EmbeddingModelType.llm(LlmConfig(...))` constructor currently rejects the
+    public `xberg.LlmConfig` class. Until that is fixed
+    ([#1165](https://github.com/xberg-io/xberg/issues/1165)), specify the model as a dict —
+    `EmbeddingConfig(model={"type": "llm", "llm": {"model": "..."}})` — as shown above. The
+    nested `llm` dict accepts the same fields as `LlmConfig` (`model`, `api_key`, `base_url`,
+    `timeout_secs`, `max_retries`, `temperature`, `max_tokens`).
+
 ### Available Models
 
 | Model                                    | Dimensions | Provider |

--- a/docs/snippets/python/llm/vlm_embeddings.md
+++ b/docs/snippets/python/llm/vlm_embeddings.md
@@ -1,12 +1,13 @@
 ```python title="Python"
 import asyncio
-from xberg import embed, EmbeddingConfig, EmbeddingModelType, LlmConfig
+from xberg import embed, EmbeddingConfig
 
 async def main() -> None:
     config = EmbeddingConfig(
-        model=EmbeddingModelType.llm(
-            LlmConfig(model="openai/text-embedding-3-small")
-        ),
+        # Pass the LLM model as a dict. The typed
+        # EmbeddingModelType.llm(LlmConfig(...)) constructor currently rejects the
+        # public LlmConfig class — see https://github.com/xberg-io/xberg/issues/1165.
+        model={"type": "llm", "llm": {"model": "openai/text-embedding-3-small"}},
         normalize=True,
     )
     embeddings = await embed(["Hello world"], config=config)


### PR DESCRIPTION
## Problem

The Python VLM-embeddings docs (`docs/snippets/python/llm/vlm_embeddings.md`) showed:

```python
EmbeddingConfig(model=EmbeddingModelType.llm(LlmConfig(model="openai/text-embedding-3-small")))
```

That raises `TypeError: 'LlmConfig' object is not an instance of 'LlmConfig'`. The public `xberg.LlmConfig` (the dataclass re-exported from `.options`) isn't the compiled type that the `EmbeddingModelType.llm()` factory accepts, and the enum-variant payload isn't coerced the way struct fields are — so the documented usage is broken. Full root cause and the proposed generator-level fix are in #1165.

## Solution

This is a docs-only change to unblock users until the generator fix in #1165 lands — it does not touch the alef-generated bindings.

- **Working example.** The Python snippet now uses the dict form, which is accepted today: `EmbeddingConfig(model={"type": "llm", "llm": {"model": "..."}})`.
- **Guide note.** A note under *VLM Embeddings → Configuration* explains the limitation, links #1165, and lists the fields the nested `llm` dict accepts (same as `LlmConfig`).

Verified the snippet compiles (`python -m py_compile`).

Refs #1165.