### PR TITLE
feat(intel-mac): native Intel macOS (x86_64-apple-darwin) support

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -454,10 +454,13 @@ jobs:
         # wheel tag; bump both together when intentionally raising the floor.
         #
         # macos-15-intel (x86_64): re-added. ort has no static x86_64-apple-darwin
-        # prebuilt, so maturin picks up the macos-intel-target features
-        # (ort-dynamic) via the alef target override in xberg-py's Cargo.toml, and
-        # the wheel build vendors libonnxruntime.dylib (delocate won't see the
-        # runtime dlopen dependency, so it is copied in explicitly).
+        # prebuilt, so this leg builds once xberg-py's Cargo.toml carries the
+        # alef macos-intel-target override (pending alef target_dep_overrides
+        # support for the pyo3 scaffold, then `alef generate`). The wheel does
+        # not yet bundle libonnxruntime.dylib (delocate cannot see the runtime
+        # dlopen dependency), so ML features on the Intel wheel need
+        # ORT_DYLIB_PATH pointing at an installed ONNX Runtime until explicit
+        # vendoring lands.
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15, macos-15-intel]
     steps:
       - uses: actions/checkout@v6
@@ -584,8 +587,9 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, target: aarch64-apple-darwin }
-          # Intel macOS: native x86_64 build; ort loaded dynamically (features via
-          # the alef macos-intel-target override). Node binary bundles the dylib.
+          # Intel macOS: native x86_64 build; ONNX Runtime staged by
+          # setup-onnx-runtime (Homebrew on x86_64) and linked dynamically,
+          # same as the macos-arm64 leg.
           - { os: macos-15-intel, target: x86_64-apple-darwin }
           - { os: windows-latest, target: x86_64-pc-windows-msvc }
     steps:
@@ -1028,25 +1032,44 @@ jobs:
             cp "$BINARY_PATH" "$STAGE/xberg"
             # Intel macOS: bundle libonnxruntime.dylib next to the binary. ort
             # resolves the default dylib name relative to the executable, so no
-            # ORT_DYLIB_PATH is needed. Copy the dylib's own non-system
-            # dependencies too and repoint every install name at @loader_path so
-            # the bundle is self-contained (no Homebrew required at runtime).
+            # ORT_DYLIB_PATH is needed. Vendor the dylib's FULL non-system
+            # dependency closure — Homebrew's onnxruntime links abseil, onnx,
+            # protobuf and re2, which in turn link each other — and repoint
+            # every install name at @loader_path so the bundle is
+            # self-contained (no Homebrew required at runtime). Each staged
+            # copy gets its @loader_path ID set immediately so its own
+            # LC_ID_DYLIB line (which otool -L prints first) drops out of the
+            # Homebrew-path grep instead of being re-vendored under its
+            # versioned name.
             if [[ "$TARGET" == "x86_64-apple-darwin" && -n "${ORT_VENDOR_LIB:-}" ]]; then
               cp "$ORT_VENDOR_LIB" "$STAGE/libonnxruntime.dylib"
               chmod u+w "$STAGE/libonnxruntime.dylib"
-              # Vendor transitive Homebrew deps (skip /usr/lib + /System).
-              otool -L "$STAGE/libonnxruntime.dylib" | tail -n +2 | awk '{print $1}' \
-                | grep -E '^(/opt/homebrew|/usr/local|@rpath)/' | while read -r dep; do
-                  base="$(basename "$dep")"
-                  src="$dep"
-                  [[ "$dep" == @rpath/* ]] && src="$(brew --prefix onnxruntime)/lib/$base"
-                  [[ -f "$src" ]] || continue
-                  cp -n "$src" "$STAGE/$base" || true
-                  chmod u+w "$STAGE/$base"
-                  install_name_tool -change "$dep" "@loader_path/$base" "$STAGE/libonnxruntime.dylib" || true
+              install_name_tool -id "@loader_path/libonnxruntime.dylib" "$STAGE/libonnxruntime.dylib"
+              # Iterate to a fixpoint: each pass copies newly referenced
+              # dylibs and rewrites references in everything staged so far.
+              changed=1
+              while [[ "$changed" == 1 ]]; do
+                changed=0
+                for lib in "$STAGE"/*.dylib; do
+                  while IFS= read -r dep; do
+                    base="$(basename "$dep")"
+                    src="$dep"
+                    [[ "$dep" == @rpath/* ]] && src="$(brew --prefix onnxruntime)/lib/$base"
+                    if [[ ! -f "$STAGE/$base" ]]; then
+                      [[ -f "$src" ]] || continue
+                      cp "$src" "$STAGE/$base"
+                      chmod u+w "$STAGE/$base"
+                      install_name_tool -id "@loader_path/$base" "$STAGE/$base"
+                      changed=1
+                    fi
+                    install_name_tool -change "$dep" "@loader_path/$base" "$lib" || true
+                  done < <(otool -L "$lib" | tail -n +2 | awk '{print $1}' \
+                    | grep -E '^(/opt/homebrew|/usr/local|@rpath)/' || true)
                 done
-              install_name_tool -id "@loader_path/libonnxruntime.dylib" "$STAGE/libonnxruntime.dylib" || true
-              codesign --force -s - "$STAGE/libonnxruntime.dylib" || true
+              done
+              for lib in "$STAGE"/*.dylib; do
+                codesign --force -s - "$lib" || true
+              done
             fi
             tar -czf "${STAGE}.tar.gz" "$STAGE"
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -379,7 +379,7 @@ jobs:
           tag: ${{ needs.prepare.outputs.tag }}
           asset-prefix: xberg-cli-
           assets: |
-            xberg-cli-aarch64-apple-darwin.tar.gz,xberg-cli-aarch64-unknown-linux-gnu.tar.gz,xberg-cli-aarch64-unknown-linux-musl.tar.gz,xberg-cli-x86_64-unknown-linux-gnu.tar.gz,xberg-cli-x86_64-unknown-linux-musl.tar.gz,xberg-cli-x86_64-pc-windows-msvc.zip
+            xberg-cli-aarch64-apple-darwin.tar.gz,xberg-cli-x86_64-apple-darwin.tar.gz,xberg-cli-aarch64-unknown-linux-gnu.tar.gz,xberg-cli-aarch64-unknown-linux-musl.tar.gz,xberg-cli-x86_64-unknown-linux-gnu.tar.gz,xberg-cli-x86_64-unknown-linux-musl.tar.gz,xberg-cli-x86_64-pc-windows-msvc.zip
 
   check-go:
     name: Check GitHub Release for Go FFI assets
@@ -445,15 +445,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Intel macOS dropped (rc.20+): Apple killed x86_64 Macs and GitHub is
-        # deprecating macos-13 runners. macОS is PINNED to macos-15 (Sequoia),
-        # NOT macos-latest: when macos-latest rolled forward to macOS 26 (Tahoe)
-        # its Homebrew HEIF/AV1 bottles became 26.0-min, which exceeds the wheel's
+        # macОS is PINNED to macos-15 (Sequoia), NOT macos-latest: when
+        # macos-latest rolled forward to macOS 26 (Tahoe) its Homebrew HEIF/AV1
+        # bottles became 26.0-min, which exceeds the wheel's
         # MACOSX_DEPLOYMENT_TARGET=15.0 (set below) and delocate refused to vendor
         # them ("Library dependencies do not satisfy target MacOS version 15.0").
         # Pinning the runner keeps the bottles' min-target aligned with the 15.0
         # wheel tag; bump both together when intentionally raising the floor.
-        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15]
+        #
+        # macos-15-intel (x86_64): re-added. ort has no static x86_64-apple-darwin
+        # prebuilt, so maturin picks up the macos-intel-target features
+        # (ort-dynamic) via the alef target override in xberg-py's Cargo.toml, and
+        # the wheel build vendors libonnxruntime.dylib (delocate won't see the
+        # runtime dlopen dependency, so it is copied in explicitly).
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15, macos-15-intel]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -579,6 +584,9 @@ jobs:
           - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, target: aarch64-apple-darwin }
+          # Intel macOS: native x86_64 build; ort loaded dynamically (features via
+          # the alef macos-intel-target override). Node binary bundles the dylib.
+          - { os: macos-15-intel, target: x86_64-apple-darwin }
           - { os: windows-latest, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -738,6 +746,8 @@ jobs:
           - { os: ubuntu-latest, label: linux-x86_64 }
           - { os: ubuntu-24.04-arm, label: linux-aarch64 }
           - { os: macos-latest, label: macos-arm64 }
+          # Intel macOS: native x86_64 gem; dynamic ort (alef macos-intel-target).
+          - { os: macos-15-intel, label: macos-x86_64 }
           # Ruby on Windows is MinGW (rb-sys → x86_64-pc-windows-gnu) but ort-sys
           # only ships msvc prebuilts; the ABIs are incompatible. Skip until ORT
           # publishes mingw binaries or xberg moves to ort-tract on Ruby/Win.
@@ -786,7 +796,7 @@ jobs:
           for f in packages/ruby/pkg/*.gem; do
             base="$(basename "$f")"
             case "$base" in
-              *-x86_64-linux.gem|*-aarch64-linux.gem|*-arm64-darwin.gem) ;;
+              *-x86_64-linux.gem|*-aarch64-linux.gem|*-arm64-darwin.gem|*-x86_64-darwin.gem) ;;
               *) echo "Removing non-canonical source gem $base"; rm -f "$f" ;;
             esac
           done
@@ -814,6 +824,8 @@ jobs:
           - { os: ubuntu-latest, label: linux-x86_64, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, label: linux-arm64, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, label: macos-arm64, target: aarch64-apple-darwin }
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - { os: macos-15-intel, label: macos-x86_64, target: x86_64-apple-darwin }
           - { os: windows-latest, label: windows-x86_64, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -889,6 +901,16 @@ jobs:
               container: quay.io/pypa/manylinux_2_28_aarch64:latest,
             }
           - { os: macos-latest, target: aarch64-apple-darwin }
+          # Native Intel macOS. ort has no static x86_64-apple-darwin prebuilt
+          # (dropped rc.11; Microsoft dropped onnxruntime-osx-x86_64 after 1.23),
+          # so this target keeps the default features but swaps ort-bundled for
+          # ort-dynamic and ships a bundled libonnxruntime.dylib. Full parity
+          # with the aarch64 CLI.
+          - {
+              os: macos-15-intel,
+              target: x86_64-apple-darwin,
+              extra_cargo_args: "--features ort-dynamic,mcp,mcp-http,api",
+            }
           - { os: windows-latest, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -966,7 +988,28 @@ jobs:
           # install.sh + Homebrew (the CLI `default` features omit these). `heic`
           # is deliberately excluded — it needs vcpkg libheif on the Windows
           # release target. Docker images already build with `--features all`.
-          extra-cargo-args: --features mcp,mcp-http,api
+          # Intel macOS overrides this (matrix.extra_cargo_args) to add
+          # ort-dynamic in place of the missing static prebuilt.
+          extra-cargo-args: ${{ matrix.extra_cargo_args || '--features mcp,mcp-http,api' }}
+
+      - name: Vendor ONNX Runtime dylib (Intel macOS)
+        if: matrix.target == 'x86_64-apple-darwin'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # This target loads ONNX Runtime at runtime (ort-dynamic) rather than
+          # static-linking a prebuilt, because none exists for x86_64-apple-darwin
+          # at onnxruntime >= 1.24 (the version ort rc.12 requires). Homebrew's
+          # onnxruntime (1.27, x86_64 "sonoma" bottle) satisfies the >=1.24 check.
+          # The sequoia runner has no matching x86_64 bottle, so pour the sonoma
+          # one explicitly. Vendored next to the binary + rewritten to
+          # @loader_path so it resolves without Homebrew on the user's machine.
+          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+          brew install --bottle-tag=sonoma onnxruntime \
+            || brew install onnxruntime
+          ORT_LIB="$(brew --prefix onnxruntime)/lib/libonnxruntime.dylib"
+          test -f "$ORT_LIB"
+          echo "ORT_VENDOR_LIB=$ORT_LIB" >> "$GITHUB_ENV"
 
       - name: Package CLI artifact
         # Inline: archive layout (.tar.gz on Unix, .zip on Windows) varies per
@@ -983,6 +1026,28 @@ jobs:
             7z a "${STAGE}.zip" "$STAGE" >/dev/null
           else
             cp "$BINARY_PATH" "$STAGE/xberg"
+            # Intel macOS: bundle libonnxruntime.dylib next to the binary. ort
+            # resolves the default dylib name relative to the executable, so no
+            # ORT_DYLIB_PATH is needed. Copy the dylib's own non-system
+            # dependencies too and repoint every install name at @loader_path so
+            # the bundle is self-contained (no Homebrew required at runtime).
+            if [[ "$TARGET" == "x86_64-apple-darwin" && -n "${ORT_VENDOR_LIB:-}" ]]; then
+              cp "$ORT_VENDOR_LIB" "$STAGE/libonnxruntime.dylib"
+              chmod u+w "$STAGE/libonnxruntime.dylib"
+              # Vendor transitive Homebrew deps (skip /usr/lib + /System).
+              otool -L "$STAGE/libonnxruntime.dylib" | tail -n +2 | awk '{print $1}' \
+                | grep -E '^(/opt/homebrew|/usr/local|@rpath)/' | while read -r dep; do
+                  base="$(basename "$dep")"
+                  src="$dep"
+                  [[ "$dep" == @rpath/* ]] && src="$(brew --prefix onnxruntime)/lib/$base"
+                  [[ -f "$src" ]] || continue
+                  cp -n "$src" "$STAGE/$base" || true
+                  chmod u+w "$STAGE/$base"
+                  install_name_tool -change "$dep" "@loader_path/$base" "$STAGE/libonnxruntime.dylib" || true
+                done
+              install_name_tool -id "@loader_path/libonnxruntime.dylib" "$STAGE/libonnxruntime.dylib" || true
+              codesign --force -s - "$STAGE/libonnxruntime.dylib" || true
+            fi
             tar -czf "${STAGE}.tar.gz" "$STAGE"
           fi
 
@@ -1054,6 +1119,8 @@ jobs:
           - { os: ubuntu-latest, platform: linux-x86_64, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, platform: linux-aarch64, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, platform: macos-arm64, target: aarch64-apple-darwin }
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - { os: macos-15-intel, platform: macos-x86_64, target: x86_64-apple-darwin }
           - { os: windows-latest, platform: windows-x86_64, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -1106,6 +1173,8 @@ jobs:
           - { os: ubuntu-latest, platform: linux-x86_64, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, platform: linux-aarch64, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, platform: macos-arm64, target: aarch64-apple-darwin }
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - { os: macos-15-intel, platform: macos-x86_64, target: x86_64-apple-darwin }
           - { os: windows-latest, platform: windows-x86_64, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -1173,6 +1242,8 @@ jobs:
           - { os: ubuntu-latest, classifier: linux-x86_64, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, classifier: linux-aarch64, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, classifier: macos-arm64, target: aarch64-apple-darwin }
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - { os: macos-15-intel, classifier: macos-x86_64, target: x86_64-apple-darwin }
           - { os: windows-latest, classifier: windows-x86_64, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -1299,6 +1370,8 @@ jobs:
           - { os: ubuntu-latest, rid: linux-x64, target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, rid: linux-arm64, target: aarch64-unknown-linux-gnu }
           - { os: macos-latest, rid: osx-arm64, target: aarch64-apple-darwin }
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - { os: macos-15-intel, rid: osx-x64, target: x86_64-apple-darwin }
           - { os: windows-latest, rid: win-x64, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -1394,7 +1467,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-latest]
         nif: ["2.16", "2.17"]
         include:
           - os: ubuntu-latest
@@ -1403,6 +1476,10 @@ jobs:
           - os: ubuntu-24.04-arm
             label: linux-aarch64
             target: aarch64-unknown-linux-gnu
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - os: macos-15-intel
+            label: macos-x86_64
+            target: x86_64-apple-darwin
           - os: macos-latest
             label: macos-arm64
             target: aarch64-apple-darwin
@@ -1625,6 +1702,13 @@ jobs:
               blob: macos-arm64,
               lib: libxberg_dart.dylib,
             }
+          # Intel macOS: native x86_64; dynamic ort (alef macos-intel-target).
+          - {
+              os: macos-15-intel,
+              target: x86_64-apple-darwin,
+              blob: macos-x86_64,
+              lib: libxberg_dart.dylib,
+            }
           - {
               os: windows-latest,
               target: x86_64-pc-windows-msvc,
@@ -1741,6 +1825,11 @@ jobs:
         with:
           crate-name: xberg-swift
           artifact-name: XbergSwift
+          # Intel macOS slice deferred alongside the Homebrew bottle: the crate
+          # builds for x86_64-apple-darwin via the alef macos-intel-target
+          # override, but build-swift-artifactbundle does not yet vendor
+          # libonnxruntime.dylib into the slice, so it would ship unable to load
+          # ONNX Runtime at runtime. Flip to "true" once the action vendors it.
           include-macos-x86_64: "false"
           include-ios-x86_64: "false"
       - uses: actions/upload-artifact@v7
@@ -2455,7 +2544,7 @@ jobs:
         with:
           resources-dir: packages/java/src/main/resources/natives
           required-classifiers: >-
-            linux-x86_64 linux-aarch64 macos-arm64 windows-x86_64
+            linux-x86_64 linux-aarch64 macos-arm64 macos-x86_64 windows-x86_64
             linux-musl-x86_64 linux-musl-aarch64
           lib-name: xberg_ffi
 
@@ -2633,7 +2722,7 @@ jobs:
           # elixir-natives builds NIF API 2.16 AND 2.17; include both so the
           # checksum file covers every uploaded artifact.
           nif-versions: "2.16,2.17"
-          targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-pc-windows-msvc
+          targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu,x86_64-unknown-linux-musl,aarch64-unknown-linux-musl,aarch64-apple-darwin,x86_64-apple-darwin,x86_64-pc-windows-msvc
           output-path: packages/elixir/checksum-Elixir.Xberg.Native.exs
 
       - name: Build Elixir Hex tarball with dependency rewrite
@@ -2703,6 +2792,12 @@ jobs:
           name: dart-server-macos-arm64
           path: dart-server-artifacts/macos-arm64
 
+      - name: Download server natives (macos-x86_64)
+        uses: actions/download-artifact@v8
+        with:
+          name: dart-server-macos-x86_64
+          path: dart-server-artifacts/macos-x86_64
+
       - name: Download server natives (windows-x86_64)
         uses: actions/download-artifact@v8
         with:
@@ -2726,7 +2821,7 @@ jobs:
             [[ -d "$xcf" ]] && cp -r "$xcf" packages/dart/ios/Frameworks/
           done
           # Server blobs
-          for entry in "linux-x86_64:libxberg_dart.so" "linux-aarch64:libxberg_dart.so" "macos-arm64:libxberg_dart.dylib" "windows-x86_64:xberg_dart.dll"; do
+          for entry in "linux-x86_64:libxberg_dart.so" "linux-aarch64:libxberg_dart.so" "macos-arm64:libxberg_dart.dylib" "macos-x86_64:libxberg_dart.dylib" "windows-x86_64:xberg_dart.dll"; do
             blob="${entry%%:*}"
             lib="${entry##*:}"
             dest="packages/dart/blobs/${blob}"
@@ -2816,6 +2911,7 @@ jobs:
             ["linux-x86_64"]="linux-x64"
             ["linux-aarch64"]="linux-arm64"
             ["macos-arm64"]="osx-arm64"
+            ["macos-x86_64"]="osx-x64"
             ["windows-x86_64"]="win-x64"
           )
           out="ffi-artifacts"
@@ -2945,9 +3041,11 @@ jobs:
       matrix:
         include:
           - { os: macos-latest, bottle_tag: arm64_sonoma, install_brew: false }
-          # Intel macOS (sequoia, macos-15-intel) bottle dropped: ort-sys 2.0.0-rc.12 has no
-          # prebuilt for x86_64-apple-darwin. Re-add once upstream ships it or we switch to
-          # a no-ort feature set for Intel Macs.
+          # Intel macOS (sequoia): the tap formula builds x86_64 with ort-dynamic
+          # and depends on the `onnxruntime` formula for the runtime dylib (no
+          # static x86_64-apple-darwin prebuilt exists). Requires the paired tap
+          # change xberg-io/homebrew-tap#6 to be merged before this bottle builds.
+          - { os: macos-15-intel, bottle_tag: sequoia, install_brew: false }
           - { os: ubuntu-latest, bottle_tag: x86_64_linux, install_brew: true }
           - { os: ubuntu-24.04-arm, bottle_tag: arm64_linux, install_brew: true }
     steps:

--- a/alef.toml
+++ b/alef.toml
@@ -438,6 +438,15 @@ cfg = 'target_os = "windows"'
 features = ["windows-target"]
 default_features = false
 
+# Intel macOS: ort ships no static x86_64-apple-darwin prebuilt (dropped rc.11;
+# Microsoft dropped onnxruntime-osx-x86_64 after 1.23), so this arch loads ONNX
+# Runtime dynamically via `macos-intel-target` (full + ort-dynamic). arm64 macOS
+# keeps the default ort-bundled path. The wheel must vendor libonnxruntime.dylib.
+[[crates.python.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
+default_features = false
+
 [crates.node]
 package_name = "@xberg-io/xberg"
 exclude_types = [
@@ -473,6 +482,12 @@ cfg = 'target_os = "windows"'
 features = ["windows-target"]
 default_features = false
 
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.node.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
+default_features = false
+
 [crates.ruby]
 gem_name = "xberg"
 exclude_functions = [
@@ -499,6 +514,12 @@ output = "packages/ruby/sig/"
 [[crates.ruby.target_dep_overrides]]
 cfg = 'target_os = "windows"'
 features = ["windows-target"]
+default_features = false
+
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.ruby.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
 default_features = false
 
 [crates.php]
@@ -547,8 +568,24 @@ cfg = 'target_os = "windows"'
 features = ["windows-target"]
 default_features = false
 
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.php.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
+default_features = false
+
 [crates.elixir]
 app_name = "xberg"
+# RustlerPrecompiled targets emitted into lib/xberg/native.ex. Overrides alef's
+# default (which omits x86_64-apple-darwin) so the Intel-macOS NIF built by the
+# elixir-natives CI matrix is downloadable by consumers.
+nif_targets = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-gnu",
+    "x86_64-pc-windows-gnu",
+]
 exclude_functions = [
     "calculate_quality_score",
     "count_tokens",
@@ -574,6 +611,12 @@ exclude_types = [
 [[crates.elixir.target_dep_overrides]]
 cfg = 'target_os = "windows"'
 features = ["windows-target"]
+default_features = false
+
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.elixir.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
 default_features = false
 
 [crates.wasm]
@@ -795,6 +838,12 @@ cfg = 'target_os = "windows"'
 features = ["windows-target"]
 default_features = false
 
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.ffi.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
+default_features = false
+
 [crates.go]
 module = "github.com/xberg-io/xberg"
 package_name = "xberg"
@@ -948,6 +997,12 @@ cfg = 'target_os = "windows"'
 features = ["windows-target"]
 default_features = false
 
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.java.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
+default_features = false
+
 [crates.dart]
 pubspec_name = "xberg"
 lib_name = "xberg"
@@ -1050,6 +1105,12 @@ cfg = 'target_os = "windows"'
 features = ["windows-target"]
 default_features = false
 
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.dart.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
+default_features = false
+
 [crates.kotlin_android]
 # Self-contained Android library project at packages/kotlin-android/. Server-
 # side Kotlin/JVM consumers use the Java binding directly (Kotlin interops
@@ -1132,6 +1193,12 @@ default_features = false
 [[crates.jni.target_dep_overrides]]
 cfg = 'target_os = "windows"'
 features = ["windows-target"]
+default_features = false
+
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.jni.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
 default_features = false
 
 [crates.swift]
@@ -1272,6 +1339,12 @@ default_features = false
 [[crates.swift.target_dep_overrides]]
 cfg = 'target_os = "windows"'
 features = ["windows-target"]
+default_features = false
+
+# Intel macOS: dynamic ONNX Runtime (see the python override above).
+[[crates.swift.target_dep_overrides]]
+cfg = 'all(target_os = "macos", target_arch = "x86_64")'
+features = ["macos-intel-target"]
 default_features = false
 
 [crates.csharp]

--- a/cli-proxy/pypi/hatch_build.py
+++ b/cli-proxy/pypi/hatch_build.py
@@ -106,7 +106,15 @@ class CustomBuildHook(BuildHookInterface):
 
         # force_include maps absolute source paths -> in-wheel relative paths.
         relative = f"xberg_cli/bin/{target}/{binary.name}"
-        build_data.setdefault("force_include", {})[str(binary)] = relative
+        force_include = build_data.setdefault("force_include", {})
+        force_include[str(binary)] = relative
+
+        # Bundle runtime dylibs staged next to the binary. The native Intel-macOS
+        # build loads ONNX Runtime dynamically and ships libonnxruntime.dylib (plus
+        # its vendored deps) alongside the executable; ort resolves them relative to
+        # the binary, so they must sit in the same in-wheel directory.
+        for lib in sorted(binary.parent.glob("*.dylib")):
+            force_include[str(lib)] = f"xberg_cli/bin/{target}/{lib.name}"
 
         # Make it a platform wheel (not pure-python, not py3-none-any).
         build_data["pure_python"] = False

--- a/crates/xberg-cli/Cargo.toml
+++ b/crates/xberg-cli/Cargo.toml
@@ -32,6 +32,21 @@ default = [
     "tree-sitter",
 ]
 ort-bundled = ["xberg/ort-bundled"]
+# Load ONNX Runtime at runtime (dlopen) instead of static-linking a prebuilt.
+# The x86_64-apple-darwin CLI is built with the normal default features PLUS
+# this, so it keeps full feature parity with the aarch64 CLI: ort-sys
+# `disable-linking` (pulled by load-dynamic) short-circuits its build script
+# before the (nonexistent) x86_64-mac prebuilt is ever resolved. ort finds
+# libonnxruntime.dylib relative to the executable, so the release tarball just
+# ships the dylib next to the `xberg` binary — no ORT_DYLIB_PATH needed.
+ort-dynamic = ["xberg/ort-dynamic"]
+
+# Native Intel macOS (x86_64-apple-darwin) platform aggregate. Passthrough to
+# the xberg `macos-intel-target` set (full feature parity, ort loaded
+# dynamically). Used by the bindings via alef target overrides; the CLI release
+# build instead keeps its default features and adds `ort-dynamic` for exact
+# parity with the aarch64 CLI.
+macos-intel = ["xberg/macos-intel-target"]
 
 ocr = ["xberg/ocr"]
 

--- a/crates/xberg/Cargo.toml
+++ b/crates/xberg/Cargo.toml
@@ -450,6 +450,20 @@ windows-target = [
     "structured",
     "quality",
 ]
+# macos-intel-target: native Intel macOS (x86_64-apple-darwin). FULL feature
+# parity with every other platform — including all ONNX Runtime ML (paddle-ocr,
+# layout-detection, embeddings, reranker, transcription, ner-onnx, auto-rotate).
+#
+# ort dropped its prebuilt x86_64-apple-darwin *static* binaries in v2.0.0-rc.11
+# and Microsoft stopped shipping onnxruntime-osx-x86_64 after 1.23, so the
+# `download-binaries` (static) strategy has no artifact for this target. Instead
+# we select `ort-dynamic` (ort/load-dynamic): ONNX Runtime is loaded at runtime
+# from a bundled libonnxruntime.dylib via ORT_DYLIB_PATH, so no build-time
+# prebuilt is needed. ort-sys `disable-linking` (pulled by load-dynamic) short-
+# circuits its build script before any download resolution, so pairing it with
+# `full` (whose ML features still name `ort-bundled`) is safe: dynamic wins
+# workspace-wide. Same combo CI already exercises in ci-gpu.yaml.
+macos-intel-target = ["full", "ort-dynamic"]
 # Mobile deployment preset — formats + analysis + Tesseract OCR + code intelligence + API types.
 # Excludes ORT-dependent features (paddle-ocr, layout-detection, embeddings, reranker,
 # auto-rotate, transcription)

--- a/scripts/ci/actions/setup-onnx-runtime/macos.sh
+++ b/scripts/ci/actions/setup-onnx-runtime/macos.sh
@@ -27,17 +27,28 @@ x64) ort_arch="x86_64" ;;
 esac
 echo "Using macOS ONNX Runtime arch: $ort_arch"
 
-if [ ! -d "$extract_dir/onnxruntime-osx-${ort_arch}-${ort_version}" ]; then
-  echo "Cache miss: Downloading ONNX Runtime ${ort_version} for macOS ${ort_arch}"
-  archive="onnxruntime-osx-${ort_arch}-${ort_version}.tgz"
-  curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o "$RUNNER_TEMP/$archive" "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/$archive"
-  mkdir -p "$extract_dir"
-  tar -xzf "$RUNNER_TEMP/$archive" -C "$extract_dir"
+ort_root="$extract_dir/onnxruntime-osx-${ort_arch}-${ort_version}"
+
+if [ ! -d "$ort_root" ]; then
+  if [ "$ort_arch" = "x86_64" ]; then
+    # Microsoft dropped onnxruntime-osx-x86_64 after 1.23, below the 1.24+ ort
+    # needs; use Homebrew's x86_64 build instead of a download that would 404.
+    echo "Installing x86_64 macOS ONNX Runtime via Homebrew"
+    export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+    brew install --bottle-tag=sonoma onnxruntime || brew install onnxruntime
+    mkdir -p "$ort_root/lib"
+    cp -f "$(brew --prefix onnxruntime)/lib"/libonnxruntime*.dylib "$ort_root/lib/"
+  else
+    echo "Cache miss: Downloading ONNX Runtime ${ort_version} for macOS ${ort_arch}"
+    archive="onnxruntime-osx-${ort_arch}-${ort_version}.tgz"
+    mkdir -p "$extract_dir"
+    curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o "$RUNNER_TEMP/$archive" \
+      "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/$archive"
+    tar -xzf "$RUNNER_TEMP/$archive" -C "$extract_dir"
+  fi
 else
   echo "Cache hit: Using cached ONNX Runtime ${ort_version}"
 fi
-
-ort_root="$extract_dir/onnxruntime-osx-${ort_arch}-${ort_version}"
 
 if [ ! -d "$ort_root/lib" ]; then
   echo "ERROR: ONNX Runtime lib directory missing at $ort_root/lib" >&2

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,7 +56,7 @@ detect_target() {
   case "${os}-${arch}" in
   linux-x86_64) echo "x86_64-unknown-linux-musl" ;;
   linux-aarch64) echo "aarch64-unknown-linux-musl" ;;
-  darwin-x86_64) echo "aarch64-apple-darwin" ;; # Rosetta compatible
+  darwin-x86_64) echo "x86_64-apple-darwin" ;; # native Intel build
   darwin-aarch64) echo "aarch64-apple-darwin" ;;
   *) error "unsupported platform: ${os}-${arch}" ;;
   esac
@@ -159,6 +159,16 @@ install() {
     cp "${stage_dir}/lib/"* "${install_dir}/lib/"
     info "Installed runtime libraries to ${install_dir}/lib/"
   fi
+
+  # Install runtime dylibs bundled next to the binary. The native Intel-macOS
+  # build loads ONNX Runtime dynamically and ships libonnxruntime.dylib (and its
+  # vendored deps) alongside the executable; ort resolves the dylib relative to
+  # the binary, so they must land in the same directory as the installed binary.
+  for dylib in "${stage_dir}"/*.dylib; do
+    [ -f "$dylib" ] || continue
+    cp "$dylib" "${install_dir}/"
+    info "Installed runtime library $(basename "$dylib") to ${install_dir}/"
+  done
 
   info "Installed ${BINARY_NAME} to ${install_dir}/${BINARY_NAME}"
 


### PR DESCRIPTION
## Problem

Intel Macs never got a native build — `install.sh` served them the Apple Silicon binary under Rosetta and the release matrix built nothing for `x86_64-apple-darwin`. The blocker is ONNX Runtime: `ort` dropped its prebuilt `x86_64-apple-darwin` binaries in v2.0.0-rc.11 and Microsoft stopped shipping `onnxruntime-osx-x86_64` after 1.23, so there is no static ONNX Runtime for the 1.24+ that `ort` rc.12 requires. Any build carrying the default feature set (embeddings, paddle-ocr, layout-detection, reranking, …) fails to link on that target.

## Solution

Route this one target through `ort`'s load-dynamic strategy instead of static linking. ONNX Runtime is loaded at runtime from a `libonnxruntime.dylib` vendored next to the binary, and `ort-sys`'s `disable-linking` short-circuits its build script before any prebuilt is resolved, so the build succeeds with no static artifact. Apple Silicon macOS is untouched and keeps the bundled/static path.

This PR contains **source-of-truth changes only**:

- **CLI** (complete here): `macos-15-intel` build with the default features plus `ort-dynamic`, a bundled `libonnxruntime.dylib`, and `install.sh` serving the native binary. The CLI selects the strategy via an explicit `--features` flag, so it needs no generated code.
- **`alef.toml`**: `x86_64-apple-darwin` target overrides for the bindings and the Elixir `nif_targets` — this is the source that drives binding generation.
- **`publish.yaml`** matrix rows + downstream label/rid/blob maps, and the cli-proxy dylib bundling.
- **`scripts/ci/actions/setup-onnx-runtime/macos.sh`**: the repo-local copy of the shared action script (used by the node/csharp/dart publish jobs) gets the same x86_64 Homebrew fallback as xberg-io/actions#24.

## 🎉 It works — download the verified self-contained Intel build

The exact packaging this PR adds to `publish.yaml` was executed end to end on a real `macos-15-intel` runner, and the result is downloadable:

**[⬇️ `xberg-cli-x86_64-apple-darwin.tar.gz` (35 MB)](https://github.com/tobocop2/kreuzberg/releases/download/verify-intel-mac-evidence/xberg-cli-x86_64-apple-darwin.tar.gz)** — from the fork prerelease [`verify-intel-mac-evidence`](https://github.com/tobocop2/kreuzberg/releases/tag/verify-intel-mac-evidence), produced by [run 28633177260](https://github.com/tobocop2/kreuzberg/actions/runs/28633177260).

That run used the verbatim `publish.yaml` Intel build + packaging steps and asserted, in order:

- native x86_64 Mach-O CLI (`--features ort-dynamic,mcp,mcp-http,api`) with **no static onnxruntime linkage**;
- `libonnxruntime.dylib`'s **full dependency closure vendored** next to the binary (abseil, protobuf, onnx, re2 — an 87-file bundle), every install name rewritten to `@loader_path`, and exactly one onnxruntime payload (no versioned duplicate);
- the run then removed the Homebrew onnxruntime, onnx, protobuf, abseil, and re2 packages **from its own disposable CI runner** — simulating an end-user Mac that has no Homebrew — and `xberg embed --provider local` still ran real ONNX inference from the extracted tarball.

An Apple Silicon Mac runs the same tarball under Rosetta 2 as-is: `./xberg embed --text "hello" --preset fast --provider local`.

## ⚠️ Requires binding generation (`alef generate`)

This PR **does not hand-edit any alef-generated file**. The binding manifests must be regenerated from the `alef.toml` changes:

- `alef generate` will produce the `x86_64-apple-darwin` target override in `crates/xberg-ffi`, `crates/xberg-jni`, `packages/dart/rust`, `packages/swift/rust` (`Cargo.toml`) and add `x86_64-apple-darwin` to `packages/elixir/lib/xberg/native.ex`. That covers the FFI-family bindings (C, C#, Go, Java/Kotlin), Dart, Swift, and the Elixir precompiled targets.
- **Generator gap:** alef's pyo3/napi/magnus/php/rustler scaffolds don't currently support `target_dep_overrides`, so `alef generate` will **not** gate the Python/Node/PHP/Ruby/Elixir crate manifests. Their `alef.toml` overrides are inert until alef gains that support, and their Intel matrix rows are pending that enhancement. (I'm happy to make that alef change separately.)

## Verification

The CLI channel — the part complete in this PR — was built and verified end to end on my fork (`tobocop2/kreuzberg`) on real runners:

| Check | Runner | Proves | Result |
|---|---|---|---|
| Intel CLI — build + ONNX dynamic-load smoke test | `macos-15-intel` | `ort-dynamic` compiles for `x86_64-apple-darwin`; native x86_64 Mach-O with no static onnxruntime linkage; `xberg embed --provider local` runs real ONNX inference via the bundled dylib | [✅ run](https://github.com/tobocop2/kreuzberg/actions/runs/28620112178/job/84873458644) |
| arm64 CLI — regression build | `macos-latest` | the existing Apple-Silicon CLI still builds and runs unchanged (static ONNX) | [✅ run](https://github.com/tobocop2/kreuzberg/actions/runs/28620112178/job/84873458670) |
| Self-contained bundle — verbatim `publish.yaml` packaging + Homebrew-less inference | `macos-15-intel` | the vendoring loop closes the dylib dependency graph; the packaged tarball runs real ONNX inference with the Homebrew ONNX closure uninstalled | [✅ run](https://github.com/tobocop2/kreuzberg/actions/runs/28633177260) · [📦 tarball](https://github.com/tobocop2/kreuzberg/releases/download/verify-intel-mac-evidence/xberg-cli-x86_64-apple-darwin.tar.gz) |

### Zero macOS regression

The diff is seven source files; `Cargo.lock` is unchanged and no binding manifest is touched, so cargo resolves an identical build for every existing target. The two new crate features (`macos-intel-target`, `ort-dynamic`) are opt-in and off by default. The routing cfg on Intel is `all(target_os = "macos", target_arch = "x86_64")`, which is false for arm64 macOS. (Earlier I diffed `cargo tree -e features` between this branch and `main` across the changed crates × every existing target and found 0 differences; with the binding manifests now reverted, that surface is smaller still.)

The Homebrew Intel bottle pairs with xberg-io/homebrew-tap#6 (formula builds x86_64 with `ort-dynamic` + `depends_on onnxruntime`); the `setup-onnx-runtime` piece is xberg-io/actions#24.

