### PR TITLE
docs(ai-rules): require CHANGELOG entries under [Unreleased]

### DIFF
--- a/.ai-rulez/domains/document-extraction/rules/api-compatibility.md
+++ b/.ai-rulez/domains/document-extraction/rules/api-compatibility.md
@@ -3,7 +3,7 @@ priority: high
 ---
 
 - Follow semantic versioning — breaking changes require major version bump
-- Document all public API changes in CHANGELOG.md
+- Document all notable changes in CHANGELOG.md under the `## [Unreleased]` heading, in the matching Keep a Changelog subsection (`### Added` / `### Changed` / `### Fixed` / `### Removed` / `### Security`). Create the subsection if it is missing. Never add new entries under an already-released `## [x.y.z]` section — those are frozen history.
 - Maintain backward compatibility for at least one minor version before removing deprecated APIs
 - All public types must be FFI-friendly or have FFI-compatible equivalents
 - Version in Cargo.toml is the single source of truth for all binding packages


### PR DESCRIPTION
## Problem

The `api-compatibility` AI rule said to "document all public API changes in CHANGELOG.md" but never said *where*. New entries kept landing ambiguously — the released `## [x.y.z]` sections are frozen history, so additions belong under `## [Unreleased]`, but the rule didn't state that.

## Solution

Make the placement explicit in `.ai-rulez/domains/document-extraction/rules/api-compatibility.md`: notable changes go under `## [Unreleased]` in the matching Keep a Changelog subsection (`### Added` / `### Changed` / `### Fixed` / `### Removed` / `### Security`), creating the subsection if missing, and never under an already-released version section.

Source-only change — the generated rule outputs (CLAUDE.md/AGENTS.md/etc.) are gitignored and regenerated by the maintainer via ai-rulez.