### PR TITLE
fix(benchmarks): scale batch timeout by file count + grant aggregate release permission

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -713,6 +713,11 @@ jobs:
         bench-liteparse,
       ]
     runs-on: ubuntu-24.04-arm
+    # The App token (BOT_APP_*) is absent on workflow_dispatch, so GH_TOKEN falls
+    # back to the default GITHUB_TOKEN. Grant it contents: write so `gh release
+    # create` does not 403 ("Resource not accessible by integration").
+    permissions:
+      contents: write
     if: ${{ !cancelled() && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') }}
     steps:
       - name: Create GitHub App token (if credentials available)

--- a/tools/benchmark-harness/src/adapters/subprocess.rs
+++ b/tools/benchmark-harness/src/adapters/subprocess.rs
@@ -894,11 +894,20 @@ impl FrameworkAdapter for SubprocessAdapter {
         force_ocr: &[bool],
         output_format: OutputFormat,
     ) -> Result<Vec<BenchmarkResult>> {
-        let timeout = self.effective_timeout(timeout);
         // Early return if file_paths is empty
         if file_paths.is_empty() {
             return Ok(Vec::new());
         }
+        // `timeout` is a per-document budget. A batch runs every file under a single
+        // subprocess invocation (one `lit batch-parse`, or one shell command over all
+        // paths), so the whole batch needs roughly per-document × file-count. Without
+        // this scaling the adapter's per-document max_timeout clamp (e.g. liteparse's
+        // 180s) is applied to the entire corpus and guarantees a timeout on any
+        // non-trivial batch.
+        let timeout = self
+            .effective_timeout(timeout)
+            .checked_mul(file_paths.len() as u32)
+            .unwrap_or(Duration::MAX);
 
         if !self.supports_batch {
             let mut results = Vec::new();

--- a/tools/benchmark-harness/src/runner.rs
+++ b/tools/benchmark-harness/src/runner.rs
@@ -564,7 +564,10 @@ impl BenchmarkRunner {
 
             let has_timeout = batch_results.iter().any(|r| r.error_kind == ErrorKind::Timeout);
 
-            if iteration >= config.warmup_iterations {
+            // Record benchmark iterations normally; also record a timed-out warmup
+            // iteration so a genuine batch timeout surfaces as a Timeout result rather
+            // than falling through to the opaque "No batch results" error below.
+            if iteration >= config.warmup_iterations || has_timeout {
                 all_batch_results.push(batch_results);
             }
 


### PR DESCRIPTION
Two independent fixes for red `Benchmarks` jobs (root-caused from CI logs):

**`liteparse (markdown/plaintext, batch)` → `Benchmark("No batch results")`**
The liteparse adapter caps per-document time at `max_timeout` (180s). `extract_batch` applied that single-document cap to the whole `lit batch-parse` run over every file, so the warmup batch timed out; the runner broke before recording an iteration and failed with the opaque "No batch results". Now the batch budget scales by file count, and a timed-out warmup iteration is recorded so a real timeout surfaces as a Timeout result.

**`Aggregate & Release Results` → HTTP 403 on `POST /releases`**
On `workflow_dispatch` the `BOT_APP_*` secrets are absent, so `GH_TOKEN` falls back to the default `GITHUB_TOKEN`, which inherited the top-level `contents: read`. Granted the job `contents: write`.

Validation: dispatched `Benchmarks` from this branch (ref + `branch` input) so the harness is rebuilt with the fix. `cargo check -p benchmark-harness` passes locally.