### PR TITLE
fix: extraction-engine audit fixes (#1223) — redaction, tables, encoding, config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,15 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
   width — scanned pages with vertical OCR layers, typeset tategaki books. The panic guard kept
   extraction alive, but the affected page came back as a per-page error with its text lost.
   pdf_oxide 0.3.73 fixes the sort, so those pages now extract normally.
+- **Bordered tables with stroke-width-rendered rules are detected (#1213).** Some
+  print-era PDF generators draw a vertical table rule as a ~1pt segment stroked with a line
+  width equal to the table height, so the rule's geometric bounding box is a speck and the
+  Lines-strategy detector saw no vertical rulings — whole fuse-chart-style tables were missed
+  (their only detected "table" being a false-positive page footer) and their text flowed out
+  column-major, destroying row associations. Table detection now expands such stroke-width-encoded
+  rules to their rendered geometry before filtering, so these grids are detected with rows
+  intact. Expansion applies only to paths with no usable geometric extent of their own, so
+  documents that don't use this drawing trick extract identically.
 
 ## [1.0.0-rc.1] - 2026-06-26
 

--- a/crates/xberg/src/pdf/oxide/table.rs
+++ b/crates/xberg/src/pdf/oxide/table.rs
@@ -56,11 +56,14 @@ const PRIMITIVE_GEOMETRY_FLOOR: f32 = 5.0;
 /// 0×507pt/7.2pt column rules in pdfplumber's la-precinct fixture — is
 /// already a valid primitive and must keep its geometric bbox).
 fn expand_hairline_stroke(path: &mut pdf_oxide::elements::PathContent) {
-    if path.stroke_color.is_none() || path.stroke_width <= PRIMITIVE_GEOMETRY_FLOOR {
+    if path.stroke_color.is_none() || !path.stroke_width.is_finite() || path.stroke_width <= PRIMITIVE_GEOMETRY_FLOOR {
         return;
     }
     let width = path.bbox.width.abs();
     let height = path.bbox.height.abs();
+    if !(width.is_finite() && height.is_finite()) {
+        return; // degenerate glyph geometry (see #1198): don't grow NaN boxes
+    }
     if width.max(height) > PRIMITIVE_GEOMETRY_FLOOR {
         return; // real geometric extent: the detector already sees this path
     }
@@ -654,7 +657,10 @@ mod tests {
         assert_eq!(path.bbox.width, 1.0);
         assert_eq!(path.bbox.height, 430.0);
         assert_eq!(path.bbox.y, 402.0 - 215.0);
-        assert!(path.is_table_primitive(), "expanded rule must classify as a table primitive");
+        assert!(
+            path.is_table_primitive(),
+            "expanded rule must classify as a table primitive"
+        );
     }
 
     /// The mirrored trick — a short vertical segment with a huge stroke width —
@@ -694,6 +700,21 @@ mod tests {
             "long stroked rules keep their geometric bbox"
         );
         assert!(path.is_table_primitive(), "still a primitive on geometry alone");
+    }
+
+    /// Non-finite geometry or stroke width (NaN glyph pathology, #1198) must
+    /// never be expanded — growing a NaN bbox propagates NaN into the
+    /// detector's sort keys.
+    #[test]
+    fn expand_hairline_stroke_skips_non_finite_geometry() {
+        let mut nan_box = stroked_line(10.0, 10.0, f32::NAN, 0.0, 430.0);
+        expand_hairline_stroke(&mut nan_box);
+        assert!(nan_box.bbox.width.is_nan(), "bbox untouched");
+        assert_eq!(nan_box.bbox.height, 0.0, "bbox untouched");
+
+        let mut nan_stroke = stroked_line(10.0, 10.0, 1.0, 0.0, f32::NAN);
+        expand_hairline_stroke(&mut nan_stroke);
+        assert_eq!((nan_stroke.bbox.width, nan_stroke.bbox.height), (1.0, 0.0));
     }
 
     /// Non-line-like shapes (both dimensions above hairline) and unstroked

--- a/crates/xberg/src/pdf/oxide/table.rs
+++ b/crates/xberg/src/pdf/oxide/table.rs
@@ -2,8 +2,9 @@
 //!
 //! Three entry points:
 //!
-//! - [`extract_tables_native`] — pdf_oxide's built-in `extract_tables_with_config`
-//!   in strict mode. High precision, requires explicit table grid with 3+ columns.
+//! - [`extract_tables_native`] — pdf_oxide's spatial detector in strict mode
+//!   (via the stroke-aware wrapper [`extract_tables_stroke_aware`]). High
+//!   precision, requires explicit table grid with 3+ columns.
 //! - [`extract_tables_bordered`] — relaxed Lines-strategy pass for bordered tables
 //!   with 2+ columns. Catches 2-column data tables (label/value) whose cells are
 //!   delimited by stroke lines that `strict()` skips due to `min_table_columns=3`.
@@ -28,6 +29,102 @@ use std::collections::HashSet;
 /// the validation chain is fast.
 const MAX_REGIONS_PER_PAGE: usize = 20;
 
+/// Geometry floor of `PathContent::is_table_primitive`: both its thin-line
+/// branches require the long dimension to exceed 5pt, and its box branch
+/// requires both dimensions to. A path whose longest dimension is at or below
+/// this can never register as a table primitive on geometry alone — its only
+/// possible rendered extent lives in the stroke width.
+const PRIMITIVE_GEOMETRY_FLOOR: f32 = 5.0;
+
+/// Expand a stroke-width-encoded rule's bounding box to its rendered geometry.
+///
+/// Some print-era PDF generators draw vertical table rules as a ~1pt
+/// horizontal segment stroked with a line width equal to the table height
+/// (`430 w` + `0 0 m 1 0 l S` renders as a 1×430pt vertical bar). pdf_oxide's
+/// `bbox` covers the path geometry only, so such a rule is a 1×0pt speck that
+/// fails `is_table_primitive` — the Lines-strategy detector then sees no
+/// vertical rulings and misses the whole table (xberg-io/xberg#1213).
+///
+/// Stroking widens a segment by half the line width on each side
+/// perpendicular to its direction; mirror that on the minor axis so the
+/// detector sees what the reader sees. Expansion is deliberately limited to
+/// geometric *specks* — paths whose longest dimension is under the
+/// [`PRIMITIVE_GEOMETRY_FLOOR`] and which therefore can never pass the
+/// primitive filter on geometry. Such paths contribute nothing to detection
+/// today, so expanding them can only add rulings, never perturb a grid that
+/// already works (a long thin separator with a thick stroke — e.g. the
+/// 0×507pt/7.2pt column rules in pdfplumber's la-precinct fixture — is
+/// already a valid primitive and must keep its geometric bbox).
+fn expand_hairline_stroke(path: &mut pdf_oxide::elements::PathContent) {
+    if path.stroke_color.is_none() || path.stroke_width <= PRIMITIVE_GEOMETRY_FLOOR {
+        return;
+    }
+    let width = path.bbox.width.abs();
+    let height = path.bbox.height.abs();
+    if width.max(height) > PRIMITIVE_GEOMETRY_FLOOR {
+        return; // real geometric extent: the detector already sees this path
+    }
+    let stroke = path.stroke_width;
+    if height <= width {
+        // Horizontal-ish segment: the stroke extends above and below.
+        path.bbox.y -= stroke / 2.0;
+        path.bbox.height += stroke;
+    } else {
+        // Vertical-ish segment: the stroke extends left and right.
+        path.bbox.x -= stroke / 2.0;
+        path.bbox.width += stroke;
+    }
+}
+
+/// Detect tables on one page with stroke-rendered rule geometry.
+///
+/// Mirrors `pdf_oxide::PdfDocument::extract_tables_with_config` (words →
+/// spans, paths → table primitives → `detect_tables_with_lines`), inserting
+/// [`expand_hairline_stroke`] between path extraction and the
+/// `is_table_primitive` filter so stroke-width-rendered rules survive it.
+fn extract_tables_stroke_aware(
+    doc: &pdf_oxide::PdfDocument,
+    page_idx: usize,
+    config: &pdf_oxide::structure::spatial_table_detector::TableDetectionConfig,
+) -> std::result::Result<Vec<pdf_oxide::structure::table_extractor::Table>, pdf_oxide::Error> {
+    use pdf_oxide::layout::{FontWeight, TextSpan};
+    use pdf_oxide::structure::spatial_table_detector::detect_tables_with_lines;
+
+    let words = doc.extract_words(page_idx)?;
+    let lines: Vec<_> = doc
+        .extract_paths(page_idx)?
+        .into_iter()
+        .map(|mut p| {
+            expand_hairline_stroke(&mut p);
+            p
+        })
+        .filter(|p| p.is_table_primitive())
+        .collect();
+
+    // Word → TextSpan conversion matching extract_tables_with_config: words
+    // (not spans) so space-separated strings split into their own columns.
+    let spans: Vec<TextSpan> = words
+        .into_iter()
+        .map(|w| TextSpan {
+            text: w.text,
+            bbox: w.bbox,
+            font_name: w.dominant_font,
+            font_size: w.avg_font_size,
+            font_weight: if w.is_bold {
+                FontWeight::Bold
+            } else {
+                FontWeight::Normal
+            },
+            is_italic: w.is_italic,
+            mcid: w.mcid,
+            horizontal_scaling: 1.0,
+            ..TextSpan::default()
+        })
+        .collect();
+
+    Ok(detect_tables_with_lines(&spans, &lines, config))
+}
+
 /// Extract tables from all pages using pdf_oxide's native table detection.
 ///
 /// Uses `TableDetectionConfig::strict()` to reduce false positives from
@@ -50,7 +147,7 @@ pub(crate) fn extract_tables_native(doc: &mut OxideDocument) -> Result<Vec<Table
     let mut all_tables = Vec::new();
 
     for page_idx in 0..page_count {
-        let extracted = match doc.doc.extract_tables_with_config(page_idx, config.clone()) {
+        let extracted = match extract_tables_stroke_aware(&doc.doc, page_idx, &config) {
             Ok(tables) => tables,
             Err(e) => {
                 tracing::warn!(page = page_idx, "pdf_oxide extract_tables failed: {e}");
@@ -151,7 +248,7 @@ pub(crate) fn extract_tables_bordered(doc: &mut OxideDocument, skip_pages: &Hash
             continue;
         }
 
-        let extracted = match doc.doc.extract_tables_with_config(page_idx, config.clone()) {
+        let extracted = match extract_tables_stroke_aware(&doc.doc, page_idx, &config) {
             Ok(tables) => tables,
             Err(e) => {
                 tracing::warn!(page = page_idx, "pdf_oxide bordered extract_tables failed: {e}");
@@ -540,6 +637,82 @@ fn convert_extracted_table(table: &pdf_oxide::structure::table_extractor::Table)
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn stroked_line(x: f32, y: f32, w: f32, h: f32, stroke_width: f32) -> pdf_oxide::elements::PathContent {
+        let mut path = pdf_oxide::elements::PathContent::new(pdf_oxide::geometry::Rect::new(x, y, w, h));
+        path.stroke_color = Some(pdf_oxide::layout::Color::black());
+        path.stroke_width = stroke_width;
+        path
+    }
+
+    /// A ~1pt horizontal segment with a table-height stroke width must expand
+    /// vertically into a full-height bar (the #1213 vertical-rule pattern).
+    #[test]
+    fn expand_hairline_stroke_expands_horizontal_speck_vertically() {
+        let mut path = stroked_line(236.0, 402.0, 1.0, 0.0, 430.0);
+        expand_hairline_stroke(&mut path);
+        assert_eq!(path.bbox.width, 1.0);
+        assert_eq!(path.bbox.height, 430.0);
+        assert_eq!(path.bbox.y, 402.0 - 215.0);
+        assert!(path.is_table_primitive(), "expanded rule must classify as a table primitive");
+    }
+
+    /// The mirrored trick — a short vertical segment with a huge stroke width —
+    /// must expand horizontally.
+    #[test]
+    fn expand_hairline_stroke_expands_vertical_speck_horizontally() {
+        let mut path = stroked_line(100.0, 300.0, 0.0, 1.0, 322.0);
+        expand_hairline_stroke(&mut path);
+        assert_eq!(path.bbox.height, 1.0);
+        assert_eq!(path.bbox.width, 322.0);
+        assert_eq!(path.bbox.x, 100.0 - 161.0);
+        assert!(path.is_table_primitive());
+    }
+
+    /// Ordinary hairline rules (stroke ≤ 5pt) must pass through unchanged —
+    /// this is every normal ruled table in the wild.
+    #[test]
+    fn expand_hairline_stroke_leaves_ordinary_rules_alone() {
+        let mut path = stroked_line(50.0, 700.0, 322.0, 0.0, 1.0);
+        expand_hairline_stroke(&mut path);
+        assert_eq!((path.bbox.width, path.bbox.height, path.bbox.y), (322.0, 0.0, 700.0));
+    }
+
+    /// A rule with real geometric extent must keep its bbox even when its
+    /// stroke is thick: it is already a valid primitive, and widening it
+    /// perturbs a grid that already works. Regression test for the
+    /// la-precinct fixture (0×507pt column separators stroked 7.2pt wide),
+    /// where expansion flipped a correctly detected 47-row results table
+    /// into a false-positive header table.
+    #[test]
+    fn expand_hairline_stroke_leaves_long_thick_stroked_rules_alone() {
+        let mut path = stroked_line(212.4, 28.8, 0.0, 507.6, 7.2);
+        expand_hairline_stroke(&mut path);
+        assert_eq!(
+            (path.bbox.x, path.bbox.width, path.bbox.height),
+            (212.4, 0.0, 507.6),
+            "long stroked rules keep their geometric bbox"
+        );
+        assert!(path.is_table_primitive(), "still a primitive on geometry alone");
+    }
+
+    /// Non-line-like shapes (both dimensions above hairline) and unstroked
+    /// paths must pass through unchanged regardless of stroke width.
+    #[test]
+    fn expand_hairline_stroke_leaves_boxes_and_fills_alone() {
+        let mut boxy = stroked_line(50.0, 550.0, 350.0, 200.0, 8.0);
+        expand_hairline_stroke(&mut boxy);
+        assert_eq!((boxy.bbox.width, boxy.bbox.height), (350.0, 200.0));
+
+        // Fill-only path (the extractor sets stroke_color: None for `f`-painted
+        // paths): stroke width is inert without a stroke.
+        let mut filled = pdf_oxide::elements::PathContent::new(pdf_oxide::geometry::Rect::new(0.0, 0.0, 1.0, 0.0));
+        filled.stroke_color = None;
+        filled.fill_color = Some(pdf_oxide::layout::Color::black());
+        filled.stroke_width = 430.0;
+        expand_hairline_stroke(&mut filled);
+        assert_eq!((filled.bbox.width, filled.bbox.height), (1.0, 0.0));
+    }
 
     #[test]
     fn test_convert_extracted_table_basic() {
@@ -1059,6 +1232,85 @@ mod tests {
         assert!(
             tables.is_empty(),
             "skip_pages={{1}} must suppress the only page; got: {tables:?}"
+        );
+    }
+
+    /// Build a 3-column bordered table whose vertical rules are drawn the way
+    /// some print-era PDF generators emit them: a ~1pt horizontal segment
+    /// stroked with a line width equal to the table height, which renders as a
+    /// full-height vertical bar. Geometrically the path is a speck (bbox
+    /// 1×0pt), so a stroke-unaware reader sees no vertical rulings at all.
+    /// Mirrors the fuse-chart tables in xberg-io/xberg#1213.
+    fn build_stroke_width_vertical_rules_table_pdf() -> Vec<u8> {
+        use pdf_oxide::geometry::Rect;
+        use pdf_oxide::writer::{DocumentBuilder, LineStyle, TextAlign};
+
+        let thin = LineStyle::new(1.0, 0.0, 0.0, 0.0);
+        // Table: x=50..400, y=510..750 (PDF y-up), 6 rows of 40pt.
+        // Column edges at x = 50, 150, 250, 400.
+        let rows: [[&str; 3]; 6] = [
+            ["Location", "Rating", "Circuit"],
+            ["6", "15A*", "Alternator regulator"],
+            ["7", "30A*", "PCM relay feed"],
+            ["11", "15A*", "A/C clutch relay feed"],
+            ["24", "10A*", "Heated mirrors"],
+            ["101", "40A**", "Blower relay feed"],
+        ];
+
+        let mut doc = DocumentBuilder::new();
+        let mut page = doc.a4_page();
+        // Horizontal rules: ordinary 1pt strokes at every row boundary.
+        for i in 0..=6u32 {
+            let y = 510.0 + 40.0 * i as f32;
+            page = page.stroke_line(50.0, y, 400.0, y, thin.clone());
+        }
+        // Vertical rules: 1pt-long horizontal segments at the table's vertical
+        // midpoint, stroked with the full table height (240pt).
+        for x in [50.0_f32, 150.0, 250.0, 400.0] {
+            page = page.stroke_line(x - 0.5, 630.0, x + 0.5, 630.0, LineStyle::new(240.0, 0.0, 0.0, 0.0));
+        }
+        // Cell text, top row first (row i occupies y = 750-40*(i+1) .. 750-40*i).
+        let col_x = [50.0_f32, 150.0, 250.0];
+        let col_w = [100.0_f32, 100.0, 150.0];
+        for (i, row) in rows.iter().enumerate() {
+            let y = 750.0 - 40.0 * (i as f32 + 1.0);
+            for (c, text) in row.iter().enumerate() {
+                page = page.text_in_rect(Rect::new(col_x[c], y, col_w[c], 40.0), text, TextAlign::Left);
+            }
+        }
+        page.done();
+        doc.build().expect("DocumentBuilder must produce valid PDF bytes")
+    }
+
+    /// A 3-column grid whose vertical rules are stroke-width-rendered must be
+    /// detected by `extract_tables_native` (strict tier) with its rows intact.
+    /// Regression test for xberg-io/xberg#1213: previously the vertical rules'
+    /// geometry-only bboxes (1×0pt) failed `is_table_primitive`, the detector
+    /// saw no vertical rulings, and the table text flowed out column-major.
+    #[test]
+    fn extract_tables_native_detects_stroke_width_vertical_rules_table() {
+        let bytes = build_stroke_width_vertical_rules_table_pdf();
+        let mut doc = OxideDocument::open_bytes(&bytes).expect("open synthetic PDF");
+        let tables = extract_tables_native(&mut doc).expect("extract_tables_native must not error");
+        assert!(
+            !tables.is_empty(),
+            "extract_tables_native must detect the stroke-width-ruled 3-column table"
+        );
+        let table = &tables[0];
+        assert_eq!(table.page_number, 1);
+        assert!(
+            table.cells.iter().all(|row| row.len() == 3),
+            "all rows must have 3 columns; rows: {:?}",
+            table.cells.iter().map(|r| r.len()).collect::<Vec<_>>()
+        );
+        let fuse_row: Vec<&str> = vec!["101", "40A**", "Blower relay feed"];
+        assert!(
+            table
+                .cells
+                .iter()
+                .any(|row| row.iter().map(String::as_str).collect::<Vec<_>>() == fuse_row),
+            "row association must survive: expected a row {fuse_row:?}; got cells: {:?}",
+            table.cells
         );
     }
 }

--- a/crates/xberg/tests/pdf_heuristic_tables.rs
+++ b/crates/xberg/tests/pdf_heuristic_tables.rs
@@ -157,3 +157,73 @@ fn test_bordered_two_column_table_detected_via_pipeline() {
         "table must produce non-empty markdown"
     );
 }
+
+/// Integration test for xberg-io/xberg#1213: a 3-column grid whose vertical
+/// rules are drawn as ~1pt segments stroked with a table-height line width
+/// (the rendered geometry is a full-height vertical bar, but the path's
+/// geometric bounding box is a speck). The native tier must detect it through
+/// the full public API path with row associations intact, and the heuristic
+/// tier must not add competing tables on that page.
+#[test]
+fn test_stroke_width_vertical_rules_table_detected_via_pipeline() {
+    use pdf_oxide::geometry::Rect;
+    use pdf_oxide::writer::{DocumentBuilder, LineStyle, TextAlign};
+
+    let thin = LineStyle::new(1.0, 0.0, 0.0, 0.0);
+    let rows: [[&str; 3]; 6] = [
+        ["Location", "Rating", "Circuit"],
+        ["6", "15A*", "Alternator regulator"],
+        ["7", "30A*", "PCM relay feed"],
+        ["11", "15A*", "A/C clutch relay feed"],
+        ["24", "10A*", "Heated mirrors"],
+        ["101", "40A**", "Blower relay feed"],
+    ];
+
+    let mut doc = DocumentBuilder::new();
+    let mut page = doc.a4_page();
+    // Horizontal rules: ordinary 1pt strokes at every row boundary.
+    for i in 0..=6u32 {
+        let y = 510.0 + 40.0 * i as f32;
+        page = page.stroke_line(50.0, y, 400.0, y, thin.clone());
+    }
+    // Vertical rules: 1pt-long horizontal segments at the table's vertical
+    // midpoint, stroked with the full table height (240pt).
+    for x in [50.0_f32, 150.0, 250.0, 400.0] {
+        page = page.stroke_line(x - 0.5, 630.0, x + 0.5, 630.0, LineStyle::new(240.0, 0.0, 0.0, 0.0));
+    }
+    let col_x = [50.0_f32, 150.0, 250.0];
+    let col_w = [100.0_f32, 100.0, 150.0];
+    for (i, row) in rows.iter().enumerate() {
+        let y = 750.0 - 40.0 * (i as f32 + 1.0);
+        for (c, text) in row.iter().enumerate() {
+            page = page.text_in_rect(Rect::new(col_x[c], y, col_w[c], 40.0), text, TextAlign::Left);
+        }
+    }
+    page.done();
+    let bytes = doc.build().expect("build synthetic PDF");
+
+    let config = ExtractionConfig::default();
+    let result = extract_bytes_document_blocking(&bytes, PDF_MIME, &config).expect("extraction must succeed");
+
+    assert_eq!(
+        result.tables.len(),
+        1,
+        "pipeline must detect exactly the stroke-width-ruled table (no heuristic duplicates); got: {:?}",
+        result.tables.iter().map(|t| &t.markdown).collect::<Vec<_>>()
+    );
+    let table = &result.tables[0];
+    assert!(
+        table.cells.iter().all(|row| row.len() == 3),
+        "all rows must have 3 columns; got: {:?}",
+        table.cells.iter().map(|r| r.len()).collect::<Vec<_>>()
+    );
+    let fuse_row = ["101", "40A**", "Blower relay feed"];
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|row| row.iter().map(String::as_str).eq(fuse_row)),
+        "row association must survive extraction; got cells: {:?}",
+        table.cells
+    );
+}


### PR DESCRIPTION
Implements fixes for the extraction-engine audit in #1223. Landing as a sequence of focused, individually-tested commits on one branch, each with a failing-test-first reproduction and (for table/extraction changes) a corpus A/B check against `main`.

## Landed

- **Stroke-width-encoded table rules are detected.** Print-era generators draw a table's vertical rules as a tiny stroked segment whose line width equals the table height — geometrically a speck, but it renders as a full-height bar. Detection only looked at path geometry, so these tables had no detectable vertical rulings and their text poured out column by column. Detection now accounts for stroke-rendered geometry when a path has no usable geometric extent of its own. Byte-identical on all 310 corpus PDFs against `main`; an earlier broader version that disturbed a pdfplumber fixture was caught by the sweep and turned into a regression test.
- **Redaction masks every output field, not just `content`.** Redaction rewrote ~7 fields and left ~12 serialized text fields (page content, table cells, elements, URIs, form-field values, image captions, metadata, `structured_output`, …) carrying the original PII while the report claimed success. An exhaustive field walk now masks every text surface of `ExtractedDocument`, recursing into image OCR sub-documents and `structured_output`/`code_intelligence` JSON. Covered by a test that plants the same email in a table cell, page, URI, form field, metadata, and structured output and asserts none survive.
- **Language detection honors `min_confidence` and is deterministic.** Multi-language mode capped the caller's threshold at 0.35 (so a request for high-confidence detection still admitted 0.35 chunks) and ordered equal-frequency languages by HashMap iteration, so the primary language flipped between runs. Both fixed.

## In progress

The remaining root-cause fixes from #1223 land as further commits here: one span-aware grid→rows helper for merged cells across HTML/DOCX/PPTX/XLSX (also closes #1212's DOCX table bugs), a central charset-detection entry point, a pipeline rule against content mutation after chunking, `PdfConfig.passwords` plumbing, effective-config cache keys, and error-not-silence for OCR/archive paths. Findings that need runtime fixtures (OCR backends, embedding models, binary Office docs) get committed fixtures + tests in the same PR.

The running-footer suppression from the first draft is held: the corpus sweep showed its repetition key collides on digit-varying repeated paragraphs (a federal-register fixture), so it is being rebuilt with an exact-match + margin-band gate before re-landing.

## Upstream (pdf_oxide)

Three findings root-cause to the pdf_oxide backend and are filed there; this PR works around them where possible and will adopt the upstream fixes when released:
- yfedoseev/pdf_oxide#811 — words split inside single string literals ("module" → "m odu le").
- yfedoseev/pdf_oxide#812 — path bounding boxes ignore stroke width (the root cause of the stroke-width table miss above).
- yfedoseev/pdf_oxide#813 — rotated pages extract in portrait order with no rotation metadata on words.

Each change ships with unit and full-pipeline integration tests plus, for extraction changes, the corpus A/B check that already caught two bad iterations.
