### PR TITLE
fix(ocr): repair WASM Tesseract backend for multi-language config

### DIFF
--- a/.github/workflows/ci-rust.yaml
+++ b/.github/workflows/ci-rust.yaml
@@ -114,6 +114,12 @@ jobs:
         run: cargo check --locked -p xberg --no-default-features
         shell: bash
 
+      # The WASM Tesseract backend is gated to `ocr-wasm` without `ocr`, a combo no other
+      # job builds; check it here so it can't bit-rot until release-time WASM publish.
+      - name: Check ocr-wasm backend
+        run: cargo check --locked -p xberg --no-default-features --features ocr-wasm --lib
+        shell: bash
+
   live-hf:
     name: Live HF preset tests
     if: github.repository == 'xberg-io/xberg' && github.actor != 'dependabot[bot]'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
   An empty language now defaults to English consistently across every OCR backend, matching the
   documented `OcrConfig` default. PaddleOCR results also report English in their metadata instead
   of an empty language when none is configured.
+- **WASM Tesseract backend builds again.** It still treated the OCR `language` config as a single
+  string after it became a list, so the WebAssembly build stopped compiling. It now uses the
+  primary language (the in-memory WASI Tesseract handles one language at a time, like the PaddleOCR
+  and VLM backends) and warns when more than one is requested.
 
 ## [1.0.0-rc.1] - 2026-06-26
 

--- a/crates/xberg/src/core/config/ocr.rs
+++ b/crates/xberg/src/core/config/ocr.rs
@@ -575,6 +575,7 @@ impl OcrConfig {
     /// "Failed to download language pack ''" error.
     #[cfg(any(
         feature = "ocr",
+        feature = "ocr-wasm",
         feature = "paddle-ocr",
         all(feature = "liter-llm", not(target_arch = "wasm32")),
     ))]

--- a/crates/xberg/src/ocr/tesseract_wasm_backend.rs
+++ b/crates/xberg/src/ocr/tesseract_wasm_backend.rs
@@ -110,7 +110,20 @@ impl OcrBackend for TesseractWasmBackend {
             });
         }
 
-        let language = config.language.first().cloned().unwrap_or_else(|| "eng".to_string());
+        // The in-memory WASI Tesseract loads a single traineddata blob per call: `init_5`
+        // takes one buffer and there is no `TESSDATA_PREFIX` directory on WASM, so this
+        // backend recognizes one language at a time (like the PaddleOCR and VLM backends).
+        // Use the primary effective language — defaulted to English and blank-filtered by
+        // `effective_languages` — and warn rather than silently drop any extras.
+        let languages = config.effective_languages();
+        let language = languages[0].clone();
+        if languages.len() > 1 {
+            tracing::warn!(
+                requested = ?languages,
+                used = %language,
+                "WASM Tesseract backend recognizes a single language per call; using the primary language"
+            );
+        }
         let tessdata = self.resolve_tessdata(&language, config)?;
 
         let img = image::load_from_memory(image_bytes).map_err(|e| crate::XbergError::Ocr {


### PR DESCRIPTION
## Problem

The WASM Tesseract backend (`tesseract_wasm_backend.rs`) stopped compiling. It still treated `OcrConfig.language` as a `String`, but #1139 migrated that field to `Vec<String>` for multi-language OCR — the native backend was updated, this one was missed:

```
error[E0308]: `if` and `else` have incompatible types
  expected `String`, found `Vec<String>`
```

It went unnoticed because the module is gated to the WASM-only build (`ocr-wasm` without `ocr`), which no per-PR CI job compiles — only the release-time WASM publish does. So the breakage is latent and would surface at the next WASM publish. Reproduces on any host with `cargo check -p xberg --no-default-features --features ocr-wasm`.

## Solution

On WASM, Tesseract loads one language at a time — `init_5` takes a single in-memory traineddata blob and there's no `TESSDATA_PREFIX` directory — so the backend recognizes a single language per call, like the PaddleOCR and VLM backends already do.

- Take the primary language from `OcrConfig::effective_languages()`, the shared accessor that defaults an empty list to English and drops blank entries, instead of the old hand-rolled `String`/`Vec` branch.
- Warn when more than one language is requested rather than silently dropping the extras.
- Extend the `effective_languages` `cfg` gate to cover `ocr-wasm` so it's available in the WASM-only build.
- Add an `ocr-wasm` lib check to per-PR CI so this class of `cfg`-gated bit-rot is caught before publish rather than at release time.

Verified with `cargo clippy -p xberg --no-default-features --features ocr-wasm --lib -- -D warnings` (clean) and `cargo check -p xberg --no-default-features --features ocr-wasm` (compiles).

Closes #1172.
