### PR TITLE
build: remove stray tree-sitter-language-pack patch override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,9 +123,6 @@ web-sys = { version = "0.3", features = [
 ] }
 
 [patch.crates-io]
-# DEV-ONLY (uncommitted): local tslp override while fixing wasm32 grammar build.
-# Remove once the fix is published to crates.io and the version floor is bumped.
-tree-sitter-language-pack = { path = "../tree-sitter-language-pack" }
 xberg = { path = "crates/xberg" }
 xberg-gliner = { path = "crates/xberg-gliner" }
 xberg-rag = { path = "crates/xberg-rag" }


### PR DESCRIPTION
> found during trial integration of latest xberg rc, super minor but easy fix and it's causing CI failures.

The DEV-ONLY `[patch.crates-io]` override pointed `tree-sitter-language-pack` at a local sibling checkout, so fresh `cargo build` / `maturin` wheel builds fail to resolve it. The wasm32 fix it existed for is published and the floor is already `1.12.1`, so this drops the override and resolves from crates.io.

Fixes #1187.