### PR TITLE
feat(chunking): let callers size chunks with their own tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
 
 ## [Unreleased]
 
+### Added
+
+- **Bring your own tokenizer for token-budgeted chunking.** Register a `TokenizerBackend`
+  plugin (`register_tokenizer_backend`) — from Rust or any language binding — and reference
+  it by name from `ChunkSizing::Tokenizer { model }`. The registry is checked before the
+  HuggingFace path, so chunks are sized with the exact tokenizer the consumer's embedder
+  uses (llama.cpp/GGUF vocabularies, SentencePiece models, custom vocabs). Existing
+  HuggingFace-id configs behave unchanged.
+
 ### Changed
 
 - **`OcrExtractionResult` now derives `Default`.** Downstream bindings and callers can

--- a/alef.toml
+++ b/alef.toml
@@ -401,6 +401,7 @@ sources = [
     "crates/xberg/src/plugins/traits.rs",
     "crates/xberg/src/plugins/embedding.rs",
     "crates/xberg/src/plugins/reranker.rs",
+    "crates/xberg/src/plugins/tokenizer.rs",
     "crates/xberg/src/plugins/registry/mod.rs",
     "crates/xberg/src/plugins/registry/reranker.rs",
     "crates/xberg/src/core/config/reranker.rs",
@@ -2412,6 +2413,22 @@ returns_result = true
 function = "listEmbeddingBackends"
 module = "xberg"
 
+[crates.e2e.calls.list_tokenizer_backends]
+result_is_simple = true
+function = "list_tokenizer_backends"
+module = "xberg"
+async = false
+args = []
+
+[crates.e2e.calls.list_tokenizer_backends.overrides.go]
+result_is_simple = true
+returns_result = true
+
+[crates.e2e.calls.list_tokenizer_backends.overrides.dart]
+function = "listTokenizerBackends"
+module = "xberg"
+
+
 [crates.e2e.calls.list_reranker_backends]
 result_is_simple = true
 function = "list_reranker_backends"
@@ -3457,6 +3474,211 @@ class = "RerankerBackendBridge"
 
 # ── rerank call ───────────────────────────────────────────────────────────────
 
+
+# ── Tokenizer backend lifecycle calls ────────────────────────────────────────────────────────────────
+
+[crates.e2e.calls.register_tokenizer_backend]
+# Trait-bridge function — excluded from gen_function surface; bridges emit it directly.
+result_is_simple = true
+function = ""
+module = ""
+async = false
+returns_result = false
+returns_void = true
+args = []
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.python]
+function = "register_tokenizer_backend"
+module = "xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.rust]
+function = "register_tokenizer_backend"
+module = "xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.node]
+function = "registerTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.go]
+function = "RegisterTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.ruby]
+function = "register_tokenizer_backend"
+module = "Xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.php]
+function = "registerTokenizerBackend"
+module = "Xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.java]
+function = "registerTokenizerBackend"
+module = "io.xberg.Xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.csharp]
+function = "RegisterTokenizerBackend"
+module = "Xberg"
+
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.swift]
+function = "registerTokenizerBackend"
+module = "Xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.dart]
+function = "registerTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.wasm]
+function = "registerTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.elixir]
+function = "register_tokenizer_backend"
+module = "Xberg"
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.zig]
+function = "register_tokenizer_backend"
+module = "xberg"
+returns_result = false
+
+[crates.e2e.calls.register_tokenizer_backend.overrides.kotlin_android]
+function = "register"
+class = "TokenizerBackendBridge"
+
+[crates.e2e.calls.unregister_tokenizer_backend]
+# Trait-bridge function — excluded from gen_function surface; bridges emit it directly.
+result_is_simple = true
+function = ""
+module = ""
+async = false
+returns_result = false
+returns_void = true
+args = [{ name = "name", field = "input.name", type = "string" }]
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.python]
+function = "unregister_tokenizer_backend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.rust]
+function = "unregister_tokenizer_backend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.node]
+function = "unregisterTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.go]
+function = "UnregisterTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.ruby]
+function = "unregister_tokenizer_backend"
+module = "Xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.php]
+function = "unregisterTokenizerBackend"
+module = "Xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.java]
+function = "unregisterTokenizerBackend"
+module = "io.xberg.Xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.csharp]
+function = "UnregisterTokenizerBackend"
+module = "Xberg"
+
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.swift]
+function = "unregisterTokenizerBackend"
+module = "Xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.dart]
+function = "unregisterTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.wasm]
+function = "unregisterTokenizerBackend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.elixir]
+function = "unregister_tokenizer_backend"
+module = "Xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.zig]
+function = "unregister_tokenizer_backend"
+module = "xberg"
+
+[crates.e2e.calls.unregister_tokenizer_backend.overrides.kotlin_android]
+function = "unregister"
+class = "TokenizerBackendBridge"
+
+[crates.e2e.calls.clear_tokenizer_backends]
+# Trait-bridge function — excluded from gen_function surface; bridges emit it directly.
+result_is_simple = true
+function = ""
+module = ""
+async = false
+returns_result = false
+returns_void = true
+args = []
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.python]
+function = "clear_tokenizer_backends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.rust]
+function = "clear_tokenizer_backends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.node]
+function = "clearTokenizerBackends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.go]
+function = "ClearTokenizerBackends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.ruby]
+function = "clear_tokenizer_backends"
+module = "Xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.php]
+function = "clearTokenizerBackends"
+module = "Xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.java]
+function = "clearTokenizerBackends"
+module = "io.xberg.Xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.csharp]
+function = "ClearTokenizerBackends"
+module = "Xberg"
+
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.swift]
+function = "clearTokenizerBackends"
+module = "Xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.dart]
+function = "clearTokenizerBackends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.wasm]
+function = "clearTokenizerBackends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.elixir]
+function = "clear_tokenizer_backends"
+module = "Xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.zig]
+function = "clear_tokenizer_backends"
+module = "xberg"
+
+[crates.e2e.calls.clear_tokenizer_backends.overrides.kotlin_android]
+function = "clearAll"
+class = "TokenizerBackendBridge"
+
 [crates.e2e.calls.register_renderer]
 # Trait-bridge function — excluded from gen_function surface; bridges emit it directly.
 result_is_simple = true
@@ -4046,3 +4268,11 @@ registry_getter = "xberg::plugins::registry::get_reranker_backend_registry"
 register_fn = "register_reranker_backend"
 unregister_fn = "unregister_reranker_backend"
 clear_fn = "clear_reranker_backends"
+
+[[crates.trait_bridges]]
+trait_name = "TokenizerBackend"
+super_trait = "xberg::plugins::Plugin"
+registry_getter = "xberg::plugins::registry::get_tokenizer_backend_registry"
+register_fn = "register_tokenizer_backend"
+unregister_fn = "unregister_tokenizer_backend"
+clear_fn = "clear_tokenizer_backends"

--- a/crates/xberg/src/chunking/core.rs
+++ b/crates/xberg/src/chunking/core.rs
@@ -93,13 +93,41 @@ pub(crate) fn chunk_text_with_heading_source(
     let text_chunks: Vec<&str> = match &config.sizing {
         #[cfg(feature = "chunking-tokenizers")]
         crate::core::config::ChunkSizing::Tokenizer { model, .. } => {
-            let tokenizer = super::tokenizer_cache::get_or_init_tokenizer(model)?;
-            let chunk_config = ChunkConfig::new(ChunkCapacity::new(config.max_characters))
-                .with_sizer((*tokenizer).clone())
-                .with_overlap(config.overlap)
-                .map(|c| c.with_trim(config.trim))
-                .map_err(|e| crate::XbergError::validation(format!("Invalid chunking configuration: {}", e)))?;
-            split_with_config(text, &config.chunker_type, chunk_config)
+            // A tokenizer backend registered under this name takes precedence
+            // over a HuggingFace model id, so callers can size chunks with the
+            // exact tokenizer their embedder uses.
+            let registered = crate::plugins::registry::get_tokenizer_backend_registry()
+                .read()
+                .lookup(model);
+            if let Some(backend) = registered {
+                let chunk_config = ChunkConfig::new(ChunkCapacity::new(config.max_characters))
+                    .with_sizer(TokenizerBackendSizer(backend))
+                    .with_overlap(config.overlap)
+                    .map(|c| c.with_trim(config.trim))
+                    .map_err(|e| crate::XbergError::validation(format!("Invalid chunking configuration: {}", e)))?;
+                split_with_config(text, &config.chunker_type, chunk_config)
+            } else {
+                // `load_tokenizer` already names the tokenizer and the load failure;
+                // append the registration hint to validation failures and pass any
+                // other error (e.g. a poisoned cache lock) through untouched.
+                let tokenizer = super::tokenizer_cache::get_or_init_tokenizer(model).map_err(|e| match e {
+                    crate::XbergError::Validation { message, source } => crate::XbergError::Validation {
+                        message: format!(
+                            "{message}. No tokenizer backend is registered under '{model}' either; \
+                             use a HuggingFace model id, or register your own tokenizer with \
+                             register_tokenizer_backend."
+                        ),
+                        source,
+                    },
+                    other => other,
+                })?;
+                let chunk_config = ChunkConfig::new(ChunkCapacity::new(config.max_characters))
+                    .with_sizer((*tokenizer).clone())
+                    .with_overlap(config.overlap)
+                    .map(|c| c.with_trim(config.trim))
+                    .map_err(|e| crate::XbergError::validation(format!("Invalid chunking configuration: {}", e)))?;
+                split_with_config(text, &config.chunker_type, chunk_config)
+            }
         }
         // Characters sizing (default) — also matches when no token features are enabled
         _ => {
@@ -186,6 +214,36 @@ fn strip_leading_heading<'a>(text: &'a str, level: u8, title: &str) -> &'a str {
     let rest = &after_prefix[title.len()..];
     let line_end = rest.find('\n').unwrap_or(rest.len());
     rest[line_end..].trim_start_matches('\n')
+}
+
+/// Adapts a registered [`crate::plugins::TokenizerBackend`] to the splitter's
+/// [`ChunkSizer`] interface: chunk size is the backend's token count.
+///
+/// A backend reporting zero tokens for non-empty text is not trusted: a zero
+/// count would make every span appear to fit any budget and silently produce
+/// oversized chunks. Host-language bridges surface backend exceptions as a
+/// zero count, so this is also the failure mode of a backend that starts
+/// erroring mid-run. The sizer falls back to the character count — tokens
+/// don't exceed characters for practical tokenizers, so the budget degrades
+/// to the conservative `max_characters` semantics instead of an unbounded
+/// chunk — and logs the substitution.
+#[cfg(feature = "chunking-tokenizers")]
+struct TokenizerBackendSizer(std::sync::Arc<dyn crate::plugins::TokenizerBackend>);
+
+#[cfg(feature = "chunking-tokenizers")]
+impl ChunkSizer for TokenizerBackendSizer {
+    fn size(&self, chunk: &str) -> usize {
+        let count = self.0.count_tokens(chunk);
+        if count == 0 && !chunk.is_empty() {
+            tracing::warn!(
+                backend = self.0.name(),
+                chunk_len = chunk.len(),
+                "Tokenizer backend reported zero tokens for non-empty text; using character count instead"
+            );
+            return chunk.chars().count();
+        }
+        count
+    }
 }
 
 /// Split text using the appropriate splitter type with a generic sizer.

--- a/crates/xberg/src/core/config/processing.rs
+++ b/crates/xberg/src/core/config/processing.rs
@@ -63,19 +63,25 @@ pub enum ChunkerType {
 /// Defaults to `Characters` (Unicode character count). When using token-based sizing,
 /// chunks are sized by token count according to the specified tokenizer.
 ///
-/// Token-based sizing uses HuggingFace tokenizers loaded at runtime. Any tokenizer
-/// available on HuggingFace Hub can be used, including OpenAI-compatible tokenizers
-/// (e.g., `Xenova/gpt-4o`, `Xenova/cl100k_base`).
+/// Token-based sizing uses HuggingFace tokenizers loaded at runtime, or a tokenizer
+/// backend you register yourself. Any tokenizer available on HuggingFace Hub can be
+/// used, including OpenAI-compatible tokenizers (e.g., `Xenova/gpt-4o`,
+/// `Xenova/cl100k_base`). To size chunks with your own tokenizer instead (llama.cpp/GGUF
+/// vocabularies, SentencePiece models, custom vocabs), register a `TokenizerBackend`
+/// with `register_tokenizer_backend` and set `model` to the registered name.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ChunkSizing {
     /// Size measured in Unicode characters (default).
     #[default]
     Characters,
-    /// Size measured in tokens from a HuggingFace tokenizer.
+    /// Size measured in tokens from a HuggingFace tokenizer or a registered
+    /// tokenizer backend.
     #[cfg(feature = "chunking-tokenizers")]
     Tokenizer {
-        /// HuggingFace model ID or path, e.g. "Xenova/gpt-4o", "bert-base-uncased".
+        /// Name of a tokenizer backend registered via `register_tokenizer_backend`,
+        /// or a HuggingFace model ID, e.g. "Xenova/gpt-4o", "bert-base-uncased".
+        /// A registered backend name takes precedence over a HuggingFace ID.
         model: String,
         /// Optional cache directory override for tokenizer files.
         /// Defaults to hf-hub's standard cache (`~/.cache/huggingface/`).

--- a/crates/xberg/src/lib.rs
+++ b/crates/xberg/src/lib.rs
@@ -456,12 +456,13 @@ pub use pdf::render::{pdf_page_count, render_pdf_page_to_png};
 #[cfg_attr(alef, alef(skip))]
 pub use plugins::{
     clear_document_extractors, clear_embedding_backends, clear_ocr_backends, clear_post_processors, clear_renderers,
-    clear_reranker_backends, clear_validators, list_document_extractors, list_embedding_backends, list_ocr_backends,
-    list_post_processors, list_renderers, list_reranker_backends, list_validators, register_document_extractor,
-    register_embedding_backend, register_ocr_backend, register_post_processor, register_renderer,
-    register_reranker_backend, register_validator, unregister_document_extractor, unregister_embedding_backend,
+    clear_reranker_backends, clear_tokenizer_backends, clear_validators, list_document_extractors,
+    list_embedding_backends, list_ocr_backends, list_post_processors, list_renderers, list_reranker_backends,
+    list_tokenizer_backends, list_validators, register_document_extractor, register_embedding_backend,
+    register_ocr_backend, register_post_processor, register_renderer, register_reranker_backend,
+    register_tokenizer_backend, register_validator, unregister_document_extractor, unregister_embedding_backend,
     unregister_ocr_backend, unregister_post_processor, unregister_renderer, unregister_reranker_backend,
-    unregister_validator,
+    unregister_tokenizer_backend, unregister_validator,
 };
 
 // ── Plugin Traits — public API (for plugin implementors) ─────────────────────
@@ -470,7 +471,7 @@ pub use plugins::{
 #[cfg_attr(alef, alef(skip))]
 pub use plugins::{
     DocumentExtractor, EmbeddingBackend, OcrBackend, OcrBackendType, PostProcessor, ProcessingStage, Renderer,
-    RerankerBackend, Validator,
+    RerankerBackend, TokenizerBackend, Validator,
 };
 
 // ── Embeddings — public API (4 functions + 1 type, feature-gated) ────────────

--- a/crates/xberg/src/plugins/mod.rs
+++ b/crates/xberg/src/plugins/mod.rs
@@ -171,6 +171,7 @@ pub mod registry;
 pub mod renderer;
 pub(crate) mod reranker;
 pub mod startup_validation;
+pub(crate) mod tokenizer;
 mod traits;
 pub mod validator;
 
@@ -194,6 +195,10 @@ pub use renderer::{Renderer, clear_renderers, list_renderers, register_renderer,
 pub use reranker::{
     RerankerBackend, clear_reranker_backends, list_reranker_backends, register_reranker_backend,
     unregister_reranker_backend,
+};
+pub use tokenizer::{
+    TokenizerBackend, clear_tokenizer_backends, list_tokenizer_backends, register_tokenizer_backend,
+    unregister_tokenizer_backend,
 };
 pub use traits::Plugin;
 pub use validator::{Validator, clear_validators, list_validators, register_validator, unregister_validator};
@@ -230,6 +235,13 @@ pub mod reranker_backend {
     pub use super::{
         RerankerBackend, clear_reranker_backends, list_reranker_backends, register_reranker_backend,
         unregister_reranker_backend,
+    };
+}
+/// Re-exports for the tokenizer backend plugin type, used by alef-generated bindings.
+pub mod tokenizer_backend {
+    pub use super::{
+        TokenizerBackend, clear_tokenizer_backends, list_tokenizer_backends, register_tokenizer_backend,
+        unregister_tokenizer_backend,
     };
 }
 /// Re-exports for the document extractor plugin type, used by alef-generated bindings.

--- a/crates/xberg/src/plugins/registry/mod.rs
+++ b/crates/xberg/src/plugins/registry/mod.rs
@@ -10,6 +10,7 @@ mod ocr;
 mod processor;
 mod renderer;
 mod reranker;
+mod tokenizer;
 mod validator;
 
 pub use embedding::EmbeddingBackendRegistry;
@@ -18,6 +19,7 @@ pub use ocr::OcrBackendRegistry;
 pub use processor::PostProcessorRegistry;
 pub use renderer::RendererRegistry;
 pub use reranker::RerankerBackendRegistry;
+pub use tokenizer::TokenizerBackendRegistry;
 pub use validator::ValidatorRegistry;
 
 use crate::{Result, XbergError};
@@ -68,6 +70,10 @@ pub static EMBEDDING_BACKEND_REGISTRY: LazyLock<Arc<RwLock<EmbeddingBackendRegis
 pub static RERANKER_BACKEND_REGISTRY: LazyLock<Arc<RwLock<RerankerBackendRegistry>>> =
     LazyLock::new(|| Arc::new(RwLock::new(RerankerBackendRegistry::new())));
 
+/// Global tokenizer backend registry singleton.
+pub static TOKENIZER_BACKEND_REGISTRY: LazyLock<Arc<RwLock<TokenizerBackendRegistry>>> =
+    LazyLock::new(|| Arc::new(RwLock::new(TokenizerBackendRegistry::new())));
+
 /// Global document extractor registry singleton.
 pub static DOCUMENT_EXTRACTOR_REGISTRY: LazyLock<Arc<RwLock<DocumentExtractorRegistry>>> =
     LazyLock::new(|| Arc::new(RwLock::new(DocumentExtractorRegistry::new())));
@@ -102,6 +108,12 @@ pub fn get_embedding_backend_registry() -> Arc<RwLock<EmbeddingBackendRegistry>>
 #[cfg_attr(alef, alef(skip))]
 pub fn get_reranker_backend_registry() -> Arc<RwLock<RerankerBackendRegistry>> {
     RERANKER_BACKEND_REGISTRY.clone()
+}
+
+/// Get the global tokenizer backend registry.
+#[cfg_attr(alef, alef(skip))]
+pub fn get_tokenizer_backend_registry() -> Arc<RwLock<TokenizerBackendRegistry>> {
+    TOKENIZER_BACKEND_REGISTRY.clone()
 }
 
 /// Get the global document extractor registry.

--- a/crates/xberg/src/plugins/registry/tokenizer.rs
+++ b/crates/xberg/src/plugins/registry/tokenizer.rs
@@ -1,0 +1,307 @@
+//! Tokenizer backend registry.
+//!
+//! In-process complement to the HuggingFace-loaded tokenizer path used by
+//! token-budgeted chunking. Callers — from Rust or a host-language bridge —
+//! register a [`TokenizerBackend`] once; `ChunkSizing::Tokenizer { model }`
+//! then resolves the name against this registry before falling back to the
+//! HuggingFace Hub, so chunks can be sized with the exact tokenizer the
+//! consumer's embedder uses.
+
+use crate::plugins::TokenizerBackend;
+use crate::{Result, XbergError};
+use ahash::AHashMap;
+use std::sync::Arc;
+
+/// Registry for tokenizer backend plugins.
+///
+/// Like [`super::EmbeddingBackendRegistry`], no default backends are registered —
+/// tokenizer backends are always supplied by the caller at runtime.
+///
+/// Unlike the embedding registry there is no cached shape metadata: a tokenizer
+/// backend is a pure `&str -> usize` counter, validated once at registration
+/// with a probe (see [`Self::register`]).
+#[cfg_attr(alef, alef(skip))]
+pub struct TokenizerBackendRegistry {
+    backends: AHashMap<String, Arc<dyn TokenizerBackend>>,
+}
+
+impl TokenizerBackendRegistry {
+    /// Create a new empty tokenizer backend registry.
+    pub fn new() -> Self {
+        Self {
+            backends: AHashMap::new(),
+        }
+    }
+
+    /// Register a tokenizer backend.
+    ///
+    /// Runs the backend's `initialize()` first (so lazy-loading implementations
+    /// can load their vocabulary), then probes `count_tokens("a")`: a backend
+    /// that reports zero tokens for non-empty text would defeat chunk sizing —
+    /// every span would appear to fit any budget — so it is rejected.
+    ///
+    /// # Errors
+    ///
+    /// - [`XbergError::Validation`] if the name is empty, contains whitespace,
+    ///   or the probe reports zero tokens for non-empty text.
+    /// - [`XbergError::Plugin`] if a backend with the same name is already registered.
+    /// - Any error from the backend's `initialize()` method.
+    #[tracing::instrument(skip(self, backend), fields(backend_name))]
+    pub fn register(&mut self, backend: Arc<dyn TokenizerBackend>) -> Result<()> {
+        let name = backend.name().to_string();
+        tracing::Span::current().record("backend_name", name.as_str());
+
+        super::validate_plugin_name(&name)?;
+
+        if self.backends.contains_key(&name) {
+            return Err(XbergError::Plugin {
+                message: format!("Tokenizer backend '{name}' is already registered"),
+                plugin_name: name,
+            });
+        }
+
+        // Run initialize() first so that backends which lazy-load their
+        // vocabulary can produce real counts from the probe below.
+        backend.initialize()?;
+
+        if backend.count_tokens("a") == 0 {
+            // initialize() already ran; give the backend a chance to release
+            // resources before we reject it.
+            let _ = backend.shutdown();
+            return Err(XbergError::Validation {
+                message: format!("Tokenizer backend '{name}' must report a non-zero token count for non-empty text"),
+                source: None,
+            });
+        }
+
+        tracing::info!(backend = %name, "Tokenizer backend registered");
+        self.backends.insert(name, backend);
+        Ok(())
+    }
+
+    /// Get a tokenizer backend by name, or `None` if not registered.
+    ///
+    /// This is the dispatch-path accessor: chunking probes the registry with
+    /// the configured tokenizer name and falls back to the HuggingFace path on
+    /// `None`, so a miss here is not an error.
+    pub fn lookup(&self, name: &str) -> Option<Arc<dyn TokenizerBackend>> {
+        self.backends.get(name).cloned()
+    }
+
+    /// Get a tokenizer backend by name.
+    ///
+    /// # Errors
+    ///
+    /// [`XbergError::Plugin`] if no backend with that name is registered.
+    #[tracing::instrument(skip(self), fields(registered_backends = ?self.backends.keys().collect::<Vec<_>>()))]
+    pub fn get(&self, name: &str) -> Result<Arc<dyn TokenizerBackend>> {
+        self.lookup(name).ok_or_else(|| {
+            let available: Vec<String> = self.backends.keys().cloned().collect();
+            XbergError::Plugin {
+                message: format!(
+                    "Tokenizer backend '{}' not registered. Available backends: {}",
+                    name,
+                    if available.is_empty() {
+                        "(none registered)".to_string()
+                    } else {
+                        available.join(", ")
+                    }
+                ),
+                plugin_name: name.to_string(),
+            }
+        })
+    }
+
+    /// List all registered backend names.
+    pub fn list(&self) -> Vec<String> {
+        self.backends.keys().cloned().collect()
+    }
+
+    /// Remove a backend from the registry, calling its `shutdown()` method.
+    pub fn remove(&mut self, name: &str) -> Result<()> {
+        if let Some(backend) = self.backends.remove(name) {
+            backend.shutdown()?;
+        }
+        Ok(())
+    }
+
+    /// Shutdown all backends and clear the registry.
+    pub fn shutdown_all(&mut self) -> Result<()> {
+        let names: Vec<_> = self.backends.keys().cloned().collect();
+        for name in names {
+            self.remove(&name)?;
+        }
+        Ok(())
+    }
+
+    /// Drain the registry. Alias for `shutdown_all` for parity with the other
+    /// plugin registries.
+    pub fn clear(&mut self) -> Result<()> {
+        self.shutdown_all()
+    }
+}
+
+impl Default for TokenizerBackendRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugins::Plugin;
+
+    struct MockTokenizer {
+        name: String,
+        tokens_per_call: usize,
+    }
+
+    impl Plugin for MockTokenizer {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn version(&self) -> String {
+            "1.0.0".to_string()
+        }
+        fn initialize(&self) -> Result<()> {
+            Ok(())
+        }
+        fn shutdown(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    impl TokenizerBackend for MockTokenizer {
+        fn count_tokens(&self, _text: &str) -> usize {
+            self.tokens_per_call
+        }
+    }
+
+    fn mock(name: &str) -> Arc<MockTokenizer> {
+        Arc::new(MockTokenizer {
+            name: name.to_string(),
+            tokens_per_call: 1,
+        })
+    }
+
+    #[test]
+    fn register_and_retrieve() {
+        let mut registry = TokenizerBackendRegistry::new();
+        registry.register(mock("mock")).unwrap();
+
+        let retrieved = registry.get("mock").unwrap();
+        assert_eq!(retrieved.name(), "mock");
+        assert_eq!(retrieved.count_tokens("anything"), 1);
+    }
+
+    #[test]
+    fn empty_registry_has_no_backends() {
+        let registry = TokenizerBackendRegistry::new();
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn lookup_missing_backend_returns_none() {
+        let registry = TokenizerBackendRegistry::new();
+        assert!(registry.lookup("never-registered").is_none());
+    }
+
+    #[test]
+    fn get_missing_backend_returns_plugin_error() {
+        let registry = TokenizerBackendRegistry::new();
+        let result = registry.get("never-registered");
+        assert!(matches!(result, Err(XbergError::Plugin { .. })));
+    }
+
+    #[test]
+    fn rejects_empty_name() {
+        let mut registry = TokenizerBackendRegistry::new();
+        assert!(matches!(
+            registry.register(mock("")),
+            Err(XbergError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_whitespace_in_name() {
+        let mut registry = TokenizerBackendRegistry::new();
+        assert!(matches!(
+            registry.register(mock("has spaces")),
+            Err(XbergError::Validation { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_zero_count_for_nonempty_text() {
+        let mut registry = TokenizerBackendRegistry::new();
+        let backend = Arc::new(MockTokenizer {
+            name: "zero-count".to_string(),
+            tokens_per_call: 0,
+        });
+        assert!(matches!(registry.register(backend), Err(XbergError::Validation { .. })));
+    }
+
+    #[test]
+    fn rejects_duplicate_name() {
+        let mut registry = TokenizerBackendRegistry::new();
+        registry.register(mock("dup")).unwrap();
+        let result = registry.register(mock("dup"));
+        assert!(matches!(result, Err(XbergError::Plugin { .. })));
+    }
+
+    #[test]
+    fn remove_backend_clears_entry() {
+        let mut registry = TokenizerBackendRegistry::new();
+        registry.register(mock("to-remove")).unwrap();
+        registry.remove("to-remove").unwrap();
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn remove_missing_backend_is_noop() {
+        let mut registry = TokenizerBackendRegistry::new();
+        assert!(registry.remove("never-registered").is_ok());
+    }
+
+    #[test]
+    fn shutdown_all_clears_all_backends() {
+        let mut registry = TokenizerBackendRegistry::new();
+        registry.register(mock("one")).unwrap();
+        registry.register(mock("two")).unwrap();
+
+        registry.shutdown_all().unwrap();
+        assert!(registry.list().is_empty());
+    }
+
+    #[test]
+    fn initialize_failure_propagates_and_backend_is_not_registered() {
+        struct FailingInit;
+        impl Plugin for FailingInit {
+            fn name(&self) -> &str {
+                "failing-init"
+            }
+            fn version(&self) -> String {
+                "1.0.0".to_string()
+            }
+            fn initialize(&self) -> Result<()> {
+                Err(XbergError::Plugin {
+                    message: "boom".to_string(),
+                    plugin_name: "failing-init".to_string(),
+                })
+            }
+            fn shutdown(&self) -> Result<()> {
+                Ok(())
+            }
+        }
+        impl TokenizerBackend for FailingInit {
+            fn count_tokens(&self, _text: &str) -> usize {
+                1
+            }
+        }
+
+        let mut registry = TokenizerBackendRegistry::new();
+        assert!(registry.register(Arc::new(FailingInit)).is_err());
+        assert!(registry.list().is_empty());
+    }
+}

--- a/crates/xberg/src/plugins/tokenizer.rs
+++ b/crates/xberg/src/plugins/tokenizer.rs
@@ -1,0 +1,231 @@
+//! Tokenizer backend plugin trait.
+//!
+//! Defines the trait for supplying a custom tokenizer to token-budgeted
+//! chunking — the in-process complement to the HuggingFace-loaded path behind
+//! `ChunkSizing::Tokenizer`. A [`TokenizerBackend`] is a caller-supplied object
+//! that counts tokens in a text span; xberg never owns the vocabulary.
+//!
+//! # Typical use
+//!
+//! Callers whose embedder tokenizes with something xberg can't load itself
+//! (a llama.cpp/GGUF vocabulary, a SentencePiece model, a tuned custom vocab)
+//! register the wrapper once and reference it by name in config:
+//!
+//! ```rust
+//! use xberg::plugins::{Plugin, TokenizerBackend, register_tokenizer_backend};
+//! use xberg::Result;
+//! use std::sync::Arc;
+//!
+//! struct MyTokenizer;
+//!
+//! impl Plugin for MyTokenizer {
+//!     fn name(&self) -> &str { "my-tokenizer" }
+//!     fn version(&self) -> String { "1.0.0".to_string() }
+//!     fn initialize(&self) -> Result<()> { Ok(()) }
+//!     fn shutdown(&self) -> Result<()> { Ok(()) }
+//! }
+//!
+//! impl TokenizerBackend for MyTokenizer {
+//!     fn count_tokens(&self, text: &str) -> usize {
+//!         // Delegate to your real tokenizer here.
+//!         text.split_whitespace().count()
+//!     }
+//! }
+//!
+//! register_tokenizer_backend(Arc::new(MyTokenizer))?;
+//! // ChunkSizing::Tokenizer { model: "my-tokenizer".into(), cache_dir: None }
+//! // now resolves to this backend, and `max_characters` becomes its token budget.
+//! # xberg::plugins::unregister_tokenizer_backend("my-tokenizer")?;
+//! # Ok::<(), xberg::XbergError>(())
+//! ```
+
+use crate::Result;
+use crate::plugins::Plugin;
+use std::sync::Arc;
+
+/// Trait for in-process tokenizer backend plugins.
+///
+/// Unlike [`crate::plugins::EmbeddingBackend`], this trait is **synchronous**:
+/// the chunk splitter calls [`Self::count_tokens`] inside its boundary search,
+/// many times per chunk, so counting must be a direct call with no async
+/// dispatch. Host-language bridges (PyO3, napi-rs, etc.) invoke their host
+/// callable synchronously on the calling thread; implementations should keep
+/// `count_tokens` cheap — it dominates chunking time when the backend is slow.
+///
+/// # Lifecycle
+///
+/// `initialize()` is called once during registration, before any
+/// `count_tokens` call; lazy-loading implementations should load their
+/// vocabulary there. After registration succeeds, `count_tokens` may be called
+/// from any thread, concurrently. `shutdown()` runs on unregistration and may
+/// overlap an in-flight `count_tokens` call from a chunking run that resolved
+/// the backend earlier — implementations must tolerate this, e.g. by keeping
+/// the resources `count_tokens` needs alive via `Arc`.
+///
+/// # Thread safety
+///
+/// Backends must be `Send + Sync + 'static` (inherited from [`Plugin`]). They
+/// are stored in `Arc<dyn TokenizerBackend>` and called concurrently from
+/// xberg's chunking pipeline. If the underlying tokenizer isn't thread-safe,
+/// the backend must serialize access internally.
+///
+/// # Contract
+///
+/// - `count_tokens` must return a non-zero count for non-empty text. The
+///   registry probes this once at registration and rejects backends that
+///   report zero — a zero count would make every span appear to fit any
+///   budget. At runtime, a zero count for non-empty text is not trusted:
+///   the chunker substitutes the character count and logs the substitution.
+///   (An implementation may still return 0 for the empty string.)
+/// - `count_tokens` must not panic; return a best-effort count for text the
+///   tokenizer can't fully process.
+/// - Counting should be deterministic for a given input — the splitter may
+///   evaluate overlapping spans of the same text repeatedly.
+pub trait TokenizerBackend: Plugin {
+    /// Count the tokens in `text` according to this backend's tokenizer.
+    fn count_tokens(&self, text: &str) -> usize;
+}
+
+/// Register a tokenizer backend with the global registry.
+///
+/// The backend is keyed by its `Plugin::name()`. Token-budgeted chunking
+/// resolves `ChunkSizing::Tokenizer { model }` against this registry first —
+/// a registered name takes precedence over a HuggingFace model id — and falls
+/// back to the HuggingFace path when the name is not registered.
+///
+/// # Errors
+///
+/// - [`crate::XbergError::Validation`] if the name is empty, contains
+///   whitespace, or the backend reports zero tokens for non-empty text.
+/// - [`crate::XbergError::Plugin`] if a backend with that name is already registered.
+/// - Any error from the backend's `initialize()` method.
+#[cfg_attr(alef, alef(skip))]
+pub fn register_tokenizer_backend(backend: Arc<dyn TokenizerBackend>) -> Result<()> {
+    use crate::plugins::registry::get_tokenizer_backend_registry;
+
+    let registry = get_tokenizer_backend_registry();
+    let mut registry = registry.write();
+    registry.register(backend)
+}
+
+/// Unregister a tokenizer backend by name, calling its `shutdown()` method.
+///
+/// No-op if the backend is not registered.
+///
+/// # Errors
+///
+/// - Any error returned by the backend's `shutdown()` method.
+#[cfg_attr(alef, alef(skip))]
+pub fn unregister_tokenizer_backend(name: &str) -> Result<()> {
+    use crate::plugins::registry::get_tokenizer_backend_registry;
+
+    let registry = get_tokenizer_backend_registry();
+    let mut registry = registry.write();
+    registry.remove(name)
+}
+
+/// Clear all tokenizer backends from the global registry.
+///
+/// Calls `shutdown()` on every registered backend, then empties the registry.
+///
+/// # Errors
+///
+/// - Any error returned by a backend's `shutdown()` method. The first error
+///   encountered stops processing of remaining backends.
+pub fn clear_tokenizer_backends() -> Result<()> {
+    use crate::plugins::registry::get_tokenizer_backend_registry;
+
+    let registry = get_tokenizer_backend_registry();
+    let mut registry = registry.write();
+    registry.shutdown_all()
+}
+
+/// List the names of all registered tokenizer backends.
+///
+/// Used by `xberg-cli`, the api/mcp endpoints, and generated language
+/// bindings.
+pub fn list_tokenizer_backends() -> Result<Vec<String>> {
+    use crate::plugins::registry::get_tokenizer_backend_registry;
+
+    let registry = get_tokenizer_backend_registry();
+    let registry = registry.read();
+    Ok(registry.list())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::XbergError;
+    use crate::plugins::Plugin;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    struct MockTokenizerBackend {
+        name: String,
+    }
+
+    impl Plugin for MockTokenizerBackend {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn version(&self) -> String {
+            "1.0.0".to_string()
+        }
+        fn initialize(&self) -> Result<()> {
+            Ok(())
+        }
+        fn shutdown(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    impl TokenizerBackend for MockTokenizerBackend {
+        fn count_tokens(&self, text: &str) -> usize {
+            text.split_whitespace().count().max(usize::from(!text.is_empty()))
+        }
+    }
+
+    /// Unique per-test name so parallel test runs don't collide in the shared
+    /// global `TOKENIZER_BACKEND_REGISTRY`.
+    fn unique_name(suffix: &str) -> String {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        format!("mock-tokenizer-{suffix}-{id}")
+    }
+
+    #[test]
+    fn register_list_unregister_roundtrip() {
+        let name = unique_name("roundtrip");
+        register_tokenizer_backend(Arc::new(MockTokenizerBackend { name: name.clone() })).unwrap();
+
+        assert!(list_tokenizer_backends().unwrap().contains(&name));
+
+        unregister_tokenizer_backend(&name).unwrap();
+        assert!(!list_tokenizer_backends().unwrap().contains(&name));
+    }
+
+    #[test]
+    fn empty_name_rejected_via_global_api() {
+        let result = register_tokenizer_backend(Arc::new(MockTokenizerBackend { name: String::new() }));
+        assert!(matches!(result, Err(XbergError::Validation { .. })));
+    }
+
+    #[test]
+    fn register_clear_roundtrip() {
+        let name = unique_name("clear");
+        register_tokenizer_backend(Arc::new(MockTokenizerBackend { name: name.clone() })).unwrap();
+
+        assert!(list_tokenizer_backends().unwrap().contains(&name));
+
+        clear_tokenizer_backends().unwrap();
+        assert!(!list_tokenizer_backends().unwrap().contains(&name));
+    }
+
+    #[test]
+    fn mock_backend_counts_words() {
+        let backend = MockTokenizerBackend {
+            name: "counter".to_string(),
+        };
+        assert_eq!(backend.count_tokens("one two three"), 3);
+        assert_eq!(backend.count_tokens(""), 0);
+    }
+}

--- a/crates/xberg/tests/chunking_tokenizer_plugin.rs
+++ b/crates/xberg/tests/chunking_tokenizer_plugin.rs
@@ -1,0 +1,262 @@
+//! Integration tests for consumer-supplied tokenizer backends in token-budgeted chunking.
+//!
+//! A registered [`TokenizerBackend`] is resolved by name from
+//! `ChunkSizing::Tokenizer { model }` before any HuggingFace lookup, so consumers
+//! can budget chunks with the exact tokenizer their embedder uses — offline.
+#![cfg(feature = "chunking-tokenizers")]
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use xberg::chunking::chunk_text;
+use xberg::plugins::{Plugin, TokenizerBackend, register_tokenizer_backend, unregister_tokenizer_backend};
+use xberg::{ChunkSizing, ChunkerType, ChunkingConfig, Result};
+
+/// Deterministic stand-in for a digit-dense tokenizer: every 2 characters cost
+/// one token (rounded up). Counts invocations so tests can prove the plugin —
+/// not a HuggingFace download — sized the chunks.
+struct HalfCharTokenizer {
+    name: String,
+    calls: AtomicUsize,
+}
+
+impl HalfCharTokenizer {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            calls: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl Plugin for HalfCharTokenizer {
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn version(&self) -> String {
+        "1.0.0".to_string()
+    }
+    fn initialize(&self) -> Result<()> {
+        Ok(())
+    }
+    fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl TokenizerBackend for HalfCharTokenizer {
+    fn count_tokens(&self, text: &str) -> usize {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        text.chars().count().div_ceil(2)
+    }
+}
+
+/// Unique per-test backend name so parallel tests don't collide in the global registry.
+fn unique_name(suffix: &str) -> String {
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    format!("test-tokenizer-{suffix}-{id}")
+}
+
+fn token_sized_config(backend_name: &str, max_tokens: usize) -> ChunkingConfig {
+    ChunkingConfig {
+        max_characters: max_tokens,
+        overlap: 0,
+        trim: true,
+        chunker_type: ChunkerType::Text,
+        sizing: ChunkSizing::Tokenizer {
+            model: backend_name.to_string(),
+            cache_dir: None,
+        },
+        ..Default::default()
+    }
+}
+
+#[test]
+fn registered_backend_sizes_chunks_by_its_token_count() {
+    let name = unique_name("sizes");
+    let backend = Arc::new(HalfCharTokenizer::new(&name));
+    register_tokenizer_backend(backend.clone()).unwrap();
+
+    // Digit-dense text: 40 space-separated pairs, ~120 chars. With a 10-token
+    // budget at 2 chars/token, a char-interpreted budget of 10 would be far
+    // smaller, and an unsized fallback would produce one giant chunk.
+    let text = (0..40).map(|i| format!("{:02}", i)).collect::<Vec<_>>().join(" ");
+    let config = token_sized_config(&name, 10);
+
+    let result = chunk_text(&text, &config, None).unwrap();
+
+    assert!(
+        backend.calls.load(Ordering::Relaxed) > 0,
+        "registered tokenizer backend was never invoked"
+    );
+    assert!(
+        result.chunk_count > 1,
+        "expected the token budget to split the text, got {} chunk(s)",
+        result.chunk_count
+    );
+    for chunk in &result.chunks {
+        let tokens = chunk.content.chars().count().div_ceil(2);
+        assert!(
+            tokens <= 10,
+            "chunk exceeds the 10-token budget ({tokens} tokens): {:?}",
+            chunk.content
+        );
+    }
+
+    unregister_tokenizer_backend(&name).unwrap();
+}
+
+#[test]
+fn plugin_budget_is_tokens_not_characters() {
+    let name = unique_name("units");
+    register_tokenizer_backend(Arc::new(HalfCharTokenizer::new(&name))).unwrap();
+
+    // 30 chars of prose. A 16-CHAR budget would split it; a 16-TOKEN budget at
+    // 2 chars/token (= 32 chars) must keep it whole.
+    let text = "alpha bravo charlie delta echo";
+    assert_eq!(text.chars().count(), 30);
+    let config = token_sized_config(&name, 16);
+
+    let result = chunk_text(text, &config, None).unwrap();
+    assert_eq!(
+        result.chunk_count, 1,
+        "16-token budget (32 chars at 2 chars/token) must not split 30 chars of text"
+    );
+
+    unregister_tokenizer_backend(&name).unwrap();
+}
+
+#[test]
+fn registered_backend_works_with_markdown_chunker() {
+    let name = unique_name("markdown");
+    let backend = Arc::new(HalfCharTokenizer::new(&name));
+    register_tokenizer_backend(backend.clone()).unwrap();
+
+    let markdown = "# Title\n\n".to_string() + &"word ".repeat(60) + "\n\n## Section\n\n" + &"data ".repeat(60);
+    let config = ChunkingConfig {
+        chunker_type: ChunkerType::Markdown,
+        ..token_sized_config(&name, 25)
+    };
+
+    let result = chunk_text(&markdown, &config, None).unwrap();
+    assert!(backend.calls.load(Ordering::Relaxed) > 0);
+    assert!(result.chunk_count > 1);
+    for chunk in &result.chunks {
+        assert!(chunk.content.chars().count().div_ceil(2) <= 25);
+    }
+
+    unregister_tokenizer_backend(&name).unwrap();
+}
+
+#[test]
+fn registered_backend_respects_overlap() {
+    let name = unique_name("overlap");
+    register_tokenizer_backend(Arc::new(HalfCharTokenizer::new(&name))).unwrap();
+
+    let text = "one two three four five six seven eight nine ten eleven twelve";
+    let config = ChunkingConfig {
+        overlap: 3,
+        ..token_sized_config(&name, 8)
+    };
+
+    let result = chunk_text(text, &config, None).unwrap();
+    assert!(result.chunk_count > 1);
+    // Consecutive chunks must overlap in the source text.
+    for pair in result.chunks.windows(2) {
+        assert!(
+            pair[1].metadata.byte_start < pair[0].metadata.byte_end,
+            "expected overlapping chunks, got [{}..{}] then [{}..{}]",
+            pair[0].metadata.byte_start,
+            pair[0].metadata.byte_end,
+            pair[1].metadata.byte_start,
+            pair[1].metadata.byte_end
+        );
+    }
+
+    unregister_tokenizer_backend(&name).unwrap();
+}
+
+#[test]
+fn zero_count_for_nonempty_text_is_clamped_not_trusted() {
+    /// Passes the registration probe (single chars count as 1) but reports
+    /// zero for anything longer — modeling a backend that starts failing
+    /// mid-run (host-language bridges surface exceptions as a zero count).
+    struct ZeroAfterProbe {
+        name: String,
+    }
+    impl Plugin for ZeroAfterProbe {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn version(&self) -> String {
+            "1.0.0".to_string()
+        }
+        fn initialize(&self) -> Result<()> {
+            Ok(())
+        }
+        fn shutdown(&self) -> Result<()> {
+            Ok(())
+        }
+    }
+    impl TokenizerBackend for ZeroAfterProbe {
+        fn count_tokens(&self, text: &str) -> usize {
+            usize::from(text.chars().count() == 1)
+        }
+    }
+
+    let name = unique_name("zero-clamp");
+    register_tokenizer_backend(Arc::new(ZeroAfterProbe { name: name.clone() })).unwrap();
+
+    // If zero counts were trusted, every span would appear to fit and the
+    // whole text would come back as one chunk. The sizer substitutes the
+    // character count instead, so the budget degrades to char semantics:
+    // a 12-token budget over this 49-char text must split it.
+    let text = "alpha bravo charlie delta echo foxtrot golf hotel";
+    let config = token_sized_config(&name, 12);
+    let result = chunk_text(text, &config, None).unwrap();
+    assert!(
+        result.chunk_count > 1,
+        "zero token counts must not be trusted (got a single {}-char chunk)",
+        result.chunks[0].content.len()
+    );
+    for chunk in &result.chunks {
+        assert!(
+            chunk.content.chars().count() <= 12,
+            "fallback must budget by characters, got {}-char chunk",
+            chunk.content.chars().count()
+        );
+    }
+
+    unregister_tokenizer_backend(&name).unwrap();
+}
+
+#[test]
+fn unregistered_backend_is_not_consulted_after_removal() {
+    let name = unique_name("removed");
+    let backend = Arc::new(HalfCharTokenizer::new(&name));
+    register_tokenizer_backend(backend.clone()).unwrap();
+    unregister_tokenizer_backend(&name).unwrap();
+    // Registration itself probes count_tokens once; chunking after removal
+    // must not add to that.
+    let calls_after_removal = backend.calls.load(Ordering::Relaxed);
+
+    // The name no longer resolves in the registry; chunking falls through to
+    // the HuggingFace path, which cannot load this name and must error rather
+    // than silently using the removed backend.
+    let text = "some text to chunk";
+    let config = token_sized_config(&name, 10);
+    let result = chunk_text(text, &config, None);
+
+    assert_eq!(
+        backend.calls.load(Ordering::Relaxed),
+        calls_after_removal,
+        "removed backend must not be invoked by chunking"
+    );
+    let err = result.expect_err("chunking must fail when the tokenizer name resolves nowhere");
+    let message = err.to_string();
+    assert!(
+        message.contains(&name),
+        "error must name the tokenizer that failed to resolve: {message}"
+    );
+}

--- a/docs/guides/chunking.md
+++ b/docs/guides/chunking.md
@@ -78,7 +78,17 @@ Each chunk in `result.chunks` contains:
 | `metadata.heading_path` | Flattened RAG-shaped heading breadcrumb (e.g., `["Title", "Section", "Subsection"]`) for vector database retrieval and context. |
 | `embedding`                             | Embedding vector (when configured)               |
 
-Chunks can be sized by token count instead of characters — enable the `chunking-tokenizers` feature and set `sizing` to `token`.
+Chunks can be sized by token count instead of characters — enable the `chunking-tokenizers` feature and set `sizing` to `tokenizer`.
+
+## Token Sizing with Your Own Tokenizer (Plugin Variant)
+
+Token budgets only protect the embedder when they are counted with the tokenizer the embedder actually uses. When that tokenizer isn't available as a HuggingFace `tokenizer.json` (llama.cpp/GGUF vocabularies, SentencePiece models, custom vocabs), plug it in — Xberg calls back into the registered backend to count tokens instead of loading one from the Hub. The `chunking-tokenizers` feature is still required (it gates the `tokenizer` sizing variant itself); language bindings ship with it enabled.
+
+1. Register the backend once at startup via `xberg::plugins::register_tokenizer_backend(Arc::new(MyTokenizer))`. The backend implements `TokenizerBackend` (a `Plugin`-inheriting trait with a synchronous `count_tokens(text) -> usize` — it runs inside the splitter's boundary search, so keep it cheap).
+2. Reference it by name in the chunking config: `{ "sizing": { "type": "tokenizer", "model": "my-tokenizer" } }`. A registered name takes precedence over a HuggingFace id; unregistered names fall back to the Hub as before.
+3. `max_characters` is then the chunk budget in that backend's tokens.
+
+Language bindings register through the same API — implement the trait's methods (`name`, `initialize`, `shutdown`, `count_tokens`) on a host-language object and pass it to `register_tokenizer_backend`.
 
 ## RAG Pipeline Example
 

--- a/fixtures/plugin_api/register_tokenizer_backend_trait_bridge.json
+++ b/fixtures/plugin_api/register_tokenizer_backend_trait_bridge.json
@@ -1,0 +1,27 @@
+{
+	"id": "register_tokenizer_backend_trait_bridge",
+	"category": "plugin_api",
+	"description": "register_tokenizer_backend: trait bridge",
+	"tags": ["trait-bridge"],
+	"call": "register_tokenizer_backend",
+	"input": {
+		"backend": {
+			"type": "test",
+			"name": "test-tokenizer-backend",
+			"count_tokens": 3
+		}
+	},
+	"args": [
+		{
+			"name": "backend",
+			"field": "backend",
+			"arg_type": "test_backend",
+			"trait": "TokenizerBackend"
+		}
+	],
+	"assertions": [
+		{
+			"type": "not_error"
+		}
+	]
+}

--- a/fixtures/plugin_api/tokenizer_backends_clear.json
+++ b/fixtures/plugin_api/tokenizer_backends_clear.json
@@ -1,0 +1,12 @@
+{
+	"id": "tokenizer_backends_clear",
+	"category": "tokenizer_backend_management",
+	"description": "Clear all tokenizer backends and verify list is empty",
+	"tags": ["tokenizer", "plugin_management", "clear", "trait-bridge"],
+	"call": "clear_tokenizer_backends",
+	"assertions": [
+		{
+			"type": "not_error"
+		}
+	]
+}

--- a/fixtures/plugin_api/tokenizer_backends_list.json
+++ b/fixtures/plugin_api/tokenizer_backends_list.json
@@ -1,0 +1,12 @@
+{
+	"id": "tokenizer_backends_list",
+	"category": "tokenizer_backend_management",
+	"description": "List all registered tokenizer backends",
+	"tags": ["tokenizer", "plugin_management", "list"],
+	"call": "list_tokenizer_backends",
+	"assertions": [
+		{
+			"type": "not_error"
+		}
+	]
+}

--- a/fixtures/plugin_api/unregister_tokenizer_backend_after_register.json
+++ b/fixtures/plugin_api/unregister_tokenizer_backend_after_register.json
@@ -1,0 +1,15 @@
+{
+	"id": "unregister_tokenizer_backend_after_register",
+	"category": "plugin_api",
+	"description": "unregister_tokenizer_backend",
+	"call": "unregister_tokenizer_backend",
+	"input": {
+		"name": "test-tokenizer-backend"
+	},
+	"assertions": [
+		{
+			"type": "not_error"
+		}
+	],
+	"tags": ["plugin-lifecycle", "trait-bridge"]
+}


### PR DESCRIPTION
## Problem

Token-budgeted chunking only works with tokenizers xberg loads itself:

- `ChunkSizing::Tokenizer { model }` → HuggingFace Hub id, or a local `tokenizer.json`
- No way to plug in the caller's **own tokenizer instance** (llama.cpp/GGUF vocab, SentencePiece, custom vocab)

So the token budget can't agree with the embedder it exists to protect. On digit-dense content the mismatch is 2–4x, forcing char-ceiling workarounds that waste most of the embed context on typical documents.

## Solution

Mirror the embedding-backend plugin pattern:

- New `TokenizerBackend: Plugin` trait — one method, `count_tokens(&self, text: &str) -> usize`
- New registry + the usual lifecycle functions (`register_tokenizer_backend`, `unregister_…`, `list_…`, `clear_…`)
- `ChunkSizing::Tokenizer { model }` resolves the name **registry first, HuggingFace fallback**

### What stays the same

- No new config fields or enum variants — existing configs behave identically
- Bindings are not regenerated in this PR (left to the maintainer's regen flow). The `trait_bridges` entry + fixtures are in place; a local alef 0.32.3 regen was used to verify the full surface — bridge shims, C header/vtable, and generated e2e management tests come out correct for every language, and the pyo3 path was exercised end to end from Python

### Design notes

- **Synchronous by design**, unlike `EmbeddingBackend`: the chunk sizer runs inside the splitter's boundary search and is called many times per chunk, so async dispatch isn't viable there; host bridges call the host tokenizer directly
- Registration validates like the embedding registry: `initialize()` first, then a probe rejecting backends that report zero tokens for non-empty text (a zero count would make every span appear to fit any budget)
- A zero count for non-empty text at runtime — the failure signature of a host backend that raises mid-run — is not trusted: the sizer falls back to character-count sizing and logs it, so the budget degrades to the conservative `max_characters` semantics instead of an unbounded chunk
- A name that resolves nowhere errors with both options spelled out (HuggingFace id, or register under that name)

### Example: Python consumer

Once bindings are regenerated, a consumer that embeds with its own tokenizer registers it once and references it by name — chunk budgets are then real token counts from that exact tokenizer:

```python
from xberg import (
    ChunkingConfig, ChunkSizing, ExtractionConfig,
    extract_file, register_tokenizer_backend,
)

class MyTokenizer:
    """Wraps whatever the embedder actually tokenizes with (llama.cpp, SentencePiece, ...)."""
    def name(self): return "my-tokenizer"
    def initialize(self): self._tok = load_my_vocab()   # lazy-load here
    def shutdown(self): pass
    def count_tokens(self, text): return len(self._tok.encode(text))

register_tokenizer_backend(MyTokenizer())

config = ExtractionConfig(
    chunking=ChunkingConfig(
        max_characters=512,   # now a 512-TOKEN budget, counted by MyTokenizer
        sizing=ChunkSizing(type="tokenizer", model="my-tokenizer"),
    ),
)
result = extract_file("filing.pdf", config=config)
# every chunk fits the embedder: count_tokens(chunk.content) <= 512
```

The same shape works from every binding (the trait bridge generates the register/list/clear API and the callback shim per language); Rust callers implement the `TokenizerBackend` trait directly.

Fixes #1195.
