### PR TITLE
test(pdf): vertical-text pages must return text, not a guarded per-page error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
   string after it became a list, so the WebAssembly build stopped compiling. It now uses the
   primary language (the in-memory WASI Tesseract handles one language at a time, like the PaddleOCR
   and VLM backends) and warns when more than one is requested.
+- **Vertical-text (tategaki) PDF pages return their text again.** pdf_oxide's reading-order
+  sort panicked on pages whose vertical-mode spans sit closer together than the median span
+  width — scanned pages with vertical OCR layers, typeset tategaki books. The panic guard kept
+  extraction alive, but the affected page came back as a per-page error with its text lost.
+  pdf_oxide 0.3.73 fixes the sort, so those pages now extract normally.
 
 ## [1.0.0-rc.1] - 2026-06-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6028,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fe525ccb850888a423bd211c1efd1af704761a7084e83edae1b99d0c7d2b4"
+checksum = "cf6730b3cabd41b9e813c9ab1e536c99e685adc8c06d6755b82b66dcedd49a95"
 dependencies = [
  "aes 0.9.1",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ once_cell = "1.21.4"
 
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "api-18"] }
 parking_lot = "0.12.5"
-pdf_oxide = { version = "0.3.72", default-features = false, features = ["rendering", "legacy-crypto"] }
+pdf_oxide = { version = "0.3.73", default-features = false, features = ["rendering", "legacy-crypto"] }
 rayon = "1.12.0"
 reqwest = { version = "0.13.4", default-features = false }
 # SVG rendering (resvg re-exports tiny_skia and usvg; default-features = false

--- a/crates/xberg/tests/pdf_oxide_tategaki_total_order.rs
+++ b/crates/xberg/tests/pdf_oxide_tategaki_total_order.rs
@@ -1,0 +1,128 @@
+//! Regression test for xberg #1198 — pdf_oxide's tategaki
+//! (vertical-writing) reading-order sort panicked with *"user-provided
+//! comparison function does not correctly implement a total order"* on pages
+//! whose vertical-mode span X-centers chain closer together than the
+//! median span width (scanned pages with vertical `Identity-V` OCR layers,
+//! typeset tategaki books).
+//!
+//! The `guard_oxide_panic` wrapper already keeps the panic from aborting the
+//! whole extraction, but the page's text is lost. This test asserts the real
+//! fix (yfedoseev/pdf_oxide#808): extraction must SUCCEED and return the
+//! page's text, not merely survive.
+//!
+//! The PDF is hand-built (no third-party fixture): one page, an `Identity-V`
+//! (vertical writing mode) Type0 font, 240 single-glyph runs whose X
+//! positions step by 0.8 pt. The extracted spans carry `wmode = 1` with a
+//! ~1 pt median width, so the tategaki sort sees a long chain of
+//! "same column" neighbors spanning far more than the tolerance — the
+//! intransitive case that panicked pdf_oxide ≤ 0.3.72.
+
+#![cfg(feature = "pdf")]
+
+mod helpers;
+use helpers::extract_bytes_document_blocking;
+
+use xberg::ExtractionConfig;
+
+/// Build a minimal single-page PDF whose text is emitted under a vertical
+/// (`Identity-V`) CMap at chained X positions.
+fn make_identity_v_chained_pdf() -> Vec<u8> {
+    let mut stream = String::from("/F1 12 Tf\n");
+    for i in 0..240 {
+        let x = 20.0 + i as f32 * 0.8;
+        let y = 700 - ((i * 37) % 96) * 7;
+        stream.push_str(&format!("BT 1 0 0 1 {x:.1} {y} Tm <0041> Tj ET\n"));
+    }
+
+    let mut pdf: Vec<u8> = Vec::new();
+
+    macro_rules! push {
+        ($s:expr) => {
+            pdf.extend_from_slice($s.as_bytes())
+        };
+    }
+
+    push!("%PDF-1.4\n");
+
+    let off1 = pdf.len();
+    push!("1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n");
+
+    let off2 = pdf.len();
+    push!("2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n");
+
+    let off3 = pdf.len();
+    push!(
+        "3 0 obj\n\
+         << /Type /Page /Parent 2 0 R /MediaBox [0 0 842 792]\
+         \n   /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\n\
+         endobj\n"
+    );
+
+    let off4 = pdf.len();
+    let stream_bytes = stream.as_bytes();
+    push!(format!("4 0 obj\n<< /Length {} >>\nstream\n", stream_bytes.len()));
+    pdf.extend_from_slice(stream_bytes);
+    push!("\nendstream\nendobj\n");
+
+    let off5 = pdf.len();
+    push!(
+        "5 0 obj\n\
+         << /Type /Font /Subtype /Type0 /BaseFont /MingLiU /Encoding /Identity-V\
+         \n   /DescendantFonts [6 0 R] >>\n\
+         endobj\n"
+    );
+
+    let off6 = pdf.len();
+    push!(
+        "6 0 obj\n\
+         << /Type /Font /Subtype /CIDFontType2 /BaseFont /MingLiU\
+         \n   /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >>\
+         \n   /FontDescriptor 7 0 R /DW 1000 /CIDToGIDMap /Identity >>\n\
+         endobj\n"
+    );
+
+    let off7 = pdf.len();
+    push!(
+        "7 0 obj\n\
+         << /Type /FontDescriptor /FontName /MingLiU /Flags 4\
+         \n   /FontBBox [0 -200 1000 900] /ItalicAngle 0 /Ascent 800\
+         \n   /Descent -200 /CapHeight 700 /StemV 80 >>\n\
+         endobj\n"
+    );
+
+    let xref_off = pdf.len();
+    push!(format!(
+        "xref\n0 8\n\
+         0000000000 65535 f \r\n\
+         {off1:010} 00000 n \r\n\
+         {off2:010} 00000 n \r\n\
+         {off3:010} 00000 n \r\n\
+         {off4:010} 00000 n \r\n\
+         {off5:010} 00000 n \r\n\
+         {off6:010} 00000 n \r\n\
+         {off7:010} 00000 n \r\n"
+    ));
+    push!(format!(
+        "trailer\n<< /Size 8 /Root 1 0 R >>\nstartxref\n{xref_off}\n%%EOF\n"
+    ));
+
+    pdf
+}
+
+/// A vertical-majority page with chained X-centers must extract its text —
+/// not panic (pdf_oxide ≤ 0.3.72) and not fall back to a guarded per-page
+/// error that drops the content.
+#[test]
+fn test_identity_v_chained_centers_extracts_text() {
+    let pdf = make_identity_v_chained_pdf();
+    let config = ExtractionConfig::default();
+    let result = extract_bytes_document_blocking(&pdf, "application/pdf", &config)
+        .expect("Identity-V chained-centers PDF must extract without error");
+
+    let non_ws = result.content.chars().filter(|c| !c.is_whitespace()).count();
+    assert!(
+        non_ws >= 240,
+        "vertical page text was lost (got {non_ws} non-whitespace chars, want ≥ 240):\n{:?}",
+        result.content
+    );
+}


### PR DESCRIPTION
## Problem

PDFs with vertical (tategaki) text can make pdf_oxide's reading-order sort panic. Our panic guard keeps extraction alive, but the affected page's text is silently lost — the page comes back as an error instead of content.

## Solution

The real fix landed upstream in yfedoseev/pdf_oxide#808 and shipped in pdf_oxide 0.3.73. This PR bumps the workspace pin to 0.3.73 and adds a regression test that builds a small vertical-text PDF triggering the sort and asserts the page's text actually comes back, not just that extraction survives. The test fails against 0.3.72 and passes with 0.3.73.
