### PR TITLE
docs(python): add MCP HTTP transport client snippet

### DIFF
--- a/docs/guides/api-server.md
+++ b/docs/guides/api-server.md
@@ -264,6 +264,10 @@ All extraction tools accept an optional `config` object. URI and byte payload de
 
     --8<-- "snippets/python/mcp/mcp_custom_client.md"
 
+=== "Python (HTTP)"
+
+    --8<-- "snippets/python/mcp/mcp_http_client.md"
+
 === "LangChain"
 
     --8<-- "snippets/python/mcp/mcp_langchain_integration.md"

--- a/docs/snippets/python/mcp/mcp_http_client.md
+++ b/docs/snippets/python/mcp/mcp_http_client.md
@@ -1,0 +1,35 @@
+```python title="Python"
+import asyncio
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+MCP_URL = "http://127.0.0.1:8001/mcp"
+
+
+async def main() -> None:
+    # Requires MCP server running with HTTP transport:
+    # xberg mcp --transport http --host 127.0.0.1 --port 8001
+
+    async with httpx.AsyncClient(follow_redirects=True) as http_client:
+        async with streamable_http_client(MCP_URL, http_client=http_client) as (
+            read,
+            write,
+        ):
+            async with ClientSession(read, write) as session:
+                await session.initialize()
+
+                tools = await session.list_tools()
+                tool_names: list[str] = [t.name for t in tools.tools]
+                print(f"Available tools: {tool_names}")
+
+                result = await session.call_tool(
+                    "extract",
+                    arguments={"path": "document.pdf"},
+                )
+                print(result)
+
+
+asyncio.run(main())
+```


### PR DESCRIPTION
## Summary

- Add `docs/snippets/python/mcp/mcp_http_client.md` with a Python MCP client example for HTTP transport using the official `mcp` SDK (`streamable_http_client`, `httpx.AsyncClient`, `ClientSession`)
- Wire the snippet into `docs/guides/api-server.md` under MCP **AI Agent Integration** as a new **Python (HTTP)** tab alongside the existing stdio client

Closes #1168

## Test plan

- [x] Python snippet passes AST parse
- [x] `mcp` + `httpx` imports verified against the official SDK
- [x] `zensical build --clean` (requires local native deps)
- [x] Manual smoke test: start `xberg mcp --transport http --host 127.0.0.1 --port 8001`, run the snippet, confirm `initialize()`, `list_tools()`, and `call_tool("extract", ...)` succeed