### PR TITLE
fix: cap hf-hub model downloads with a wall-clock watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
 
 ## [Unreleased]
 
+### Fixed
+
+- **Model downloads can no longer hang the extraction pipeline on a blocked network.** hf-hub
+  builds its ureq agent with no read/connect timeout, so a firewalled or stalled HuggingFace
+  connection made the blocking `ApiRepo::get()` block forever — wedging the whole pipeline at 0%
+  CPU with no error. Every model-file fetch (embeddings, reranker, transcription, PaddleOCR/layout
+  managers, and the Candle TrOCR / GLM-OCR backends) now runs under a wall-clock watchdog: on
+  expiry it logs a warning and returns an error so the caller degrades (skips the model-backed
+  backend) instead of hanging. Default ceiling 300s; override with
+  `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS`.
+
 ### Added
 
 - **Bring your own tokenizer for token-budgeted chunking.** Register a `TokenizerBackend`

--- a/crates/xberg-candle-ocr/src/download_guard.rs
+++ b/crates/xberg-candle-ocr/src/download_guard.rs
@@ -1,0 +1,113 @@
+//! Wall-clock watchdog for blocking HuggingFace model downloads.
+//!
+//! This is a self-contained copy of the guard in the `xberg` crate's `model_download` module.
+//! `xberg-candle-ocr` is a leaf crate that `xberg` depends on, so it cannot reach back into that
+//! module; the helper is small and dependency-free, so duplicating it here is cheaper than
+//! inverting the dependency. Keep the two copies in sync (same env var, same tracing target).
+
+use std::time::Duration;
+
+/// Default wall-clock ceiling for a single model-file download. hf-hub builds its ureq agent with
+/// no read/connect timeout, so a stalled or firewalled connection to HuggingFace makes the blocking
+/// `ApiRepo::get()` hang forever — silently wedging the whole extraction pipeline (observed: OCR /
+/// embedding model pulls parked at 0% CPU behind a host firewall). We cap each fetch so a dead
+/// network fails fast and the caller can degrade. Generous by default because a cold GB-scale model
+/// legitimately takes minutes; override with `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS`.
+const DEFAULT_MODEL_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Resolve the model-download deadline, honoring `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS` (seconds; a
+/// value of 0 or unparseable falls back to the default).
+pub(crate) fn model_download_timeout() -> Duration {
+    std::env::var("XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_MODEL_DOWNLOAD_TIMEOUT)
+}
+
+/// Run a blocking model-download closure under a hard wall-clock deadline so a hung network cannot
+/// block the pipeline indefinitely. The closure runs on a detached worker thread; if it does not
+/// finish within `model_download_timeout()` we log a warning and return `Err`, letting the caller
+/// degrade (skip the model-backed backend) rather than hang. The worker thread cannot be
+/// force-killed — it stays parked on the socket until the OS tears the connection down — but it
+/// holds no lock the pipeline needs, so progress resumes. `label` names the fetch in the log/error.
+pub(crate) fn with_download_deadline<T, F>(label: &str, f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    let deadline = model_download_timeout();
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Result<T, String>>(1);
+    std::thread::Builder::new()
+        .name("xberg-model-download".into())
+        .spawn(move || {
+            let _ = tx.send(f());
+        })
+        .map_err(|e| format!("failed to spawn model-download thread: {e}"))?;
+    match rx.recv_timeout(deadline) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                target: "xberg::model_download",
+                label = %label,
+                timeout_secs = deadline.as_secs(),
+                "model download exceeded deadline (network unreachable / firewalled?); aborting so \
+                 the extraction pipeline does not hang. Set XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS to adjust."
+            );
+            Err(format!(
+                "model download '{label}' timed out after {}s (HuggingFace unreachable?)",
+                deadline.as_secs()
+            ))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(format!("model-download thread for '{label}' died unexpectedly"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn with_download_deadline_returns_ok_for_fast_closure() {
+        let result = with_download_deadline("fast", || Ok::<i32, String>(7));
+        assert_eq!(result, Ok(7), "fast closure must return its Ok value verbatim");
+    }
+
+    #[test]
+    fn deadline_reads_env_override_and_aborts_a_hung_closure() {
+        // SAFETY: env mutation in the 2024 edition is unsafe; this var is exclusive to these tests
+        // and only read at call time, so the set/read/remove sequence here has no observer to race.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS", "1");
+        }
+        assert_eq!(
+            model_download_timeout(),
+            Duration::from_secs(1),
+            "explicit override must win"
+        );
+
+        let started = Instant::now();
+        let result = with_download_deadline("hung", || {
+            std::thread::sleep(Duration::from_secs(10));
+            Ok::<(), String>(())
+        });
+        let elapsed = started.elapsed();
+        // SAFETY: restore process state so sibling tests see the default (same reasoning as above).
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS");
+        }
+
+        let err = result.expect_err("a closure that outlives the deadline must return Err");
+        assert!(err.contains("timed out"), "error must mention the timeout, got: {err}");
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "guard must fire near the 1s deadline, not wait out the 10s sleep (took {elapsed:?})"
+        );
+    }
+}

--- a/crates/xberg-candle-ocr/src/lib.rs
+++ b/crates/xberg-candle-ocr/src/lib.rs
@@ -22,6 +22,10 @@
 #![allow(clippy::too_many_arguments)]
 
 pub mod device;
+// Wall-clock watchdog for hf-hub `.get()` downloads. Only compiled for the model backends that
+// actually fetch weights from HuggingFace, so a default (no-model) build stays warning-clean.
+#[cfg(any(feature = "trocr", feature = "glm-ocr"))]
+pub(crate) mod download_guard;
 pub mod error;
 pub mod models;
 pub(crate) mod vendor;

--- a/crates/xberg-candle-ocr/src/models/glm_ocr/mod.rs
+++ b/crates/xberg-candle-ocr/src/models/glm_ocr/mod.rs
@@ -218,16 +218,25 @@ mod engine {
             let api = hf_hub::api::sync::Api::new()
                 .map_err(|e| CandleOcrError::ModelLoadFailed(format!("HF API init: {}", e)))?;
 
-            let repo = api.repo(hf_hub::Repo::with_revision(
+            // `ApiRepo` is not `Clone` in hf-hub 0.4, but `Api` and `Repo` are, so keep the repo
+            // spec around and let each watchdog closure rebuild its `ApiRepo` via `api.repo(..)`.
+            let repo_spec = hf_hub::Repo::with_revision(
                 "zai-org/GLM-OCR".to_string(),
                 hf_hub::RepoType::Model,
                 "main".to_string(),
-            ));
+            );
 
+            // hf-hub sets no read/connect timeout, so a firewalled host would hang these blocking
+            // `.get()` calls forever. Run each under the wall-clock watchdog.
             // Load and parse config.json
-            let config_file = repo
-                .get("config.json")
-                .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to get config: {}", e)))?;
+            let config_file = {
+                let api = api.clone();
+                let repo_spec = repo_spec.clone();
+                crate::download_guard::with_download_deadline("zai-org/GLM-OCR/config.json", move || {
+                    api.repo(repo_spec).get("config.json").map_err(|e| e.to_string())
+                })
+            }
+            .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to get config: {}", e)))?;
             let config_str = std::fs::read_to_string(&config_file)
                 .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to read config: {}", e)))?;
             let config: GlmOcrConfig = serde_json::from_str(&config_str)
@@ -242,18 +251,42 @@ mod engine {
             // if/when fine-tunes ship divergent settings.
 
             // Load tokenizer
-            let tokenizer_file = repo
-                .get("tokenizer.json")
-                .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to get tokenizer: {}", e)))?;
+            let tokenizer_file = {
+                let api = api.clone();
+                let repo_spec = repo_spec.clone();
+                crate::download_guard::with_download_deadline("zai-org/GLM-OCR/tokenizer.json", move || {
+                    api.repo(repo_spec).get("tokenizer.json").map_err(|e| e.to_string())
+                })
+            }
+            .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to get tokenizer: {}", e)))?;
             let tokenizer = Tokenizer::from_file(&tokenizer_file)
                 .map_err(|e| CandleOcrError::Tokenizer(format!("Tokenizer load error: {}", e)))?;
 
             // Load model weights: try model.safetensors first, fall back to index if sharded
-            let model_files = match repo.get("model.safetensors") {
+            let single_weight = {
+                let api = api.clone();
+                let repo_spec = repo_spec.clone();
+                crate::download_guard::with_download_deadline("zai-org/GLM-OCR/model.safetensors", move || {
+                    api.repo(repo_spec).get("model.safetensors").map_err(|e| e.to_string())
+                })
+            };
+            let model_files = match single_weight {
                 Ok(f) => vec![f],
                 Err(_) => {
                     // Try loading sharded weights via index file
-                    let index_file = repo.get("model.safetensors.index.json").map_err(|e| {
+                    let index_file = {
+                        let api = api.clone();
+                        let repo_spec = repo_spec.clone();
+                        crate::download_guard::with_download_deadline(
+                            "zai-org/GLM-OCR/model.safetensors.index.json",
+                            move || {
+                                api.repo(repo_spec)
+                                    .get("model.safetensors.index.json")
+                                    .map_err(|e| e.to_string())
+                            },
+                        )
+                    }
+                    .map_err(|e| {
                         CandleOcrError::ModelLoadFailed(format!("Failed to get model.safetensors or index: {}", e))
                     })?;
 
@@ -278,7 +311,16 @@ mod engine {
                     // Download all shards
                     let mut result = Vec::new();
                     for filename in files {
-                        let shard_file = repo.get(&filename).map_err(|e| {
+                        let shard_file = {
+                            let api = api.clone();
+                            let repo_spec = repo_spec.clone();
+                            let shard = filename.clone();
+                            crate::download_guard::with_download_deadline(
+                                &format!("zai-org/GLM-OCR/{filename}"),
+                                move || api.repo(repo_spec).get(&shard).map_err(|e| e.to_string()),
+                            )
+                        }
+                        .map_err(|e| {
                             CandleOcrError::ModelLoadFailed(format!("Failed to get shard {}: {}", filename, e))
                         })?;
                         result.push(shard_file);

--- a/crates/xberg-candle-ocr/src/models/trocr.rs
+++ b/crates/xberg-candle-ocr/src/models/trocr.rs
@@ -148,8 +148,20 @@ impl TrocrEngine {
         let branch = variant.branch().to_string();
         let model_repo = hf_hub::Repo::with_revision(repo_id.clone(), RepoType::Model, branch.clone());
 
+        // hf-hub sets no read/connect timeout, so a firewalled host would hang these blocking
+        // `.get()` calls forever. Run each under the wall-clock watchdog. `ApiRepo` is not `Clone`
+        // in hf-hub 0.4, but `Api` and `Repo` are, so each closure rebuilds its repo via
+        // `api.repo(..)` inside from cheap clones.
+
         // Download model weights (~1.4GB for base variants)
-        let model_file = api.repo(model_repo.clone()).get("model.safetensors").map_err(|e| {
+        let model_file = {
+            let api = api.clone();
+            let model_repo = model_repo.clone();
+            crate::download_guard::with_download_deadline(&format!("{}/model.safetensors", repo_id), move || {
+                api.repo(model_repo).get("model.safetensors").map_err(|e| e.to_string())
+            })
+        }
+        .map_err(|e| {
             CandleOcrError::ModelLoadFailed(format!(
                 "Failed to download model weights for {} (branch {}): {}",
                 variant, branch, e
@@ -159,7 +171,14 @@ impl TrocrEngine {
         tracing::info!("Downloaded model weights to: {}", model_file.display());
 
         // Download and parse config.json to get both encoder and decoder configs
-        let config_file = api.repo(model_repo).get("config.json").map_err(|e| {
+        let config_file = {
+            let api = api.clone();
+            let model_repo = model_repo.clone();
+            crate::download_guard::with_download_deadline(&format!("{}/config.json", repo_id), move || {
+                api.repo(model_repo).get("config.json").map_err(|e| e.to_string())
+            })
+        }
+        .map_err(|e| {
             CandleOcrError::ModelLoadFailed(format!("Failed to download config.json for {}: {}", variant, e))
         })?;
 
@@ -191,9 +210,11 @@ impl TrocrEngine {
 
         // Download and load tokenizer from ToluClassics/candle-trocr-tokenizer
         let tokenizer_repo = api.model("ToluClassics/candle-trocr-tokenizer".to_string());
-        let tokenizer_file = tokenizer_repo
-            .get("tokenizer.json")
-            .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to download tokenizer: {}", e)))?;
+        let tokenizer_file = crate::download_guard::with_download_deadline(
+            "ToluClassics/candle-trocr-tokenizer/tokenizer.json",
+            move || tokenizer_repo.get("tokenizer.json").map_err(|e| e.to_string()),
+        )
+        .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to download tokenizer: {}", e)))?;
 
         let tokenizer = Tokenizer::from_file(&tokenizer_file)
             .map_err(|e| CandleOcrError::ModelLoadFailed(format!("Failed to load tokenizer: {}", e)))?;

--- a/crates/xberg/src/embeddings/mod.rs
+++ b/crates/xberg/src/embeddings/mod.rs
@@ -571,33 +571,71 @@ fn download_model_files(
         .build()
         .map_err(|e| crate::XbergError::embedding(format!("Failed to create HF API client: {e}")))?;
 
-    let repo = api.model(repo_name.to_string());
+    // Every fetch runs under the wall-clock watchdog: hf-hub sets no read/connect timeout, so a
+    // firewalled host would otherwise wedge the whole pipeline at 0% CPU. `ApiRepo` is not `Clone`
+    // in hf-hub 0.4, but `Api` is — so each closure captures a cheap `Api` clone and rebuilds its
+    // `ApiRepo` via `api.model(..)` inside. The `LockAcquisition` hint is computed inside the
+    // closure (where the typed `ApiError` is still available) and folded into the returned string;
+    // the outer map adds the "Failed to download …" framing.
+    let model_path = {
+        let api = api.clone();
+        let file = model_file.to_string();
+        let cache_dir = cache_directory.to_path_buf();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/{model_file}"), move || {
+            api.model(repo_name.clone()).get(&file).map_err(|e| {
+                let hint = if matches!(e, hf_hub::api::sync::ApiError::LockAcquisition(_)) {
+                    lock_acquisition_hint(&cache_dir, &repo_name)
+                } else {
+                    String::new()
+                };
+                format!("{e}{hint}")
+            })
+        })
+    }
+    .map_err(|e| crate::XbergError::embedding(format!("Failed to download {model_file}: {e}")))?;
 
-    let model_path = repo.get(model_file).map_err(|e| {
-        let hint = if matches!(e, hf_hub::api::sync::ApiError::LockAcquisition(_)) {
-            lock_acquisition_hint(cache_directory, repo_name)
-        } else {
-            String::new()
-        };
-        crate::XbergError::embedding(format!("Failed to download {model_file}: {e}{hint}"))
-    })?;
+    let tokenizer_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/tokenizer.json"), move || {
+            api.model(repo_name).get("tokenizer.json").map_err(|e| e.to_string())
+        })
+    }
+    .map_err(|e| crate::XbergError::embedding(format!("Failed to download tokenizer.json: {e}")))?;
 
-    let tokenizer_path = repo
-        .get("tokenizer.json")
-        .map_err(|e| crate::XbergError::embedding(format!("Failed to download tokenizer.json: {e}")))?;
+    let config_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/config.json"), move || {
+            api.model(repo_name).get("config.json").map_err(|e| e.to_string())
+        })
+    }
+    .map_err(|e| crate::XbergError::embedding(format!("Failed to download config.json: {e}")))?;
 
-    let config_path = repo
-        .get("config.json")
-        .map_err(|e| crate::XbergError::embedding(format!("Failed to download config.json: {e}")))?;
+    // These are optional — fall back to empty paths that load_tokenizer handles gracefully. Still
+    // wrapped in the deadline so a hang on an optional file cannot stall the pipeline either.
+    let special_tokens_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/special_tokens_map.json"), move || {
+            api.model(repo_name)
+                .get("special_tokens_map.json")
+                .map_err(|e| e.to_string())
+        })
+    }
+    .unwrap_or_else(|_| std::path::PathBuf::new());
 
-    // These are optional — fall back to empty paths that load_tokenizer handles gracefully
-    let special_tokens_path = repo
-        .get("special_tokens_map.json")
-        .unwrap_or_else(|_| std::path::PathBuf::new());
-
-    let tokenizer_config_path = repo
-        .get("tokenizer_config.json")
-        .unwrap_or_else(|_| std::path::PathBuf::new());
+    let tokenizer_config_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/tokenizer_config.json"), move || {
+            api.model(repo_name)
+                .get("tokenizer_config.json")
+                .map_err(|e| e.to_string())
+        })
+    }
+    .unwrap_or_else(|_| std::path::PathBuf::new());
 
     Ok((
         model_path,

--- a/crates/xberg/src/lib.rs
+++ b/crates/xberg/src/lib.rs
@@ -138,15 +138,11 @@ pub mod ocr;
 ))]
 pub mod ort_discovery;
 
-#[cfg(any(
-    feature = "paddle-ocr",
-    feature = "layout-detection",
-    feature = "auto-rotate",
-    feature = "ner-onnx",
-    // Only Hunyuan-OCR stages weights through model_download; other candle
-    // backends fetch via hf-hub directly or take a local model_path.
-    feature = "candle-hunyuan-ocr"
-))]
+// Always compiled: besides the checksummed model-manager helpers (feature-gated
+// inside the module), it hosts `with_download_deadline`, the network-agnostic
+// watchdog every hf-hub `.get()` site wraps itself in. That guard has no hf-hub
+// dependency and must be reachable from every download feature (embeddings,
+// reranker, transcription, …) without threading a shared cfg through each one.
 pub(crate) mod model_download;
 
 #[cfg(any(feature = "paddle-ocr", feature = "paddle-ocr-types"))]

--- a/crates/xberg/src/model_download.rs
+++ b/crates/xberg/src/model_download.rs
@@ -2,10 +2,37 @@
 //!
 //! Used by both layout detection and PaddleOCR model managers.
 
+use std::time::Duration;
+
+// `BufReader`/`Read`/`Path`/`sha2` back `verify_sha256`, which is only compiled for the
+// model-manager features that checksum their downloads. `PathBuf` is likewise only
+// referenced by the HF-download and cache-dir helpers. Gate the imports to those features
+// so an `embeddings`/`reranker`/`transcription`-only build (which reaches this module solely
+// for the always-compiled download watchdog below) stays warning-clean.
+#[cfg(any(
+    feature = "paddle-ocr",
+    feature = "layout-detection",
+    feature = "auto-rotate",
+    feature = "ner-onnx",
+    feature = "candle-hunyuan-ocr"
+))]
+use sha2::{Digest, Sha256};
+#[cfg(any(
+    feature = "paddle-ocr",
+    feature = "layout-detection",
+    feature = "auto-rotate",
+    feature = "ner-onnx",
+    feature = "candle-hunyuan-ocr"
+))]
 use std::io::{BufReader, Read};
+#[cfg(any(
+    feature = "paddle-ocr",
+    feature = "layout-detection",
+    feature = "auto-rotate",
+    feature = "ner-onnx",
+    feature = "candle-hunyuan-ocr"
+))]
 use std::path::Path;
-// `PathBuf` is only referenced by the HF-download and cache-dir helpers, which are
-// gated to the features that use them.
 #[cfg(any(
     feature = "paddle-ocr",
     feature = "layout-detection",
@@ -15,7 +42,70 @@ use std::path::Path;
 ))]
 use std::path::PathBuf;
 
-use sha2::{Digest, Sha256};
+/// Default wall-clock ceiling for a single model-file download. hf-hub builds its ureq agent with
+/// no read/connect timeout, so a stalled or firewalled connection to HuggingFace makes the blocking
+/// `ApiRepo::get()` hang forever — silently wedging the whole extraction pipeline (observed: OCR /
+/// embedding model pulls parked at 0% CPU behind a host firewall). We cap each fetch so a dead
+/// network fails fast and the caller can degrade. Generous by default because a cold GB-scale model
+/// legitimately takes minutes; override with `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS`.
+// dead_code: the watchdog is always compiled but only *called* from features that download models
+// (embeddings / reranker / transcription / the OCR + NER managers). A no-download-feature build
+// legitimately never reaches it; suppress the lint rather than fragment the guard behind a cfg.
+#[allow(dead_code)]
+const DEFAULT_MODEL_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Resolve the model-download deadline, honoring `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS` (seconds; a
+/// value of 0 or unparseable falls back to the default).
+#[allow(dead_code)] // see DEFAULT_MODEL_DOWNLOAD_TIMEOUT: called only from download-feature builds.
+pub(crate) fn model_download_timeout() -> Duration {
+    std::env::var("XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_MODEL_DOWNLOAD_TIMEOUT)
+}
+
+/// Run a blocking model-download closure under a hard wall-clock deadline so a hung network cannot
+/// block the pipeline indefinitely. The closure runs on a detached worker thread; if it does not
+/// finish within `model_download_timeout()` we log a warning and return `Err`, letting the caller
+/// degrade (skip the model-backed backend) rather than hang. The worker thread cannot be
+/// force-killed — it stays parked on the socket until the OS tears the connection down — but it
+/// holds no lock the pipeline needs, so progress resumes. `label` names the fetch in the log/error.
+#[allow(dead_code)] // see DEFAULT_MODEL_DOWNLOAD_TIMEOUT: called only from download-feature builds.
+pub(crate) fn with_download_deadline<T, F>(label: &str, f: F) -> Result<T, String>
+where
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    T: Send + 'static,
+{
+    let deadline = model_download_timeout();
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Result<T, String>>(1);
+    std::thread::Builder::new()
+        .name("xberg-model-download".into())
+        .spawn(move || {
+            let _ = tx.send(f());
+        })
+        .map_err(|e| format!("failed to spawn model-download thread: {e}"))?;
+    match rx.recv_timeout(deadline) {
+        Ok(result) => result,
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            tracing::warn!(
+                target: "xberg::model_download",
+                label = %label,
+                timeout_secs = deadline.as_secs(),
+                "model download exceeded deadline (network unreachable / firewalled?); aborting so \
+                 the extraction pipeline does not hang. Set XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS to adjust."
+            );
+            Err(format!(
+                "model download '{label}' timed out after {}s (HuggingFace unreachable?)",
+                deadline.as_secs()
+            ))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(format!("model-download thread for '{label}' died unexpectedly"))
+        }
+    }
+}
 
 /// Return the process-wide lock guarding downloads of a single `(repo, file)`.
 ///
@@ -69,10 +159,20 @@ pub(crate) fn hf_download(repo_id: &str, remote_filename: &str) -> Result<PathBu
         .build()
         .map_err(|e| format!("Failed to initialize HuggingFace Hub API: {e}"))?;
 
-    let repo = api.model(repo_id.to_string());
-    let cached_path = repo
-        .get(remote_filename)
-        .map_err(|e| format!("Failed to download '{remote_filename}' from {repo_id}: {e}"))?;
+    // Wrap the blocking fetch in the wall-clock watchdog so a firewalled HuggingFace host can no
+    // longer hang the extraction pipeline forever (hf-hub sets no read/connect timeout). `ApiRepo`
+    // is not `Clone` in hf-hub 0.4, but `Api` is, so the closure captures a cheap `Api` clone and
+    // rebuilds its `ApiRepo` via `api.model(..)` inside.
+    let cached_path = {
+        let api = api.clone();
+        let filename = remote_filename.to_string();
+        let repo_id = repo_id.to_string();
+        with_download_deadline(&format!("{repo_id}/{remote_filename}"), move || {
+            api.model(repo_id.clone())
+                .get(&filename)
+                .map_err(|e| format!("Failed to download '{filename}' from {repo_id}: {e}"))
+        })?
+    };
 
     Ok(cached_path)
 }
@@ -116,6 +216,13 @@ pub(crate) fn parse_sha256_manifest(content: &str) -> Result<Vec<(String, String
 ///
 /// Streams the file in 64 KiB chunks to avoid loading large model files (100MB+) entirely
 /// into memory. Returns `Ok(())` if the checksum matches or is empty (skip verification).
+#[cfg(any(
+    feature = "paddle-ocr",
+    feature = "layout-detection",
+    feature = "auto-rotate",
+    feature = "ner-onnx",
+    feature = "candle-hunyuan-ocr"
+))]
 pub(crate) fn verify_sha256(path: &Path, expected: &str, label: &str) -> Result<(), String> {
     if expected.is_empty() {
         return Ok(());
@@ -155,6 +262,62 @@ pub(crate) fn verify_sha256(path: &Path, expected: &str, label: &str) -> Result<
 #[cfg(feature = "layout-detection")]
 pub(crate) fn resolve_cache_dir(module: &str) -> PathBuf {
     crate::cache_dir::resolve_cache_dir(module)
+}
+
+/// Tests for the always-compiled download watchdog. Deliberately network-free: they exercise the
+/// deadline machinery with plain closures so the guard's behavior is provable in CI without any
+/// HuggingFace connectivity.
+#[cfg(test)]
+mod download_deadline_tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn with_download_deadline_returns_ok_for_fast_closure() {
+        // A closure that finishes well within the (default, generous) deadline must pass its
+        // value straight through untouched.
+        let result = with_download_deadline("fast", || Ok::<i32, String>(42));
+        assert_eq!(result, Ok(42), "fast closure must return its Ok value verbatim");
+    }
+
+    // The env var `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS` is process-global, so the two tests that
+    // mutate it are folded into one serial test rather than racing under the parallel runner.
+    #[test]
+    fn deadline_reads_env_override_and_aborts_a_hung_closure() {
+        // First: the override resolves as the exact configured ceiling.
+        // SAFETY: env mutation in the 2024 edition is unsafe; this var is exclusive to these tests
+        // and only read at call time, so the set/read/remove sequence here has no observer to race.
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::set_var("XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS", "1");
+        }
+        assert_eq!(
+            model_download_timeout(),
+            Duration::from_secs(1),
+            "explicit override must win"
+        );
+
+        // Second: simulate a wedged (firewalled) download — a closure that sleeps far past the
+        // 1s ceiling must be abandoned with Err("...timed out...") in ~1s, never the full sleep.
+        let started = Instant::now();
+        let result = with_download_deadline("hung", || {
+            std::thread::sleep(Duration::from_secs(10));
+            Ok::<(), String>(())
+        });
+        let elapsed = started.elapsed();
+        // SAFETY: restore process state so sibling tests see the default (same reasoning as above).
+        #[allow(unsafe_code)]
+        unsafe {
+            std::env::remove_var("XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS");
+        }
+
+        let err = result.expect_err("a closure that outlives the deadline must return Err");
+        assert!(err.contains("timed out"), "error must mention the timeout, got: {err}");
+        assert!(
+            elapsed < Duration::from_secs(3),
+            "guard must fire near the 1s deadline, not wait out the 10s sleep (took {elapsed:?})"
+        );
+    }
 }
 
 #[cfg(all(

--- a/crates/xberg/src/reranking/mod.rs
+++ b/crates/xberg/src/reranking/mod.rs
@@ -448,43 +448,90 @@ fn download_model_files(
         .build()
         .map_err(|e| crate::XbergError::reranking(format!("Failed to create HF API client: {e}")))?;
 
-    let repo = api.model(repo_name.to_string());
-
-    let model_path = repo.get(model_file).map_err(|e| {
-        let hint = if matches!(e, hf_hub::api::sync::ApiError::LockAcquisition(_)) {
-            lock_acquisition_hint(cache_directory, repo_name)
-        } else {
-            String::new()
-        };
-        crate::XbergError::reranking(format!("Failed to download {model_file} from {repo_name}: {e}{hint}"))
-    })?;
+    // Every fetch runs under the wall-clock watchdog: hf-hub sets no read/connect timeout, so a
+    // firewalled host would otherwise wedge the whole pipeline at 0% CPU. `ApiRepo` is not `Clone`
+    // in hf-hub 0.4, but `Api` is — so each closure captures a cheap `Api` clone and rebuilds its
+    // `ApiRepo` via `api.model(..)` inside. The `LockAcquisition` hint is computed inside the
+    // closure (typed `ApiError` still in scope) and folded into the returned string; the outer map
+    // adds the "Failed to download …" framing.
+    let model_path = {
+        let api = api.clone();
+        let file = model_file.to_string();
+        let cache_dir = cache_directory.to_path_buf();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/{model_file}"), move || {
+            api.model(repo_name.clone()).get(&file).map_err(|e| {
+                let hint = if matches!(e, hf_hub::api::sync::ApiError::LockAcquisition(_)) {
+                    lock_acquisition_hint(&cache_dir, &repo_name)
+                } else {
+                    String::new()
+                };
+                format!("{e}{hint}")
+            })
+        })
+    }
+    .map_err(|e| crate::XbergError::reranking(format!("Failed to download {model_file} from {repo_name}: {e}")))?;
 
     // Sibling files (e.g. `model.onnx.data`) must be present in the same cache
     // dir before ORT opens the model. hf-hub places them next to model_file
     // because they share the repo's blobs/snapshots layout.
     for sibling in additional_files {
-        repo.get(sibling).map_err(|e| {
+        let api = api.clone();
+        let repo_name_owned = repo_name.to_string();
+        let sibling_owned = sibling.clone();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/{sibling}"), move || {
+            api.model(repo_name_owned)
+                .get(&sibling_owned)
+                .map_err(|e| e.to_string())
+        })
+        .map_err(|e| {
             crate::XbergError::reranking(format!(
                 "Failed to download sibling file {sibling} from {repo_name}: {e}"
             ))
         })?;
     }
 
-    let tokenizer_path = repo
-        .get("tokenizer.json")
-        .map_err(|e| crate::XbergError::reranking(format!("Failed to download tokenizer.json: {e}")))?;
+    let tokenizer_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/tokenizer.json"), move || {
+            api.model(repo_name).get("tokenizer.json").map_err(|e| e.to_string())
+        })
+    }
+    .map_err(|e| crate::XbergError::reranking(format!("Failed to download tokenizer.json: {e}")))?;
 
-    let config_path = repo
-        .get("config.json")
-        .map_err(|e| crate::XbergError::reranking(format!("Failed to download config.json: {e}")))?;
+    let config_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/config.json"), move || {
+            api.model(repo_name).get("config.json").map_err(|e| e.to_string())
+        })
+    }
+    .map_err(|e| crate::XbergError::reranking(format!("Failed to download config.json: {e}")))?;
 
-    let special_tokens_path = repo
-        .get("special_tokens_map.json")
-        .unwrap_or_else(|_| std::path::PathBuf::new());
+    // Optional — fall back to empty paths, but still under the deadline so a hang on an optional
+    // file cannot stall the pipeline either.
+    let special_tokens_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/special_tokens_map.json"), move || {
+            api.model(repo_name)
+                .get("special_tokens_map.json")
+                .map_err(|e| e.to_string())
+        })
+    }
+    .unwrap_or_else(|_| std::path::PathBuf::new());
 
-    let tokenizer_config_path = repo
-        .get("tokenizer_config.json")
-        .unwrap_or_else(|_| std::path::PathBuf::new());
+    let tokenizer_config_path = {
+        let api = api.clone();
+        let repo_name = repo_name.to_string();
+        crate::model_download::with_download_deadline(&format!("{repo_name}/tokenizer_config.json"), move || {
+            api.model(repo_name)
+                .get("tokenizer_config.json")
+                .map_err(|e| e.to_string())
+        })
+    }
+    .unwrap_or_else(|_| std::path::PathBuf::new());
 
     Ok((
         model_path,

--- a/crates/xberg/src/transcription/model.rs
+++ b/crates/xberg/src/transcription/model.rs
@@ -390,8 +390,6 @@ pub fn ensure_whisper_model(
         .build()
         .map_err(|error| WhisperModelError::Download(format!("Failed to initialise hf-hub API: {error}")))?;
 
-    let repo = api.model(hf_repo(model).to_string());
-
     for (remote_path, local_name) in model_files(model) {
         let local_path = target_dir.join(local_name);
 
@@ -409,7 +407,18 @@ pub fn ensure_whisper_model(
             "Downloading Whisper model file",
         );
 
-        let downloaded = repo.get(remote_path).map_err(|error| {
+        // Run the blocking fetch under the wall-clock watchdog: hf-hub sets no read/connect
+        // timeout, so a firewalled host would otherwise wedge the pipeline forever at 0% CPU.
+        // `ApiRepo` is not `Clone` in hf-hub 0.4, but `Api` is, so rebuild the repo inside.
+        let downloaded = {
+            let api = api.clone();
+            let remote = remote_path.to_string();
+            let repo_id = hf_repo(model).to_string();
+            crate::model_download::with_download_deadline(&format!("{}/{remote_path}", hf_repo(model)), move || {
+                api.model(repo_id).get(&remote).map_err(|e| e.to_string())
+            })
+        }
+        .map_err(|error| {
             WhisperModelError::Download(format!(
                 "Failed to download '{remote_path}' from {}: {error}",
                 hf_repo(model)


### PR DESCRIPTION
## Problem

hf-hub (both 0.4 and 0.5) builds its ureq agent with **no read/connect timeout**, and its `ApiBuilder` exposes no way to set one. So a firewalled or stalled connection to HuggingFace makes the blocking `ApiRepo::get()` **hang forever** — silently wedging the whole extraction pipeline at 0% CPU with no error.

Observed downstream (basemind, a documents-tier scan behind a host firewall): OCR/embedding model pulls parked indefinitely, `lsof` on the stuck process hanging on the socket, unrecoverable without killing the process or dropping the firewall.

## Fix

`with_download_deadline` — a dependency-free wall-clock watchdog. The blocking fetch runs on a detached worker thread; we wait at most `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS` (default **300s**). On expiry we log a `tracing::warn!` and return an error, so the caller **degrades** (skips the model-backed backend) rather than hanging.

`ApiRepo` is not `Clone`, so each closure captures a cheap `Api` clone and rebuilds the repo via `api.model(..)` / `api.repo(..)` inside.

Applied at every hf-hub `.get()` site:
- `xberg`: `model_download::hf_download`, `embeddings`, `reranking`, `transcription`
- `xberg-candle-ocr` (leaf crate — gets its own copy of the guard): `trocr`, `glm_ocr`

Existing error mappings — including the `LockAcquisition` cache hint — are preserved. `model_download` is now always compiled (the guard has no hf-hub dependency and must be reachable from every download feature); the checksummed model-manager helpers inside it stay feature-gated.

## Verification

- `cargo fmt --check` clean; `cargo clippy -p xberg --features "embeddings,reranker,paddle-ocr" -- -D warnings` clean; same for `xberg-candle-ocr --features "trocr,glm-ocr"`.
- Builds clean across `embeddings,reranker,paddle-ocr,transcription,layout-detection`.
- **Network-free** unit tests prove the guard: a hung closure with `XBERG_MODEL_DOWNLOAD_TIMEOUT_SECS=1` returns a timeout error in ~1s; the fast path passes its value through. (`cargo test -p xberg --lib model_download`, `-p xberg-candle-ocr --lib download_guard` — 4 passed.)

## Notes / follow-ups

- On timeout the worker thread is detached — it cannot be force-killed and stays parked on the socket until the OS tears the connection down, but it holds no lock the pipeline needs. Only happens on network failure. A progress-based (no-bytes-for-N-seconds) abort would be a tighter future refinement.
- Only the `trocr` / `glm_ocr` Candle backends are wrapped here; `paddleocr-vl` / `hunyuan-ocr` / `deepseek-ocr` fetch paths can get the same guard in a follow-up.