### PR TITLE
fix(publish): target macOS 11 for wheels and npm, drop Homebrew ORT from the Intel CLI

### DIFF
--- a/.github/actions/setup-onnx-runtime/action.yml
+++ b/.github/actions/setup-onnx-runtime/action.yml
@@ -25,10 +25,10 @@ runs:
       with:
         path: |
           ${{ runner.temp }}/onnxruntime
-        key: onnx-v2-${{ runner.os }}-${{ inputs.arch-id != '' && inputs.arch-id || runner.arch }}-${{ inputs.ort-version }}
+        key: onnx-v3-${{ runner.os }}-${{ inputs.arch-id != '' && inputs.arch-id || runner.arch }}-${{ inputs.ort-version }}
         restore-keys: |
-          onnx-v2-${{ runner.os }}-${{ inputs.arch-id != '' && inputs.arch-id || runner.arch }}-
-          onnx-v2-${{ runner.os }}-
+          onnx-v3-${{ runner.os }}-${{ inputs.arch-id != '' && inputs.arch-id || runner.arch }}-
+          onnx-v3-${{ runner.os }}-
 
     - name: Prepare ONNX Runtime (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -516,10 +516,9 @@ jobs:
       matrix:
         include:
           - { os: macos-15, target: aarch64-apple-darwin }
-          # x86_64-apple-darwin (Intel macOS) intentionally omitted: Microsoft
-          # ships no x86_64-macOS ONNX Runtime prebuilt, so the .node cannot
-          # vendor a relocatable ORT. Kept in sync with alef's
-          # [crates.node].exclude_platforms=["darwin-x64"].
+          # x86_64-apple-darwin (Intel macOS) intentionally omitted: pyke ships
+          # no static ORT for it and Microsoft's last dylib is 1.23.2. Kept in
+          # sync with alef's [crates.node].exclude_platforms=["darwin-x64"].
           - { os: windows-latest, target: x86_64-pc-windows-msvc }
     steps:
       - uses: actions/checkout@v6
@@ -998,18 +997,11 @@ jobs:
         run: |
           set -euxo pipefail
           # This target loads ONNX Runtime at runtime (ort-dynamic) rather than
-          # static-linking a prebuilt, because none exists for x86_64-apple-darwin
-          # at onnxruntime >= 1.24 (the version ort rc.12 requires). Homebrew's
-          # onnxruntime (1.27, x86_64 "sonoma" bottle) satisfies the >=1.24 check.
-          # The sequoia runner has no matching x86_64 bottle, so pour the sonoma
-          # one explicitly. Vendored next to the binary + rewritten to
-          # @loader_path so it resolves without Homebrew on the user's machine.
-          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install --bottle-tag=sonoma onnxruntime \
-            || brew install onnxruntime
-          ORT_LIB="$(brew --prefix onnxruntime)/lib/libonnxruntime.dylib"
-          test -f "$ORT_LIB"
-          echo "ORT_VENDOR_LIB=$ORT_LIB" >> "$GITHUB_ENV"
+          # static-linking: pyke ships no x86_64-apple-darwin build. Vendor the
+          # dylib setup-onnx-runtime staged (Microsoft's last x86_64 release,
+          # 1.23.2, self-contained) next to the binary.
+          test -f "$ORT_DYLIB_PATH"
+          echo "ORT_VENDOR_LIB=$ORT_DYLIB_PATH" >> "$GITHUB_ENV"
 
       - name: Package CLI artifact
         env:
@@ -1024,46 +1016,20 @@ jobs:
             7z a "${STAGE}.zip" "$STAGE" >/dev/null
           else
             cp "$BINARY_PATH" "$STAGE/xberg"
-            # Intel macOS: bundle libonnxruntime.dylib next to the binary. ort
-            # resolves the default dylib name relative to the executable, so no
-            # ORT_DYLIB_PATH is needed. Vendor the dylib's FULL non-system
-            # dependency closure — Homebrew's onnxruntime links abseil, onnx,
-            # protobuf and re2, which in turn link each other — and repoint
-            # every install name at @loader_path so the bundle is
-            # self-contained (no Homebrew required at runtime). Each staged
-            # copy gets its @loader_path ID set immediately so its own
-            # LC_ID_DYLIB line (which otool -L prints first) drops out of the
-            # Homebrew-path grep instead of being re-vendored under its
-            # versioned name.
+            # Intel macOS: bundle libonnxruntime.dylib next to the binary; ort
+            # resolves the default dylib name relative to the executable. The
+            # official build links only system frameworks, so the one file is
+            # the whole closure.
             if [[ "$TARGET" == "x86_64-apple-darwin" && -n "${ORT_VENDOR_LIB:-}" ]]; then
               cp "$ORT_VENDOR_LIB" "$STAGE/libonnxruntime.dylib"
               chmod u+w "$STAGE/libonnxruntime.dylib"
               install_name_tool -id "@loader_path/libonnxruntime.dylib" "$STAGE/libonnxruntime.dylib"
-              # Iterate to a fixpoint: each pass copies newly referenced
-              # dylibs and rewrites references in everything staged so far.
-              changed=1
-              while [[ "$changed" == 1 ]]; do
-                changed=0
-                for lib in "$STAGE"/*.dylib; do
-                  while IFS= read -r dep; do
-                    base="$(basename "$dep")"
-                    src="$dep"
-                    [[ "$dep" == @rpath/* ]] && src="$(brew --prefix onnxruntime)/lib/$base"
-                    if [[ ! -f "$STAGE/$base" ]]; then
-                      [[ -f "$src" ]] || continue
-                      cp "$src" "$STAGE/$base"
-                      chmod u+w "$STAGE/$base"
-                      install_name_tool -id "@loader_path/$base" "$STAGE/$base"
-                      changed=1
-                    fi
-                    install_name_tool -change "$dep" "@loader_path/$base" "$lib" || true
-                  done < <(otool -L "$lib" | tail -n +2 | awk '{print $1}' \
-                    | grep -E '^(/opt/homebrew|/usr/local|@rpath)/' || true)
-                done
-              done
-              for lib in "$STAGE"/*.dylib; do
-                codesign --force -s - "$lib" || true
-              done
+              deps="$(otool -L "$STAGE/libonnxruntime.dylib" | tail -n +3 | awk '{print $1}' \
+                | grep -E '^(/opt/homebrew|/usr/local)/' || true)"
+              if [[ -n "$deps" ]]; then
+                echo "::error::vendored ONNX Runtime links non-system libraries:"; echo "$deps"; exit 1
+              fi
+              codesign --force -s - "$STAGE/libonnxruntime.dylib" || true
             fi
             tar -czf "${STAGE}.tar.gz" "$STAGE"
           fi

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -459,7 +459,12 @@ jobs:
             export CC="gcc ${CFLAGS}"
             export CXX="g++ ${CXXFLAGS}"
           cibw-environment: 'MATURIN_BUILD_ARGS="--compatibility manylinux_2_28" CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=gcc CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc CXX_x86_64_unknown_linux_gnu=g++ CXX_aarch64_unknown_linux_gnu=g++'
-          cibw-environment-macos: 'MATURIN_BUILD_ARGS="" CARGO_BUILD_LOCKED=true MACOSX_DEPLOYMENT_TARGET=15.0'
+          # The deployment target is the wheel's macOS floor: 15.0 left macOS 11-14
+          # with no installable wheel (#1243). delocate bundles the libheif closure,
+          # so the hook builds it from source at the target and PKG_CONFIG_PATH links
+          # the wheel against it instead of Homebrew's runner-OS bottles.
+          cibw-before-build-macos: bash {project}/scripts/ci/build-macos-heif-deps.sh
+          cibw-environment-macos: 'MATURIN_BUILD_ARGS="" CARGO_BUILD_LOCKED=true MACOSX_DEPLOYMENT_TARGET=11.0 PKG_CONFIG_PATH=/tmp/xberg-heif/lib/pkgconfig'
           cibw-before-build-windows: "rustup install 1.95-x86_64-pc-windows-msvc --profile minimal --component rust-src --component rustfmt --component clippy && rustup target add x86_64-pc-windows-msvc --toolchain 1.95-x86_64-pc-windows-msvc && pip install maturin uv && set PATH=%USERPROFILE%\\.cargo\\bin;%PATH%"
           cibw-environment-windows: 'MATURIN_BUILD_ARGS="--target x86_64-pc-windows-msvc" RUSTUP_TOOLCHAIN="1.95-x86_64-pc-windows-msvc" RUSTC_WRAPPER='
 
@@ -539,6 +544,19 @@ jobs:
         with:
           ort-version: "1.24.2"
 
+      # Build the libheif closure from source at the macOS floor (#1243) and
+      # make the .node link it instead of Homebrew's runner-OS bottles.
+      - name: Build libheif stack for the macOS floor
+        if: contains(matrix.target, 'apple-darwin')
+        shell: bash
+        run: |
+          export MACOSX_DEPLOYMENT_TARGET=11.0
+          bash scripts/ci/build-macos-heif-deps.sh
+          {
+            echo "MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET"
+            echo "PKG_CONFIG_PATH=/tmp/xberg-heif/lib/pkgconfig"
+          } >>"$GITHUB_ENV"
+
       - name: Build NAPI binding
         uses: xberg-io/actions/build-node-napi@v1
         with:
@@ -552,13 +570,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # build-node-napi staged the .node (+ vendored ONNX Runtime, which is
-          # @rpath-relocatable) into crates/xberg-node/npm/<platform>/ and packed
-          # the tarball. libheif and its transitive codec closure (libde265,
-          # libx265, libaom, libsharpyuv, libvmaf, ...) are still absolute
-          # Homebrew paths in the .node, so vendor them beside it (@loader_path)
-          # and repack — otherwise the darwin package fails to dlopen on any Mac
-          # without those exact Homebrew formulae installed.
+          # build-node-napi staged the .node (+ @rpath-relocatable ONNX Runtime)
+          # into crates/xberg-node/npm/<platform>/ and packed the tarball. The
+          # libheif closure is still absolute paths in the .node, so vendor it
+          # beside the .node (@loader_path) and repack.
           node_file="$(find crates/xberg-node/npm -maxdepth 2 -name '*.node' -type f | head -1)"
           [ -n "$node_file" ] || { echo "::error::no .node staged under crates/xberg-node/npm"; exit 1; }
           platform_dir="$(dirname "$node_file")"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
   bundle a libheif decode stack built from source at the 11.0 target — as the Linux wheels
   already do inside the manylinux container — and CI fails if any bundled library misses that
   floor or is sourced from Homebrew.
+- **The Intel CLI tarball's ONNX Runtime now runs on macOS 13.4+ and is a single file.** It
+  previously vendored Homebrew's unpinned onnxruntime bottle (macOS 14 floor) plus its
+  abseil/onnx/protobuf/re2 closure. It now ships Microsoft's official 1.23.2 build, the last
+  x86_64 macOS release, which links only system frameworks.
 - **Markdown, CSV, and other text members inside an archive are no longer flattened to escaped
   prose.** Recursive archive extraction resolved each member's MIME by content sniffing first, but
   markdown/CSV/YAML are all plain UTF-8 and sniff to `text/plain` — so a zipped `.md` reached the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
 
 ### Fixed
 
+- **macOS wheels and the npm darwin package now target macOS 11, instead of only macOS 15.**
+  Wheels were built with a deployment target of 15.0, so pip and uv matched no wheel below
+  macOS 15 and silently fell back to compiling the Rust sdist; the npm darwin package vendored
+  the same Homebrew libheif closure, compiled for the runner's macOS 15. Both artifacts now
+  bundle a libheif decode stack built from source at the 11.0 target — as the Linux wheels
+  already do inside the manylinux container — and CI fails if any bundled library misses that
+  floor or is sourced from Homebrew.
 - **Markdown, CSV, and other text members inside an archive are no longer flattened to escaped
   prose.** Recursive archive extraction resolved each member's MIME by content sniffing first, but
   markdown/CSV/YAML are all plain UTF-8 and sniff to `text/plain` — so a zipped `.md` reached the

--- a/PLATFORM_SUPPORT.md
+++ b/PLATFORM_SUPPORT.md
@@ -33,13 +33,14 @@ Legend: ✅ prebuilt shipped · ❌ not shipped · — not applicable
 
 ## Known gaps & rationale
 
-1. **Node · macOS x64 (Intel) — dropped (rc.23).** Microsoft ships no x86_64-macOS ONNX Runtime
-   prebuilt, so CI provisioned ORT via Homebrew, whose bottle dynamically links a ~252-lib abseil
-   closure at absolute Homebrew paths. The self-containment vendor step (`scripts/ci/vendor-macos-node-dylibs.sh`)
-   correctly rejected the non-portable package. Rather than vendor the abseil closure (package bloat)
-   or static-link ORT (unverified pyke static x64-mac binary), the Intel-mac node leg was dropped.
-   Intel Mac users run the arm64 binding under Rosetta or use the WASM package. In **rc.22** this leg
-   *failed* (so no node package published at all); the drop lands in **rc.23**.
+1. **Node · macOS x64 (Intel) — dropped (rc.23).** pyke ships no static x64-mac ORT, and
+   Microsoft's last x86_64-macOS ONNX Runtime dylib is 1.23.2 (the CLI vendors that one), so at the
+   time CI provisioned ORT via Homebrew, whose bottle dynamically links a ~252-lib abseil closure
+   at absolute Homebrew paths. The self-containment vendor step
+   (`scripts/ci/vendor-macos-node-dylibs.sh`) correctly rejected the non-portable package, and the
+   Intel-mac node leg was dropped. Intel Mac users run the arm64 binding under Rosetta or use the
+   WASM package. In **rc.22** this leg *failed* (so no node package published at all); the drop
+   lands in **rc.23**.
 2. **PHP** builds against **8.3, 8.4, 8.5** on every listed platform.
 3. **Dart** ships the server-mode native; the full pub.dev package has a known size blocker (all-platform
    natives exceed the 100 MB cap) tracked separately — see the release notes.

--- a/docs-site/src/content/docs/concepts/platform-support.md
+++ b/docs-site/src/content/docs/concepts/platform-support.md
@@ -35,14 +35,14 @@ Legend: ✅ prebuilt shipped · ❌ not shipped · — not applicable
 
 ## Known gaps and rationale
 
-1. **Node - macOS x64 (Intel) - dropped (rc.23).** Microsoft ships no x86_64-macOS ONNX Runtime
-   prebuilt, so CI provisioned ORT via Homebrew, whose bottle dynamically links a ~252-lib abseil
-   closure at absolute Homebrew paths. The self-containment vendor step
-   (`scripts/ci/vendor-macos-node-dylibs.sh`) correctly rejected the non-portable package. Rather
-   than vendor the abseil closure (package bloat) or static-link ORT (unverified pyke static x64-mac
-   binary), the Intel-mac node leg was dropped. Intel Mac users run the arm64 binding under Rosetta
-   or use the WASM package. In rc.22 this leg failed (so no node package published at all); the drop
-   lands in rc.23.
+1. **Node - macOS x64 (Intel) - dropped (rc.23).** pyke ships no static x64-mac ORT, and
+   Microsoft's last x86_64-macOS ONNX Runtime dylib is 1.23.2 (the CLI vendors that one), so at the
+   time CI provisioned ORT via Homebrew, whose bottle dynamically links a ~252-lib abseil closure
+   at absolute Homebrew paths. The self-containment vendor step
+   (`scripts/ci/vendor-macos-node-dylibs.sh`) correctly rejected the non-portable package, and the
+   Intel-mac node leg was dropped. Intel Mac users run the arm64 binding under Rosetta or use the
+   WASM package. In rc.22 this leg failed (so no node package published at all); the drop lands in
+   rc.23.
 2. **PHP** builds against 8.3, 8.4, and 8.5 on every listed platform.
 3. **Dart** ships the server-mode native; the full pub.dev package has a known size blocker (all-platform
    natives exceed the 100 MB cap) tracked separately in the release notes.

--- a/scripts/ci/actions/setup-onnx-runtime/macos.sh
+++ b/scripts/ci/actions/setup-onnx-runtime/macos.sh
@@ -27,23 +27,21 @@ x64) ort_arch="x86_64" ;;
 esac
 echo "Using macOS ONNX Runtime arch: $ort_arch"
 
+# Last Microsoft x86_64 macOS release (1.24 dropped the arch). Self-contained
+# with a macOS 13.4 floor; ort built with api-18 accepts any runtime >= 1.18.
+if [ "$ort_arch" = "x86_64" ]; then
+  ort_version="1.23.2"
+fi
+
 ort_root="$extract_dir/onnxruntime-osx-${ort_arch}-${ort_version}"
 
 if [ ! -d "$ort_root" ]; then
-  if [ "$ort_arch" = "x86_64" ]; then
-    echo "Installing x86_64 macOS ONNX Runtime via Homebrew"
-    export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-    brew install --bottle-tag=sonoma onnxruntime || brew install onnxruntime
-    mkdir -p "$ort_root/lib"
-    cp -f "$(brew --prefix onnxruntime)/lib"/libonnxruntime*.dylib "$ort_root/lib/"
-  else
-    echo "Cache miss: Downloading ONNX Runtime ${ort_version} for macOS ${ort_arch}"
-    archive="onnxruntime-osx-${ort_arch}-${ort_version}.tgz"
-    mkdir -p "$extract_dir"
-    curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o "$RUNNER_TEMP/$archive" \
-      "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/$archive"
-    tar -xzf "$RUNNER_TEMP/$archive" -C "$extract_dir"
-  fi
+  echo "Cache miss: Downloading ONNX Runtime ${ort_version} for macOS ${ort_arch}"
+  archive="onnxruntime-osx-${ort_arch}-${ort_version}.tgz"
+  mkdir -p "$extract_dir"
+  curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o "$RUNNER_TEMP/$archive" \
+    "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/$archive"
+  tar -xzf "$RUNNER_TEMP/$archive" -C "$extract_dir"
 else
   echo "Cache hit: Using cached ONNX Runtime ${ort_version}"
 fi

--- a/scripts/ci/build-macos-heif-deps.sh
+++ b/scripts/ci/build-macos-heif-deps.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Build the libheif decode stack (libde265, libaom, libheif) from source at
+# MACOSX_DEPLOYMENT_TARGET, into a prefix that macOS artifacts bundle instead
+# of Homebrew bottles, which target the runner's own macOS (#1243).
+# Decode-only, mirroring the manylinux build-libheif step in xberg-io/actions.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$REPO_ROOT/scripts/lib/retry.sh"
+source "$REPO_ROOT/scripts/lib/macho.sh"
+
+LIBDE265_VERSION=1.0.16
+LIBAOM_VERSION=3.12.1
+LIBHEIF_VERSION=1.23.0 # keep in step with build-libheif in xberg-io/actions
+
+PREFIX="${XBERG_HEIF_PREFIX:-/tmp/xberg-heif}"
+TARGET="${MACOSX_DEPLOYMENT_TARGET:-11.0}"
+WORK="$(mktemp -d)"
+JOBS="$(sysctl -n hw.ncpu)"
+
+# Absolute install names so delocate can resolve every load command.
+CMAKE_COMMON=(
+  -DCMAKE_BUILD_TYPE=Release
+  -DCMAKE_INSTALL_PREFIX="$PREFIX"
+  -DCMAKE_INSTALL_LIBDIR=lib
+  -DCMAKE_INSTALL_NAME_DIR="$PREFIX/lib"
+  -DCMAKE_OSX_DEPLOYMENT_TARGET="$TARGET"
+  -DBUILD_SHARED_LIBS=ON
+)
+
+ensure_nasm() {
+  [ "$(uname -m)" = "x86_64" ] || return 0
+  command -v nasm >/dev/null 2>&1 || retry_with_backoff brew install nasm
+}
+
+build_dep() {
+  local name="$1" version="$2" url="$3"
+  shift 3
+  echo "::group::$name $version"
+  retry_with_backoff curl -fsSL --retry 3 -o "$WORK/$name.tar.gz" "$url"
+  tar -xzf "$WORK/$name.tar.gz" -C "$WORK"
+  cmake -S "$WORK/$name-$version" -B "$WORK/$name-build" "${CMAKE_COMMON[@]}" "$@"
+  cmake --build "$WORK/$name-build" -j "$JOBS"
+  cmake --install "$WORK/$name-build"
+  echo "::endgroup::"
+}
+
+deps_of() {
+  otool -L "$1" | tail -n +3 | sed 's/^[[:space:]]*//; s/ (compatibility.*//'
+}
+
+verify_dylib() {
+  local lib="$1" minos dep
+  minos="$(minos_of "$lib")"
+  if [ "$minos" != "$TARGET" ]; then
+    echo "::error::$(basename "$lib") targets macOS $minos, expected $TARGET"
+    return 1
+  fi
+  while IFS= read -r dep; do
+    case "$dep" in
+      "$PREFIX"/lib/* | /usr/lib/* | /System/*) ;;
+      *)
+        echo "::error::$(basename "$lib") links outside the prefix: $dep"
+        return 1
+        ;;
+    esac
+  done < <(deps_of "$lib")
+}
+
+verify_prefix() {
+  local lib fail=0
+  for lib in "$PREFIX"/lib/*.dylib; do
+    [ -L "$lib" ] && continue
+    verify_dylib "$lib" || fail=1
+  done
+  return "$fail"
+}
+
+main() {
+  if [ -f "$PREFIX/lib/libheif.dylib" ]; then
+    echo "libheif stack already present in $PREFIX, skipping build"
+    return 0
+  fi
+  trap 'rm -rf "$WORK"' EXIT
+  ensure_nasm
+
+  build_dep libde265 "$LIBDE265_VERSION" \
+    "https://github.com/strukturag/libde265/releases/download/v$LIBDE265_VERSION/libde265-$LIBDE265_VERSION.tar.gz" \
+    -DENABLE_SDL=OFF
+
+  build_dep libaom "$LIBAOM_VERSION" \
+    "https://storage.googleapis.com/aom-releases/libaom-$LIBAOM_VERSION.tar.gz" \
+    -DCONFIG_AV1_ENCODER=0 -DENABLE_EXAMPLES=0 -DENABLE_TESTS=0 -DENABLE_DOCS=0 -DENABLE_TOOLS=0
+
+  # Pin dependency discovery to this prefix so no Homebrew library leaks in.
+  PKG_CONFIG_LIBDIR="$PREFIX/lib/pkgconfig" build_dep libheif "$LIBHEIF_VERSION" \
+    "https://github.com/strukturag/libheif/releases/download/v$LIBHEIF_VERSION/libheif-$LIBHEIF_VERSION.tar.gz" \
+    -DCMAKE_PREFIX_PATH="$PREFIX" -DCMAKE_IGNORE_PREFIX_PATH="/opt/homebrew;/usr/local" \
+    -DWITH_LIBDE265=ON -DWITH_AOM_DECODER=ON -DWITH_AOM_ENCODER=OFF -DWITH_X265=OFF \
+    -DWITH_EXAMPLES=OFF -DWITH_GDK_PIXBUF=OFF -DBUILD_TESTING=OFF
+
+  verify_prefix
+  echo "libheif stack built for macOS $TARGET in $PREFIX"
+}
+
+main "$@"

--- a/scripts/ci/vendor-macos-node-dylibs.sh
+++ b/scripts/ci/vendor-macos-node-dylibs.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
-# Recursively vendor a macOS .node's non-system dylib closure beside it and
-# rewrite every absolute (non-system) load command to @loader_path, then ad-hoc
-# re-sign each rewritten binary.
-#
-# Why: the NAPI .node links libheif (HEIC/AVIF) via an absolute Homebrew path
-# (/opt/homebrew/opt/libheif/lib/libheif.1.dylib), and libheif in turn pulls a
-# transitive closure (libde265, libx265, libaom, libsharpyuv, libvmaf, ...).
-# None of these are vendored by the shared build-node-napi action (it only
-# vendors ONNX Runtime, which is already @rpath-relocatable), so the published
-# darwin package fails to dlopen on any Mac without those Homebrew formulae at
-# those exact paths. ONNX Runtime is left untouched here: it is referenced via
-# @rpath and resolved by co-location + the .node's @loader_path LC_RPATH.
+# Vendor a macOS .node's non-system dylib closure (the libheif stack) beside
+# it, rewrite absolute load commands to @loader_path, and ad-hoc re-sign, so
+# the darwin package dlopens without anything preinstalled. ONNX Runtime is
+# untouched: @rpath-relocatable and resolved by co-location.
 #
 # Usage: vendor-macos-node-dylibs.sh <dir-containing-the-.node>
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${REPO_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+source "$REPO_ROOT/scripts/lib/macho.sh"
 
 DIR="${1:?usage: vendor-macos-node-dylibs.sh <dir>}"
 DIR="$(cd "$DIR" && pwd)"
@@ -63,7 +59,14 @@ while [ $i -lt ${#queue[@]} ]; do
     is_vendorable "$dep" || continue
     b="$(basename "$dep")"
     if [ ! -f "$DIR/$b" ]; then
-      cp -f "$(resolve "$dep")" "$DIR/$b"; chmod u+w "$DIR/$b"
+      src="$(resolve "$dep")"
+      # Homebrew bottles target the runner's own macOS and would raise the
+      # package's floor; the heif closure comes from build-macos-heif-deps.sh.
+      case "$src" in
+        /opt/homebrew/*|/usr/local/*)
+          echo "::error::refusing to vendor Homebrew dylib $dep"; exit 1 ;;
+      esac
+      cp -f "$src" "$DIR/$b"; chmod u+w "$DIR/$b"
       echo "vendored $b"
     fi
     install_name_tool -change "$dep" "@loader_path/$b" "$target"
@@ -85,4 +88,18 @@ for f in "$DIR"/*.node "$DIR"/*.dylib; do
   done < <(deps_of "$f")
 done
 [ $leaks -eq 0 ] || { echo "::error::$leaks unvendored absolute deps remain"; exit 1; }
+
+# The .node must sit at the declared floor. Vendored dylibs we did not compile
+# (ONNX Runtime) are reported so the package's effective floor is visible.
+if [ -n "${MACOSX_DEPLOYMENT_TARGET:-}" ]; then
+  for f in "$DIR"/*.node "$DIR"/*.dylib; do
+    [ -e "$f" ] || continue
+    m="$(minos_of "$f")"
+    echo "minos $m $(basename "$f")"
+    case "$f" in
+      *.node) [ "$m" = "$MACOSX_DEPLOYMENT_TARGET" ] || {
+        echo "::error::$(basename "$f") targets macOS $m, expected $MACOSX_DEPLOYMENT_TARGET"; exit 1; } ;;
+    esac
+  done
+fi
 echo "macOS dylib closure vendored and self-contained under $DIR"

--- a/scripts/lib/macho.sh
+++ b/scripts/lib/macho.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Mach-O inspection helpers.
+
+# Minimum macOS version a Mach-O binary declares (LC_BUILD_VERSION or the
+# older LC_VERSION_MIN_MACOSX).
+minos_of() {
+  otool -l "$1" | awk '
+    /LC_BUILD_VERSION/ {b = 1}
+    b && /minos/ {print $2; exit}
+    /LC_VERSION_MIN_MACOSX/ {v = 1}
+    v && /version / {print $2; exit}'
+}


### PR DESCRIPTION
Fixes #1243.

## Problem

Published macOS wheels are tagged `macosx_15_0`, so pip and uv match nothing below macOS 15 and fall back to compiling the sdist (`xberg==1.0.0rc22 has no usable wheels` on macOS 14). The npm darwin package shares the floor: it vendors the Homebrew libheif closure, and every bundled dylib in rc22 is `minos 15.0`. Bottles are compiled for the runner's own macOS; no deployment-target setting can lower them.

## Solution

- Wheels build with `MACOSX_DEPLOYMENT_TARGET=11.0`.
- A shared script compiles the libheif decode stack (libde265, libaom, libheif 1.23.0) from source at the target, mirroring the manylinux `build-libheif` step. The wheel and the `.node` link it via `PKG_CONFIG_PATH`.
- The script rejects any dylib that misses the target or links outside its prefix, and the node vendor script refuses Homebrew-sourced dylibs and asserts the `.node`'s floor, so regressions fail CI.
- The Intel CLI vendors Microsoft's official ONNX Runtime 1.23.2 (macOS 13.4 floor, links only system frameworks) instead of Homebrew's unpinned bottle (macOS 14 floor plus an abseil/onnx/protobuf/re2 closure). The workflow comment claiming ort requires ORT ≥ 1.24 was stale — the workspace pins `api-18`, so the runtime floor is 1.18. No x86_64 macOS ORT binary below 13.4 exists; a lower floor there means building ORT from source.

## Verification

On macOS 14 arm64: the stack builds with every dylib at `minos 11.0`, a Rust binary linked through the prefix records the prefix path and runs, and the vendor script vendors the prefix closure and refuses a Homebrew-sourced dep in a negative test. Microsoft's 1.23.2 x86_64 dylib was downloaded and checked: `minos 13.4`, system-framework deps only, so the new packaging guard passes on it. The publish workflow only runs on release, so the fixed artifacts ship with the next one.
