### PR TITLE
fix(candle-ocr): fix the failing GPU OCR jobs (Hunyuan-OCR + DeepSeek-OCR)

### DIFF
--- a/crates/xberg-candle-ocr/src/models/deepseek_ocr/engine.rs
+++ b/crates/xberg-candle-ocr/src/models/deepseek_ocr/engine.rs
@@ -14,6 +14,27 @@ use crate::vendor::aha::InferenceModel;
 
 use super::{config::DeepseekOCRConfig, model::DeepseekOCRModel, processor::DeepseekOCRProcessor};
 
+// DeepSeek-OCR "deepencoder" preprocessing constants, taken from the reference
+// (`base_size`, `patch_size`, `downsample_ratio` and the BasicImageTransform in
+// deepseek-ai/DeepSeek-OCR's modeling code). The vision towers turn the padded
+// global view into a fixed square grid of image tokens; `input_ids` has to carry
+// exactly that many image tokens so the vision features scatter into the right slots.
+
+/// Side length the global view is padded to before the SAM + CLIP towers.
+const BASE_SIZE: u32 = 1024;
+/// ViT patch size and the projector's token-merge downsample.
+const PATCH_SIZE: u32 = 16;
+const DOWNSAMPLE_RATIO: u32 = 4;
+/// Image tokens per side for the global view:
+/// `ceil((base_size / patch_size) / downsample_ratio)` = `(1024 / 16) / 4` = 16.
+const NUM_QUERIES_BASE: usize = (BASE_SIZE / PATCH_SIZE / DOWNSAMPLE_RATIO) as usize;
+/// Channel mean and std for normalization (reference BasicImageTransform uses 0.5).
+const IMAGE_MEAN_STD: f32 = 0.5;
+/// Default plain-OCR instruction. In the reference this is `"<image>\nFree OCR."`;
+/// the `<image>` placeholder is materialized as the image-token run built below, so
+/// only the trailing text lives here.
+const DEFAULT_OCR_PROMPT: &str = "\nFree OCR.";
+
 /// DeepSeek-OCR inference engine.
 ///
 /// Manages model initialization, input processing, and generation.
@@ -235,56 +256,73 @@ impl DeepseekOCREngine {
         let (img_width, img_height) = (img.width(), img.height());
         tracing::debug!(width = img_width, height = img_height, "DeepSeek-OCR: image dimensions");
 
-        // 2. Simple preprocessing: create placeholder tensors for the image inputs
-        // For Phase 5, we skip complex crop/mask logic and use minimal tensors
-        let batch_size = 1usize;
-        let img_h = 384usize;
-        let img_w = 384usize;
+        // 2. Preprocess the image into DeepSeek-OCR's "deepencoder" inputs. The global
+        // view is aspect-preserving-padded to BASE_SIZE and normalized (see the module
+        // constants). The test path uses the global view only (no dynamic 640 crops),
+        // which the forward's no-crop branch handles.
         let channels = 3usize;
+        let image_token_id = self.processor.image_token_id();
 
-        // Resize image to standard size using simple bilinear resize
-        let resized = img.resize_exact(img_w as u32, img_h as u32, image::imageops::FilterType::Triangle);
-        let rgb_img = resized.to_rgb8();
+        let mean = Tensor::from_slice(&[IMAGE_MEAN_STD; 3], (3, 1, 1), &self.device)
+            .and_then(|t| t.to_dtype(self.dtype))
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Mean tensor: {}", e)))?;
+        let std = Tensor::from_slice(&[IMAGE_MEAN_STD; 3], (3, 1, 1), &self.device)
+            .and_then(|t| t.to_dtype(self.dtype))
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Std tensor: {}", e)))?;
 
-        // Convert to tensor (batch, channels, height, width)
-        let mut pixels = vec![];
-        for pixel in rgb_img.pixels() {
-            pixels.push(pixel[0] as f32 / 255.0);
-            pixels.push(pixel[1] as f32 / 255.0);
-            pixels.push(pixel[2] as f32 / 255.0);
-        }
+        // Pad with the mean grey (mean * 255), matching the reference ImageOps.pad(color=mean).
+        let pad = (IMAGE_MEAN_STD * 255.0) as u8;
+        let global_view =
+            crate::vendor::aha::image::resize_with_edge_padding(&img, BASE_SIZE, BASE_SIZE, [pad, pad, pad]);
+        let images_ori = crate::vendor::aha::image::img_transform(&global_view, &mean, &std, &self.device, self.dtype)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Global transform: {}", e)))?
+            .unsqueeze(0)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Global batch: {}", e)))?;
 
-        let images_ori = Tensor::from_slice(&pixels, (batch_size, channels, img_h, img_w), &self.device)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Images tensor: {}", e)))?;
-
-        // Placeholder tensors for crop, mask, spatial_crop (all zeros for Phase 5)
-        let image_crop = Tensor::zeros((0, channels, 64, 64), self.dtype, &self.device)
+        // No dynamic crops on this path: an empty crop tensor selects the forward's
+        // global-only branch (image_crop.sum() == 0).
+        let image_crop = Tensor::zeros((0, channels, BASE_SIZE as usize, BASE_SIZE as usize), self.dtype, &self.device)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Image crop tensor: {}", e)))?;
-
-        let images_seq_mask = Tensor::ones((batch_size, 1), self.dtype, &self.device)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Seq mask tensor: {}", e)))?;
-
-        let images_spatial_crop = Tensor::zeros((batch_size, 2), candle_core::DType::U32, &self.device)
+        let images_spatial_crop = Tensor::new(&[[1u32, 1u32]], &self.device)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Spatial crop tensor: {}", e)))?;
 
-        // 3. Tokenize prompt
-        let prompt_text = prompt.unwrap_or("OCR this image.");
-        let encoding = self
+        // 3. Build input_ids and the image-token mask. The global view is an
+        // NUM_QUERIES_BASE x NUM_QUERIES_BASE grid; the reference appends one
+        // image_newline per row plus a trailing view_separator, giving
+        // `n * (n + 1) + 1` = 16 * 17 + 1 = 273 image tokens (the model inserts the
+        // learned image_newline / view_separator at these positions during the
+        // forward). Layout: BOS, the image tokens, then the OCR prompt.
+        let num_image_tokens = NUM_QUERIES_BASE * (NUM_QUERIES_BASE + 1) + 1;
+        let prompt_text = prompt.unwrap_or(DEFAULT_OCR_PROMPT);
+        let text_ids: Vec<u32> = self
             .tokenizer
             .encode(prompt_text, false)
-            .map_err(|e| CandleOcrError::Tokenizer(format!("Encode prompt: {}", e)))?;
+            .map_err(|e| CandleOcrError::Tokenizer(format!("Encode prompt: {}", e)))?
+            .get_ids()
+            .to_vec();
 
-        let prompt_ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
+        let mut ids: Vec<i64> = Vec::with_capacity(1 + num_image_tokens + text_ids.len());
+        let mut mask: Vec<u32> = Vec::with_capacity(ids.capacity());
+        ids.push(self.config.bos_token_id as i64);
+        mask.push(0);
+        ids.extend(std::iter::repeat_n(image_token_id as i64, num_image_tokens));
+        mask.extend(std::iter::repeat_n(1u32, num_image_tokens));
+        ids.extend(text_ids.iter().map(|&t| t as i64));
+        mask.extend(std::iter::repeat_n(0u32, text_ids.len()));
+
         tracing::debug!(
-            prompt_len = prompt_ids.len(),
-            prompt = prompt_text,
-            "DeepSeek-OCR: prompt tokenization"
+            seq_len = ids.len(),
+            num_image_tokens,
+            "DeepSeek-OCR: input construction"
         );
 
-        let input_ids = Tensor::new(prompt_ids.as_slice(), &self.device)
+        let input_ids = Tensor::new(ids.as_slice(), &self.device)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Token tensor: {}", e)))?
             .unsqueeze(0)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Unsqueeze batch: {}", e)))?;
+        let prompt_ids: Vec<i64> = ids;
+        let images_seq_mask = Tensor::new(mask.as_slice(), &self.device)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Seq mask tensor: {}", e)))?;
 
         // 4. Prepare multimodal data for forward pass
         let mm_data = crate::vendor::aha::MultiModalData::new(vec![
@@ -298,12 +336,13 @@ impl DeepseekOCREngine {
         tracing::debug!("DeepSeek-OCR: clearing cache and running forward_initial");
         self.model.clear_kv_cache();
 
-        let logits = self
+        let mut logits = self
             .model
             .forward_initial(&input_ids, 0, mm_data)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Initial forward: {}", e)))?;
 
-        // 6. Greedy decoding loop (Phase 5: limit to small token count for stability)
+        // 6. Greedy decoding loop, capped so a degenerate image (no stop token) can't
+        // run unbounded.
         const MAX_NEW_TOKENS: usize = 128;
         let stop_ids = self.model.stop_token_ids();
         let mut output_tokens = prompt_ids.iter().map(|&id| id as u32).collect::<Vec<_>>();
@@ -324,12 +363,14 @@ impl DeepseekOCREngine {
                 .narrow(1, seq_len - 1, 1)
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("Narrow last: {}", e)))?;
 
+            // last_logits is [1, 1, vocab]; argmax over the vocab dim yields [1, 1],
+            // so squeeze the two length-1 dims to a scalar token id.
             let next_token = last_logits
                 .argmax(2)
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("Argmax: {}", e)))?
-                .squeeze(2)
-                .map_err(|e| CandleOcrError::InferenceFailed(format!("Squeeze: {}", e)))?
                 .squeeze(1)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Squeeze seq: {}", e)))?
+                .squeeze(0)
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("Squeeze batch: {}", e)))?
                 .to_scalar::<u32>()
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("To scalar: {}", e)))?;
@@ -346,22 +387,27 @@ impl DeepseekOCREngine {
                 break;
             }
 
-            // Forward step for next token
+            // Feed the token back and take ITS logits for the next iteration; the
+            // seqlen_offset is the token's absolute position (the prompt occupies
+            // 0..prompt_len), which drives RoPE. Discarding the step logits (or
+            // restarting the offset near zero) re-reads the initial forward's logits
+            // every iteration and emits the same token MAX_NEW_TOKENS times.
             let next_token_tensor = Tensor::new(&[next_token as i64], &self.device)
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("Next token tensor: {}", e)))?
                 .unsqueeze(0)
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("Unsqueeze next: {}", e)))?;
 
-            let _ = self
+            logits = self
                 .model
-                .forward_step(&next_token_tensor, step + 1)
+                .forward_step(&next_token_tensor, prompt_ids.len() + step)
                 .map_err(|e| CandleOcrError::InferenceFailed(format!("Forward step {}: {}", step, e)))?;
         }
 
-        // 7. Decode tokens back to text
+        // 7. Decode only the newly generated tokens (skip the prompt + image tokens).
+        let generated = output_tokens.get(prompt_ids.len()..).unwrap_or(&[]);
         let output_text = self
             .tokenizer
-            .decode(&output_tokens, false)
+            .decode(generated, true)
             .map_err(|e| CandleOcrError::Tokenizer(format!("Decode error: {}", e)))?
             .trim()
             .to_string();

--- a/crates/xberg-candle-ocr/src/models/deepseek_ocr/model.rs
+++ b/crates/xberg-candle-ocr/src/models/deepseek_ocr/model.rs
@@ -217,14 +217,16 @@ impl Attention {
         let key_states = qkv.i(1)?.contiguous()?;
         let value_states = qkv.i(2)?.contiguous()?;
         let xs = if self.use_rel_pos {
+            // use_rel_pos implies the decomposed rel-pos tables were loaded; surface a
+            // clear error instead of panicking if a checkpoint set the flag without them.
+            let rel_pos_h = self.rel_pos_h.as_ref().ok_or_else(|| {
+                CandleOcrError::InferenceFailed("SAM attention: use_rel_pos set but rel_pos_h is missing".into())
+            })?;
+            let rel_pos_w = self.rel_pos_w.as_ref().ok_or_else(|| {
+                CandleOcrError::InferenceFailed("SAM attention: use_rel_pos set but rel_pos_w is missing".into())
+            })?;
             let q_reshape = query_states.reshape((b * self.num_heads, h * w, ()))?;
-            let (rel_h, rel_w) = self.add_decomposed_rel_pos(
-                &q_reshape,
-                self.rel_pos_h.as_ref().unwrap(),
-                self.rel_pos_w.as_ref().unwrap(),
-                (h, w),
-                (h, w),
-            )?;
+            let (rel_h, rel_w) = self.add_decomposed_rel_pos(&q_reshape, rel_pos_h, rel_pos_w, (h, w), (h, w))?;
             let (_, rel_h_dim1, rel_h_dim2, rel_h_dim3) = rel_h.dims4()?;
             let rel_h = rel_h.reshape((b, self.num_heads, rel_h_dim1, rel_h_dim2, rel_h_dim3))?;
             let (_, rel_w_dim1, rel_w_dim2, rel_w_dim3) = rel_w.dims4()?;
@@ -781,7 +783,14 @@ impl VitModel {
             ffn_hidden_size,
             eps,
         )?;
-        let pre_layernorm = get_layer_norm(vb.pp("pre_layernorm"), eps, hidden_size, true)?;
+        // HuggingFace CLIP genuinely names this "pre_layrnorm" (sic) and the released
+        // DeepSeek-OCR checkpoint keeps that spelling; accept both the misspelled and
+        // the corrected key, like view_seperator below.
+        let pre_layernorm = if vb.contains_tensor("pre_layrnorm.weight") {
+            get_layer_norm(vb.pp("pre_layrnorm"), eps, hidden_size, true)?
+        } else {
+            get_layer_norm(vb.pp("pre_layernorm"), eps, hidden_size, true)?
+        };
         Ok(Self {
             embeddings,
             transformer,
@@ -850,7 +859,9 @@ impl MoEGate {
                 self.scoring_func
             )));
         };
-        let (topk_weight, topk_idx) = if self.topk_method == "greedy" {
+        // topk returns (indices, weights) in that order; keep them straight so the
+        // U32 expert indices feed onehot/gather and the F32 weights get normalized.
+        let (topk_idx, topk_weight) = if self.topk_method == "greedy" {
             topk(&scores, self.top_k)?
         } else {
             return Err(CandleOcrError::UnsupportedConfig(format!(
@@ -1288,7 +1299,15 @@ impl DeepseekOCRModel {
             config.vision_config.width.sam_vit_b.global_attn_indexes.clone(),
             version,
         )?;
-        let (vision_model, image_newline) = if version == 2 {
+        // The SAM neck version (net_3 = 896 vs 1024) and the second vision-encoder
+        // type (CLIP ViT vs Qwen2) are independent axes: the released
+        // deepseek-ai/DeepSeek-OCR checkpoint pairs a v2 SAM neck (net_3 = 1024)
+        // with a CLIP tower at model.vision_model and has no model.qwen2_model.
+        // Select the tower by which tensors are actually present rather than by the
+        // SAM version, so a v2-neck + CLIP checkpoint loads the CLIP path.
+        let has_qwen2_tower =
+            vb_m.contains_tensor("qwen2_model.model.model.layers.0.self_attn.q_proj.weight");
+        let (vision_model, image_newline) = if has_qwen2_tower {
             let qwen2 = Qwen2Decoder2Encoder::new(vb_m.pp("qwen2_model"))?;
             (VisionModel::Qwen2(qwen2), None)
         } else {
@@ -1303,7 +1322,13 @@ impl DeepseekOCRModel {
             vb_m.pp("projector.layers"),
         )?;
 
-        let view_separator = vb_m.get_with_hints(1280, "view_separator", Init::Const(0.))?;
+        // The released checkpoint stores this as "view_seperator" (sic); accept
+        // both the misspelled and the corrected key.
+        let view_separator = if vb_m.contains_tensor("view_seperator") {
+            vb_m.get_with_hints(1280, "view_seperator", Init::Const(0.))?
+        } else {
+            vb_m.get_with_hints(1280, "view_separator", Init::Const(0.))?
+        };
         let language_model = DeepseekV2Model::new(vb_m, config.language_config.clone())?;
         let lm_head = linear_no_bias(config.hidden_size, config.vocab_size, vb.pp("lm_head"))?;
         let stop_token_ids = vec![config.eos_token_id, config.bos_token_id];

--- a/crates/xberg-candle-ocr/src/models/deepseek_ocr/utils.rs
+++ b/crates/xberg-candle-ocr/src/models/deepseek_ocr/utils.rs
@@ -68,26 +68,30 @@ pub fn interpolate_bicubic(
     Tensor::stack(&rows, 2).map_err(|e| CandleOcrError::InferenceFailed(format!("stack failed: {e}")))
 }
 
-/// Select 2D indices from tensor.
+/// Advanced 2D gather: `t` is a `[num, dim]` lookup table and `index` is an
+/// `[ih, iw]` grid of row indices; returns `t[index]` shaped `[ih, iw, dim]`.
+///
+/// This is the SAM decomposed relative-position lookup (`rel_pos[coords]`): the
+/// caller passes the rank-2 `[2*max-1, head_dim]` rel-pos table, not a rank-3
+/// tensor, so gather rows and restore the `[ih, iw]` grid on the result.
 pub fn index_select_2d(t: &Tensor, index: &Tensor) -> Result<Tensor> {
-    let (h, _w, _dim) = t.dims3()?;
-    let (ih, iw) = index.dims2()?;
-    let mut result = Vec::new();
-    for i in 0..ih {
-        for j in 0..iw {
-            let idx = index.i((i, j))?.to_scalar::<u32>()? as usize;
-            if idx < h {
-                let val = t.i(idx)?;
-                result.push(val);
-            }
-        }
-    }
-    if result.is_empty() {
+    let (num, dim) = t.dims2()?;
+    if num == 0 {
         return Err(CandleOcrError::InferenceFailed(
-            "index_select_2d produced empty result".to_string(),
+            "index_select_2d: lookup table has no rows".to_string(),
         ));
     }
-    Tensor::stack(&result, 0).map_err(|e| CandleOcrError::InferenceFailed(format!("stack failed: {e}")))
+    let (ih, iw) = index.dims2()?;
+    let mut result = Vec::with_capacity(ih * iw);
+    for i in 0..ih {
+        for j in 0..iw {
+            let idx = (index.i((i, j))?.to_scalar::<u32>()? as usize).min(num - 1);
+            result.push(t.i(idx)?);
+        }
+    }
+    Tensor::stack(&result, 0)
+        .and_then(|r| r.reshape((ih, iw, dim)))
+        .map_err(|e| CandleOcrError::InferenceFailed(format!("index_select_2d: {e}")))
 }
 
 /// One-hot encoding.
@@ -153,10 +157,17 @@ pub fn attn_masked_fill(on_true: &Tensor, mask: &Tensor, on_false: f32) -> Resul
 }
 
 /// Masked scatter on dimension 0.
+///
+/// Replaces the rows of `dst` where `mask` is set with successive rows of `src`.
+/// `dst` arrives batched as `[1, seq, hidden]` from the language embeddings, so the
+/// batch dim is dropped for the row scatter and restored afterwards; `mask` is
+/// flattened to a rank-1 `[seq]`. Without this the sequence rows past the batch
+/// dimension are dropped and Tensor::stack sees mixed ranks.
 pub fn masked_scatter_dim0(dst: &Tensor, src: &Tensor, mask: &Tensor) -> Result<Tensor> {
-    // Simple implementation: iterate and gather where mask == 1
+    let batched = dst.rank() == 3;
+    let dst = if batched { dst.squeeze(0)? } else { dst.clone() };
     let mut output_rows = Vec::new();
-    let mask_vec = mask.to_vec1::<u32>()?;
+    let mask_vec = mask.flatten_all()?.to_vec1::<u32>()?;
     let mut src_idx = 0;
     for (i, &m) in mask_vec.iter().enumerate() {
         if m != 0 && src_idx < src.dim(0)? {
@@ -169,12 +180,17 @@ pub fn masked_scatter_dim0(dst: &Tensor, src: &Tensor, mask: &Tensor) -> Result<
         }
     }
     if output_rows.is_empty() {
-        return Ok(dst.clone());
+        return Ok(if batched { dst.unsqueeze(0)? } else { dst });
     }
-    Tensor::stack(&output_rows, 0).map_err(|e| CandleOcrError::InferenceFailed(format!("stack failed: {e}")))
+    let out = Tensor::stack(&output_rows, 0)
+        .map_err(|e| CandleOcrError::InferenceFailed(format!("stack failed: {e}")))?;
+    if batched { Ok(out.unsqueeze(0)?) } else { Ok(out) }
 }
 
 /// Top-k selection.
+///
+/// Returns `(indices, weights)` in that order: U32 positions of the k largest
+/// values per row, then the F32 values themselves.
 pub fn topk(input: &Tensor, k: usize) -> Result<(Tensor, Tensor)> {
     let shape = input.shape().dims();
     let flattened = input.reshape((shape[0], ()))?;
@@ -205,4 +221,51 @@ pub fn topk(input: &Tensor, k: usize) -> Result<(Tensor, Tensor)> {
     let indices = Tensor::new(top_indices_flat.as_slice(), input.device())?.reshape((batch_size, k))?;
 
     Ok((indices, weights))
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::Device;
+
+    use super::*;
+
+    #[test]
+    fn index_select_2d_gathers_rows_into_grid() {
+        let dev = Device::Cpu;
+        let table = Tensor::new(&[[0f32, 1.], [10., 11.], [20., 21.]], &dev).expect("table");
+        let index = Tensor::new(&[[2u32, 0], [1, 2]], &dev).expect("index");
+        let out = index_select_2d(&table, &index).expect("gather");
+        assert_eq!(out.dims(), &[2, 2, 2]);
+        let rows = out.reshape((4, 2)).and_then(|t| t.to_vec2::<f32>()).expect("read");
+        assert_eq!(rows, vec![vec![20., 21.], vec![0., 1.], vec![10., 11.], vec![20., 21.]]);
+    }
+
+    #[test]
+    fn index_select_2d_rejects_empty_table() {
+        let dev = Device::Cpu;
+        let table = Tensor::zeros((0usize, 4usize), DType::F32, &dev).expect("empty table");
+        let index = Tensor::new(&[[0u32]], &dev).expect("index");
+        assert!(index_select_2d(&table, &index).is_err());
+    }
+
+    #[test]
+    fn masked_scatter_dim0_replaces_masked_rows_and_keeps_batch_dim() {
+        let dev = Device::Cpu;
+        let dst = Tensor::new(&[[[0f32, 0.], [1., 1.], [2., 2.], [3., 3.]]], &dev).expect("dst");
+        let src = Tensor::new(&[[10f32, 10.], [20., 20.]], &dev).expect("src");
+        let mask = Tensor::new(&[[0u32, 1, 1, 0]], &dev).expect("mask");
+        let out = masked_scatter_dim0(&dst, &src, &mask).expect("scatter");
+        assert_eq!(out.dims(), &[1, 4, 2]);
+        let rows = out.reshape((4, 2)).and_then(|t| t.to_vec2::<f32>()).expect("read");
+        assert_eq!(rows, vec![vec![0., 0.], vec![10., 10.], vec![20., 20.], vec![3., 3.]]);
+    }
+
+    #[test]
+    fn topk_returns_indices_then_weights() {
+        let dev = Device::Cpu;
+        let input = Tensor::new(&[[0.1f32, 0.7, 0.2]], &dev).expect("input");
+        let (indices, weights) = topk(&input, 2).expect("topk");
+        assert_eq!(indices.to_vec2::<u32>().expect("idx"), vec![vec![1, 2]]);
+        assert_eq!(weights.to_vec2::<f32>().expect("w"), vec![vec![0.7, 0.2]]);
+    }
 }

--- a/crates/xberg-candle-ocr/src/models/hunyuan_ocr/engine.rs
+++ b/crates/xberg-candle-ocr/src/models/hunyuan_ocr/engine.rs
@@ -4,14 +4,33 @@
 
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use tokenizers::Tokenizer;
 
 use crate::CandleOcrOutput;
 use crate::error::{CandleOcrError, Result};
 use crate::models::hunyuan_ocr::config::{HunYuanVLConfig, HunyuanOCRGenerationConfig};
 use crate::models::hunyuan_ocr::model::HunyuanVLModel;
-use crate::models::hunyuan_ocr::processor::HunyuanVLProcessor;
+use crate::models::hunyuan_ocr::processor::{HunyuanVLProcessor, IMAGE_TOKEN};
 use crate::vendor::aha::InferenceModel;
+
+/// Plain OCR instruction placed in the user turn of the chat template, the analog of
+/// GLM-OCR's `GlmOcrTask::Ocr` prompt (`"Text Recognition:"`). Kept separate from the
+/// chat-template scaffolding built in [`build_ocr_prompt`].
+const OCR_INSTRUCTION: &str = "OCR this image.";
+
+/// Build HunyuanOCR's chat-template prompt around `instruction`, mirroring the model's
+/// own chat_template (like GLM-OCR's `tokenizer::build_input_ids`). The scaffolding is,
+/// in order: begin-of-sentence, a format token, the image_start / image-placeholder /
+/// image_end triple, the instruction, then the user turn. The image placeholder is the
+/// processor's [`IMAGE_TOKEN`]; the processor expands it to one token per patch and
+/// tokenizes the result, so `input_ids` carries the image tokens the mask and
+/// vision-merge depend on. A bare "Image OCR:" prompt has no image tokens, so
+/// image-position indexing narrows an empty tensor and inference fails.
+fn build_ocr_prompt(instruction: &str) -> String {
+    format!(
+        "<｜hy_begin▁of▁sentence｜><｜hy_place▁holder▁no▁3｜><｜hy_place▁holder▁no▁100｜>\
+         {IMAGE_TOKEN}<｜hy_place▁holder▁no▁101｜>{instruction}<｜hy_User｜>"
+    )
+}
 
 /// Hunyuan-OCR inference engine: manages model, processor, and generation config.
 #[cfg_attr(alef, alef(skip))]
@@ -21,7 +40,6 @@ pub struct HunyuanOCREngine {
     device: Device,
     generation_config: HunyuanOCRGenerationConfig,
     model_name: String,
-    tokenizer: Tokenizer,
 }
 
 impl HunyuanOCREngine {
@@ -52,12 +70,8 @@ impl HunyuanOCREngine {
             _ => DType::F32,
         });
 
+        // The processor owns the tokenizer; the engine reads it back for decoding.
         let processor = HunyuanVLProcessor::new(path, &device, dtype)?;
-
-        // Load tokenizer
-        let tokenizer_path = format!("{}/tokenizer.json", path);
-        let tokenizer = Tokenizer::from_file(&tokenizer_path)
-            .map_err(|e| CandleOcrError::Tokenizer(format!("Tokenizer load error: {}", e)))?;
 
         // Find and mmap safetensors files.
         let model_files: Vec<String> = std::fs::read_dir(path)?
@@ -72,6 +86,9 @@ impl HunyuanOCREngine {
             ));
         }
 
+        // SAFETY: mmaped_safetensors is called with valid, existence-checked file paths.
+        // The files are opened read-only and the mmap is held by the returned VarBuilder
+        // for as long as the weights are in use, so the mapping outlives every tensor read.
         #[allow(unsafe_code)]
         let vb = unsafe {
             VarBuilder::from_mmaped_safetensors(&model_files, dtype, &device)
@@ -97,7 +114,6 @@ impl HunyuanOCREngine {
             device,
             generation_config,
             model_name,
-            tokenizer,
         })
     }
 
@@ -149,28 +165,11 @@ impl HunyuanOCREngine {
         let (img_width, img_height) = (img.width(), img.height());
         tracing::debug!(width = img_width, height = img_height, "Hunyuan-OCR: image dimensions");
 
-        // Build OCR prompt that matches the model's expected input template
-        let prompt_text = "Image OCR:";
-
-        // Tokenize the prompt to get input IDs
-        let encoding = self
-            .tokenizer
-            .encode(prompt_text, false)
-            .map_err(|e| CandleOcrError::Tokenizer(format!("Encode prompt: {}", e)))?;
-        let prompt_ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
-
-        tracing::debug!(prompt_len = prompt_ids.len(), "Hunyuan-OCR: prompt tokenization");
-
-        let input_ids = Tensor::new(prompt_ids.as_slice(), &self.device)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Token tensor: {}", e)))?
-            .unsqueeze(0)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Unsqueeze batch: {}", e)))?;
-
-        // Use the processor to build full multimodal data with image preprocessing, mask and position IDs
+        // Preprocess the image and build multimodal data; the processor expands the
+        // image placeholder and tokenizes to produce input_ids, image mask and position IDs.
         tracing::debug!("Hunyuan-OCR: processing image and text to multimodal data");
-        let hunyuan_data = self
-            .processor
-            .process_images_and_text(&[img], input_ids.clone(), prompt_text)?;
+        let prompt = build_ocr_prompt(OCR_INSTRUCTION);
+        let hunyuan_data = self.processor.process_images_and_text(&[img], &prompt)?;
 
         // Prepare multimodal data for the model's forward_initial call
         // The model expects: [pixel_values, image_grid_thw, image_mask, position_ids]
@@ -185,33 +184,70 @@ impl HunyuanOCREngine {
         tracing::debug!("Hunyuan-OCR: clearing cache and running forward pass");
         self.model.clear_kv_cache();
 
-        let output_ids = self
+        let mut logits = self
             .model
             .forward_initial(&hunyuan_data.input_ids, 0, mm_data)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Initial forward: {}", e)))?;
 
-        // For a simple first implementation, use the logits from forward_initial to get the next token
-        // In a full implementation, this would be an autoregressive loop
-        let seq_len = output_ids
+        // Greedy autoregressive decode, mirroring the reference generation loop:
+        // take a token from the initial forward's logits, then feed each token back
+        // through forward_step at its absolute position (the prompt occupies
+        // 0..prompt_len). Decode steps use the standard offset-based RoPE
+        // (no position_ids); the XD-RoPE positions only shape the prompt pass, and
+        // generated text tokens continue sequentially after it. Capped so a
+        // degenerate image (no stop token) can't run unbounded.
+        const MAX_NEW_TOKENS: usize = 128;
+        let prompt_len = hunyuan_data
+            .input_ids
             .dim(1)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Output seq len: {}", e)))?;
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Prompt len: {}", e)))?;
+        let stop_ids = self.model.stop_token_ids();
+        let mut generated: Vec<u32> = Vec::new();
 
-        let last_logits = output_ids
-            .narrow(1, seq_len - 1, 1)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Narrow last: {}", e)))?;
+        for step in 0..MAX_NEW_TOKENS {
+            let seq_len = logits
+                .dim(1)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Output seq len: {}", e)))?;
 
-        let token_id = last_logits
-            .argmax(2)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Argmax: {}", e)))?
-            .squeeze(2)
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("Squeeze: {}", e)))?
-            .to_vec1::<u32>()
-            .map_err(|e| CandleOcrError::InferenceFailed(format!("To vec: {}", e)))?;
+            let last_logits = logits
+                .narrow(1, seq_len - 1, 1)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Narrow last: {}", e)))?;
 
-        // Decode the generated token to text
+            // last_logits is [1, 1, vocab]; argmax over the vocab dim yields [1, 1],
+            // so squeeze the two length-1 dims to a scalar token id.
+            let next_token = last_logits
+                .argmax(2)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Argmax: {}", e)))?
+                .squeeze(1)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Squeeze seq: {}", e)))?
+                .squeeze(0)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Squeeze batch: {}", e)))?
+                .to_scalar::<u32>()
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("To scalar: {}", e)))?;
+
+            generated.push(next_token);
+
+            if stop_ids.contains(&next_token) {
+                tracing::debug!(step = step, num_tokens = generated.len(), "Hunyuan-OCR: reached stop token");
+                break;
+            }
+
+            let next_token_tensor = Tensor::new(&[next_token as i64], &self.device)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Next token tensor: {}", e)))?
+                .unsqueeze(0)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Unsqueeze next: {}", e)))?;
+
+            logits = self
+                .model
+                .forward_step(&next_token_tensor, prompt_len + step)
+                .map_err(|e| CandleOcrError::InferenceFailed(format!("Forward step {}: {}", step, e)))?;
+        }
+
+        // Decode the generated tokens, skipping the stop/special tokens.
         let output_text = self
-            .tokenizer
-            .decode(&token_id, false)
+            .processor
+            .tokenizer()
+            .decode(&generated, true)
             .map_err(|e| CandleOcrError::Tokenizer(format!("Decode error: {}", e)))?
             .trim()
             .to_string();
@@ -221,7 +257,7 @@ impl HunyuanOCREngine {
         } else {
             tracing::debug!(
                 text_len = output_text.len(),
-                num_tokens = token_id.len(),
+                num_tokens = generated.len(),
                 "Hunyuan-OCR: decoding complete"
             );
         }
@@ -231,5 +267,25 @@ impl HunyuanOCREngine {
             is_structured_markdown: false,
             confidence: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_ocr_prompt_carries_exactly_one_image_token_and_the_instruction() {
+        let prompt = build_ocr_prompt(OCR_INSTRUCTION);
+        // The processor's expansion loop finds image positions by this exact token;
+        // zero occurrences reintroduces the empty-tensor crash, two would double the
+        // image-token run.
+        assert_eq!(prompt.matches(IMAGE_TOKEN).count(), 1);
+        assert!(prompt.contains(OCR_INSTRUCTION));
+        assert!(prompt.ends_with("<｜hy_User｜>"));
+        // The line-continuation in the template must not leak whitespace into the
+        // special-token scaffolding.
+        let scaffolding = prompt.replace(OCR_INSTRUCTION, "");
+        assert!(!scaffolding.contains(' ') && !scaffolding.contains('\n'));
     }
 }

--- a/crates/xberg-candle-ocr/src/models/hunyuan_ocr/model.rs
+++ b/crates/xberg-candle-ocr/src/models/hunyuan_ocr/model.rs
@@ -964,8 +964,20 @@ fn prepare_causal_attention_mask(batch_size: usize, seq_len: usize, device: &can
 
 /// Scatter image embeddings into position placeholders using a mask.
 fn masked_scatter_dim0(base: &Tensor, image_embeds: &Tensor, mask: &Tensor) -> Result<Tensor> {
+    // The forward passes a batched [1, seq, hidden]; the scatter replaces rows along
+    // the sequence axis, so drop the leading batch dim, scatter, then restore it.
+    // Without this base_len is the batch size (1) and every text row past position 0
+    // is dropped while image rows keep a stale rank, so Tensor::stack sees mixed ranks.
+    let batched = base.rank() == 3;
+    let base = if batched {
+        base.squeeze(0)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Base squeeze: {}", e)))?
+    } else {
+        base.clone()
+    };
     let mask_vec = mask
-        .to_vec1::<u32>()
+        .flatten_all()
+        .and_then(|t| t.to_vec1::<u32>())
         .map_err(|e| CandleOcrError::InferenceFailed(format!("Mask vec: {}", e)))?;
     let base_len = base
         .dim(0)
@@ -995,7 +1007,14 @@ fn masked_scatter_dim0(base: &Tensor, image_embeds: &Tensor, mask: &Tensor) -> R
         }
     }
 
-    Tensor::stack(&result_rows, 0).map_err(|e| CandleOcrError::InferenceFailed(format!("Stack: {}", e)))
+    let out = Tensor::stack(&result_rows, 0)
+        .map_err(|e| CandleOcrError::InferenceFailed(format!("Stack: {}", e)))?;
+    if batched {
+        out.unsqueeze(0)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Scatter unsqueeze: {}", e)))
+    } else {
+        Ok(out)
+    }
 }
 
 #[cfg(test)]

--- a/crates/xberg-candle-ocr/src/models/hunyuan_ocr/processor.rs
+++ b/crates/xberg-candle-ocr/src/models/hunyuan_ocr/processor.rs
@@ -4,10 +4,23 @@
 
 use candle_core::{DType, Device, IndexOp, Shape, Tensor};
 use image::DynamicImage;
+use tokenizers::Tokenizer;
 
 use crate::error::{CandleOcrError, Result};
 use crate::models::hunyuan_ocr::config::HunyuanOCRPreprocessorConfig;
 use crate::vendor::aha::image::{img_smart_resize, img_transform};
+
+/// Vocabulary id of HunyuanOCR's image token (`<｜hy_place▁holder▁no▁102｜>`). The
+/// image mask and vision-merge locate image positions by matching this id.
+const IMAGE_TOKEN_ID: u32 = 120_120;
+/// The image token in text form; each one is expanded to N tokens (one per patch).
+/// Shared with the engine's prompt builder, which must emit exactly this token for
+/// the expansion loop to find it.
+pub(crate) const IMAGE_TOKEN: &str = "<｜hy_place▁holder▁no▁102｜>";
+/// A scratch token used only during expansion so the freshly written run isn't
+/// re-matched by the `contains(IMAGE_TOKEN)` loop; swapped back to IMAGE_TOKEN before
+/// tokenizing.
+const PLACEHOLDER_TOKEN: &str = "<｜hy_place▁holder▁no▁799｜>";
 
 /// Processed multimodal data: input IDs, position IDs, image embeddings, and masks.
 pub struct HunyuanData {
@@ -28,12 +41,18 @@ pub struct HunyuanVLProcessor {
     image_token_id: u32,
     image_token: String,
     placeholder_token: String,
+    tokenizer: Tokenizer,
     pub process_cfg: HunyuanOCRPreprocessorConfig,
     device: Device,
     dtype: DType,
 }
 
 impl HunyuanVLProcessor {
+    /// Return the tokenizer (also used by the engine for output decoding).
+    pub fn tokenizer(&self) -> &Tokenizer {
+        &self.tokenizer
+    }
+
     /// Create a new Hunyuan-VL processor.
     ///
     /// # Arguments
@@ -63,14 +82,20 @@ impl HunyuanVLProcessor {
         let process_cfg: HunyuanOCRPreprocessorConfig = serde_json::from_slice(&config_bytes)
             .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Parse preprocessor_config.json: {}", e)))?;
 
-        let image_token_id = 120120u32;
-        let image_token = "<｜hy_place▁holder▁no▁102｜>".to_string();
-        let placeholder_token = "<｜hy_place▁holder▁no▁799｜>".to_string();
+        let image_token_id = IMAGE_TOKEN_ID;
+        let image_token = IMAGE_TOKEN.to_string();
+        let placeholder_token = PLACEHOLDER_TOKEN.to_string();
+
+        // Needed to tokenize the image-expanded prompt (one image token per patch)
+        // so input_ids actually carries the image tokens the merge/mask rely on.
+        let tokenizer = Tokenizer::from_file(format!("{}/tokenizer.json", path))
+            .map_err(|e| CandleOcrError::Tokenizer(format!("Tokenizer load error: {}", e)))?;
 
         Ok(Self {
             image_token_id,
             image_token,
             placeholder_token,
+            tokenizer,
             process_cfg,
             device: device.clone(),
             dtype,
@@ -192,8 +217,9 @@ impl HunyuanVLProcessor {
     /// 3. Builds position IDs for XD-RoPE
     /// 4. Creates image mask
     ///
-    /// Note: Tokenization is not performed here; callers must provide pre-tokenized `input_ids`.
-    pub fn process_images_and_text(&self, imgs: &[DynamicImage], input_ids: Tensor, text: &str) -> Result<HunyuanData> {
+    /// `text` is the raw prompt containing one image token per image; each is expanded
+    /// to one token per patch and the result is tokenized here to produce `input_ids`.
+    pub fn process_images_and_text(&self, imgs: &[DynamicImage], text: &str) -> Result<HunyuanData> {
         let img_mean = Tensor::from_slice(&self.process_cfg.image_mean, (3, 1, 1), &self.device)
             .map_err(|e| CandleOcrError::InferenceFailed(format!("Mean tensor: {}", e)))?
             .to_dtype(self.dtype)
@@ -247,7 +273,22 @@ impl HunyuanVLProcessor {
             }
         }
 
-        let _text = text.replace(&self.placeholder_token, &self.image_token);
+        // Expansion replaced each image token with N scratch placeholders (one per
+        // patch); swap them back to the real image token and tokenize THIS text, so
+        // input_ids carries one image token per patch. Tokenizing the un-expanded
+        // prompt (as the caller used to) left input_ids with no image tokens at all,
+        // so the image-position indexing narrowed an empty tensor and the image mask
+        // was all-false (vision features never merged).
+        let expanded_text = text.replace(&self.placeholder_token, &self.image_token);
+        let encoding = self
+            .tokenizer
+            .encode(expanded_text.as_str(), false)
+            .map_err(|e| CandleOcrError::Tokenizer(format!("Encode expanded prompt: {}", e)))?;
+        let ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
+        let input_ids = Tensor::new(ids.as_slice(), &self.device)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Input IDs tensor: {}", e)))?
+            .unsqueeze(0)
+            .map_err(|e| CandleOcrError::InferenceFailed(format!("Input IDs batch: {}", e)))?;
 
         let seq_len = input_ids
             .dim(1)
@@ -391,9 +432,12 @@ fn get_eq_indices(tensor: &Tensor, target: u32) -> Result<Tensor> {
 
 /// Create a binary mask where positions equal to target are 1, others are 0.
 fn get_equal_mask(tensor: &Tensor, target: u32) -> Result<Tensor> {
-    // `input_ids` arrive as I64 from the tokenizer; normalise to U32 first.
+    // `input_ids` arrive as I64 from the tokenizer; normalise to U32 first, and
+    // flatten so a batched [1, seq] tensor reads as the rank-1 [seq] mask that
+    // masked_scatter_dim0 expects (the caller passes the full batched input_ids).
     let vec = tensor
-        .to_dtype(DType::U32)
+        .flatten_all()
+        .and_then(|t| t.to_dtype(DType::U32))
         .and_then(|t| t.to_vec1::<u32>())
         .map_err(|e| CandleOcrError::InferenceFailed(format!("To vec: {}", e)))?;
 

--- a/crates/xberg-candle-ocr/tests/hunyuan_ocr_integration.rs
+++ b/crates/xberg-candle-ocr/tests/hunyuan_ocr_integration.rs
@@ -71,7 +71,11 @@ fn hunyuan_ocr_extracts_text_from_sample_image() {
     let image_bytes = include_bytes!("../../../fixtures/images/test_hello_world.png");
 
     eprintln!("Constructing Hunyuan-OCR engine from {}…", model_path);
-    let mut engine = HunyuanOCREngine::init(&model_path, None, None)
+    // Run the reference-correctness path on CPU in F32, like the DeepSeek-OCR e2e test.
+    // The checkpoint is bfloat16, but candle has no BF16 matmul on this backend, so
+    // leaving dtype unset (which defaults to the config's BF16) makes every matmul fail.
+    let device = candle_core::Device::Cpu;
+    let mut engine = HunyuanOCREngine::init(&model_path, Some(&device), Some(candle_core::DType::F32))
         .expect("HunyuanOCREngine::init should succeed with a valid model directory");
 
     eprintln!("Engine ready. Running inference on test fixture…");


### PR DESCRIPTION
## Problem

Two GPU OCR jobs fail in CI: https://github.com/xberg-io/xberg/actions/runs/28739853552. Neither backend had ever run a real image end to end.

- Hunyuan-OCR crashed on every image: its prompt had none of the model's image tokens, so the image-merge step hit an empty tensor (#1206). The engine also decoded only a single token instead of running a generation loop (#1207).
- DeepSeek-OCR couldn't load the released weights (#1208), its preprocessing was a placeholder that fed the wrong-sized image into the encoder (#1209), its decode loop discarded each step's logits and repeated the first token 128 times (#1210), and its MoE gate swapped topk indices and weights (#1211).

Fixes #1206, fixes #1207, fixes #1208, fixes #1209, fixes #1210, fixes #1211.

## Solution

- Hunyuan-OCR: build the chat-template prompt with the image tokens, merge the vision features at the matching positions, and run a real greedy decode loop that stops on EOS.
- DeepSeek-OCR: load the checkpoint as it ships (the right vision tower, its actual tensor names), implement the reference preprocessing (pad to 1024, normalize, the 273-token image layout), feed each step's logits back at the token's position, and fix the MoE gate's topk order.

## Validation

Run on a RunPod A100 host (Rust 1.95, CUDA 12.x) against the real released checkpoints, downloaded from HuggingFace (`tencent/HunyuanOCR`, `deepseek-ai/DeepSeek-OCR`). The original failures were reproduced with these same commands before any code changed.

```
XBERG_HUNYUAN_OCR_MODEL_PATH=... cargo test -p xberg-candle-ocr --release \
  --features "hunyuan-ocr,cuda" --test hunyuan_ocr_integration -- --ignored --nocapture

XBERG_DEEPSEEK_OCR_MODEL_PATH=... cargo test -p xberg-candle-ocr --release \
  --features "deepseek-ocr,cuda" --test deepseek_ocr_integration -- --ignored --nocapture
```

The tests run the real weights end to end (no mocks) through image decode, preprocessing, the vision towers, projector, language model, and generation.

| Test | Result | Output |
|---|---|---|
| unit tests (34) | ok | includes new contract tests for the fixed helpers |
| Hunyuan-OCR e2e | ok, 20.35s | "Hello World" (the single-token engine could only say "Hello") |
| DeepSeek-OCR e2e | ok, 47.61s | "Hello World", repeat_run=0 (was "Hello" repeated 128 times in 360s) |

Both models read the complete fixture text and stop at EOS.

The fixes come from references, not guesswork: DeepSeek's preprocessing constants are from its released modeling code, the Hunyuan prompt from the model's own chat template, and both decode loops mirror the reference generation loop. New unit tests pin the contracts the fixes depend on (rel-pos gather shape, batched masked scatter, topk return order, the prompt builder's image token).
