### PR TITLE
fix(archives): route text members by extension when bytes sniff to text/plain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
 
 ### Fixed
 
+- **Markdown, CSV, and other text members inside an archive are no longer flattened to escaped
+  prose.** Recursive archive extraction resolved each member's MIME by content sniffing first, but
+  markdown/CSV/YAML are all plain UTF-8 and sniff to `text/plain` — so a zipped `.md` reached the
+  plain-text extractor, which escaped its headings (`# Title` -> `\# Title`) and dropped its
+  structure. Member detection now prefers the file extension whenever the sniff is only the generic
+  `text/plain`, matching how the top-level path resolves a file by `detect_mime_type(path)` first,
+  so a `.md` member routes to the markdown extractor. Concrete binary formats (PDF/DOCX/images),
+  which sniff to a specific type, are unaffected.
 - **Model downloads can no longer hang the extraction pipeline on a blocked network.** hf-hub
   builds its ureq agent with no read/connect timeout, so a firewalled or stalled HuggingFace
   connection made the blocking `ApiRepo::get()` block forever — wedging the whole pipeline at 0%

--- a/crates/xberg/src/extractors/archive.rs
+++ b/crates/xberg/src/extractors/archive.rs
@@ -128,18 +128,22 @@ async fn build_archive_doc(
 
     if config.max_archive_depth > current_depth && !file_bytes.is_empty() {
         for (path, bytes) in &file_bytes {
-            let detected_mime = crate::core::mime::detect_mime_type_from_bytes(bytes).ok().or_else(|| {
-                std::path::Path::new(path)
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .and_then(|ext| mime_guess::from_ext(ext).first())
-                    .map(|m| m.to_string())
-            });
+            let sniffed_mime = crate::core::mime::detect_mime_type_from_bytes(bytes).ok();
 
-            let file_mime = match detected_mime {
-                Some(m) if m != "application/octet-stream" => m,
-                _ => continue,
+            // Sniffing sees markdown/CSV/YAML as plain UTF-8 and returns `text/plain`,
+            // so fall back to the extension (as the top-level path does) to reach their
+            // real extractors; a concrete sniff (PDF, DOCX, ...) still wins.
+            let file_mime = match sniffed_mime {
+                Some(m) if m != crate::core::mime::PLAIN_TEXT_MIME_TYPE => m,
+                sniffed => crate::core::mime::detect_mime_type(path, false)
+                    .ok()
+                    .or(sniffed)
+                    .unwrap_or_else(|| crate::core::mime::PLAIN_TEXT_MIME_TYPE.to_string()),
             };
+
+            if file_mime == "application/octet-stream" {
+                continue;
+            }
 
             let mut child_config = config.clone();
             child_config.max_archive_depth = config.max_archive_depth.saturating_sub(current_depth + 1);
@@ -602,6 +606,43 @@ mod tests {
         };
         assert_eq!(archive_meta.format, "ZIP");
         assert_eq!(archive_meta.file_count, 1);
+    }
+
+    #[tokio::test]
+    async fn test_zip_markdown_member_routes_to_markdown_extractor() {
+        let markdown = "# Title\n\nBody paragraph.\n\n## Section\n\n- a\n- b\n";
+
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut zip = ZipWriter::new(&mut cursor);
+            let options = FileOptions::<'_, ()>::default();
+            zip.start_file("doc.md", options).unwrap();
+            zip.write_all(markdown.as_bytes()).unwrap();
+            zip.finish().unwrap();
+        }
+
+        let bytes = cursor.into_inner();
+        let config = ExtractionConfig {
+            output_format: crate::core::config::OutputFormat::Markdown,
+            ..Default::default()
+        };
+
+        let result = ZipExtractor::new()
+            .extract_content(&bytes, "application/zip", &config)
+            .await
+            .unwrap();
+
+        let children = result.children.expect("archive should extract its member");
+        let member = children.iter().find(|c| c.path == "doc.md").unwrap();
+        assert_eq!(member.mime_type, "text/markdown");
+
+        let rendered = member
+            .result
+            .formatted_content
+            .as_ref()
+            .unwrap_or(&member.result.content);
+        assert!(rendered.contains("# Title"), "heading lost: {rendered:?}");
+        assert!(!rendered.contains("\\#"), "heading was escaped as prose: {rendered:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

A markdown, CSV, or YAML file inside an archive extracts as escaped plain text instead of structured content. A zipped `doc.md` whose body is `# Title` / `## Section` comes back in the member's result as `\# Title` / `\#\# Section` — headings backslash-escaped, list items run together — so a downstream markdown parser sees no structure and renders the whole file as one flat paragraph. The same `.md` uploaded on its own extracts correctly.

## Root cause

`build_archive_doc` resolved each member's MIME content-first:

```rust
detect_mime_type_from_bytes(bytes).ok().or_else(|| /* extension fallback */)
```

`detect_mime_type_from_bytes` returns `Ok("text/plain")` for any UTF-8 text without a distinguishing signature, so markdown/CSV/YAML all resolve to `text/plain` — and because that's an `Ok`, the extension fallback never runs. The member is dispatched to the plain-text extractor, which treats `# Title` as literal prose and escapes it on render. The top-level path resolves a file by `detect_mime_type(path)` (extension-first via the `EXT_TO_MIME` registry), which is why a standalone `.md` works; the two paths just had inverted precedence.

## Solution

Prefer the extension whenever the byte sniff is missing or only the generic `text/plain`, matching the top-level path. A member whose bytes sniff to a concrete type (PDF/DOCX/images, or JSON/XML/HTML) keeps that type, so only the ambiguous plain-text case now consults `detect_mime_type(path)`. A `.md` member routes to the markdown extractor; a `.txt` or an unknown extension still resolves to `text/plain`.

## Verification

- `cargo fmt -p xberg --check` clean; `cargo clippy -p xberg --features archives --lib` adds no new warnings (the three pre-existing dead-code warnings are unchanged).
- New regression test `test_zip_markdown_member_routes_to_markdown_extractor` zips a `doc.md` with headings and asserts the child extracts as `text/markdown` with an unescaped `# Title` (no `\#`). Full archive suite: `cargo test -p xberg --features archives --lib extractors::archive` — 10 passed.

Fixes #1237.
