### PR TITLE
fix(xml): stop dropping XML entities (& < >) from extracted text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
 
 ### Fixed
 
+- **XML entities (`&amp;`, `&lt;`, `&gt;`) no longer disappear from extracted text.** quick-xml
+  0.37+ delivers entity and character references as separate events instead of inlining them in
+  text, and every streaming reader that only matched text events silently dropped them —
+  `Falafel & Hummus <combo>` in a DOCX came out as `Falafel  Hummus combo`. Affected formats:
+  DOCX (body, tables, headers/footers, footnotes/endnotes, math), DocBook, JATS, and generic
+  XML/SVG. Text fragments are now coalesced with their resolved references before any
+  whitespace handling, so entities survive with correct spacing (`5>3` stays `5>3`, not `5 > 3`).
 - **Markdown, CSV, and other text members inside an archive are no longer flattened to escaped
   prose.** Recursive archive extraction resolved each member's MIME by content sniffing first, but
   markdown/CSV/YAML are all plain UTF-8 and sniff to `text/plain` — so a zipped `.md` reached the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,8 @@ The changelog starts fresh at `1.0.0-rc.1`. For the Kreuzberg v1–v4 history, s
 ### Fixed
 
 - **XML entities (`&amp;`, `&lt;`, `&gt;`) no longer disappear from extracted text.** quick-xml
-  0.37+ delivers entity and character references as separate events instead of inlining them in
-  text, and every streaming reader that only matched text events silently dropped them —
+  0.38 started delivering entity and character references as separate events instead of inlining
+  them in text, and every streaming reader that only matched text events silently dropped them —
   `Falafel & Hummus <combo>` in a DOCX came out as `Falafel  Hummus combo`. Affected formats:
   DOCX (body, tables, headers/footers, footnotes/endnotes, math), DocBook, JATS, and generic
   XML/SVG. Text fragments are now coalesced with their resolved references before any

--- a/crates/xberg/src/extraction/docx/math.rs
+++ b/crates/xberg/src/extraction/docx/math.rs
@@ -238,6 +238,11 @@ fn collect_run(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Resul
                     text.push_str(&t);
                 }
             }
+            Ok(Event::GeneralRef(ref e)) if in_text => {
+                let t = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                budget.account_text(t.len())?;
+                text.push_str(&t);
+            }
             Ok(Event::End(ref e)) => {
                 budget.leave();
                 match e.name().as_ref() as &[u8] {

--- a/crates/xberg/src/extraction/docx/math.rs
+++ b/crates/xberg/src/extraction/docx/math.rs
@@ -239,7 +239,7 @@ fn collect_run(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Resul
                 }
             }
             Ok(Event::GeneralRef(ref e)) if in_text => {
-                let t = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                let t = crate::utils::xml_utils::resolve_general_ref(e);
                 budget.account_text(t.len())?;
                 text.push_str(&t);
             }

--- a/crates/xberg/src/extraction/docx/parser.rs
+++ b/crates/xberg/src/extraction/docx/parser.rs
@@ -1789,14 +1789,14 @@ impl<R: Read + Seek> DocxParser<R> {
                 }
                 Ok(Event::GeneralRef(e)) => {
                     if in_text && let Some(ref mut run) = current_run {
-                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        let text = crate::utils::xml_utils::resolve_general_ref(&e);
                         budget.account_text(text.len())?;
                         run.text.push_str(&text);
                         if revision_kind == Some(RevisionKind::Insertion) {
                             revision_text.push_str(&text);
                         }
                     } else if in_del_text {
-                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        let text = crate::utils::xml_utils::resolve_general_ref(&e);
                         budget.account_text(text.len())?;
                         revision_text.push_str(&text);
                     }
@@ -2179,7 +2179,7 @@ impl<R: Read + Seek> DocxParser<R> {
                 }
                 Ok(Event::GeneralRef(e)) => {
                     if in_text && let Some(ref mut run) = current_run {
-                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        let text = crate::utils::xml_utils::resolve_general_ref(&e);
                         budget.account_text(text.len())?;
                         run.text.push_str(&text);
                     }
@@ -2286,7 +2286,7 @@ impl<R: Read + Seek> DocxParser<R> {
                 }
                 Ok(Event::GeneralRef(e)) => {
                     if in_text && let Some(ref mut run) = current_run {
-                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        let text = crate::utils::xml_utils::resolve_general_ref(&e);
                         budget.account_text(text.len())?;
                         run.text.push_str(&text);
                     }

--- a/crates/xberg/src/extraction/docx/parser.rs
+++ b/crates/xberg/src/extraction/docx/parser.rs
@@ -1787,6 +1787,20 @@ impl<R: Read + Seek> DocxParser<R> {
                         revision_text.push_str(&text);
                     }
                 }
+                Ok(Event::GeneralRef(e)) => {
+                    if in_text && let Some(ref mut run) = current_run {
+                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        budget.account_text(text.len())?;
+                        run.text.push_str(&text);
+                        if revision_kind == Some(RevisionKind::Insertion) {
+                            revision_text.push_str(&text);
+                        }
+                    } else if in_del_text {
+                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        budget.account_text(text.len())?;
+                        revision_text.push_str(&text);
+                    }
+                }
                 Ok(Event::End(ref e)) => {
                     budget.leave();
                     match e.name().as_ref() as &[u8] {
@@ -2163,6 +2177,13 @@ impl<R: Read + Seek> DocxParser<R> {
                         run.text.push_str(&text);
                     }
                 }
+                Ok(Event::GeneralRef(e)) => {
+                    if in_text && let Some(ref mut run) = current_run {
+                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
+                        budget.account_text(text.len())?;
+                        run.text.push_str(&text);
+                    }
+                }
                 Ok(Event::End(ref e)) => {
                     budget.leave();
                     match e.name().as_ref() as &[u8] {
@@ -2259,6 +2280,13 @@ impl<R: Read + Seek> DocxParser<R> {
                     if in_text && let Some(ref mut run) = current_run {
                         let text = e.decode()?;
                         budget.check_entity(&text)?;
+                        budget.account_text(text.len())?;
+                        run.text.push_str(&text);
+                    }
+                }
+                Ok(Event::GeneralRef(e)) => {
+                    if in_text && let Some(ref mut run) = current_run {
+                        let text = crate::utils::xml_utils::resolve_general_ref(e.as_ref());
                         budget.account_text(text.len())?;
                         run.text.push_str(&text);
                     }

--- a/crates/xberg/src/extraction/xml.rs
+++ b/crates/xberg/src/extraction/xml.rs
@@ -31,8 +31,8 @@
 use crate::error::{Result, XbergError};
 use crate::extractors::security::{SecurityBudget, SecurityLimits};
 use crate::types::XmlExtractionResult;
+use crate::utils::xml_utils::EntityReader;
 use ahash::AHashSet;
-use quick_xml::Reader;
 use quick_xml::events::Event;
 use std::borrow::Cow;
 
@@ -84,21 +84,22 @@ fn parse_xml_inner(
         xml_bytes
     };
 
-    let mut reader = Reader::from_reader(effective_bytes);
-    reader.config_mut().trim_text(!preserve_whitespace);
+    // No reader-level trim_text: EntityReader coalesces text fragments around
+    // entity references, and trimming fragments first would corrupt spacing.
+    // Text is trimmed below (when `preserve_whitespace` is off), after coalescing.
+    let mut reader = EntityReader::from_bytes(effective_bytes);
     reader.config_mut().check_end_names = false;
 
     let mut budget = SecurityBudget::from_limits(limits);
     let mut content = String::new();
     let mut element_count = 0usize;
     let mut unique_elements_set = AHashSet::new();
-    let mut buf = Vec::new();
     let mut element_stack: Vec<String> = Vec::new();
     let mut had_depth1_element = false;
 
     loop {
         budget.step()?;
-        match reader.read_event_into(&mut buf) {
+        match reader.read_event() {
             Ok(Event::Start(e)) => {
                 budget.enter()?;
                 let name_bytes = (e.name().as_ref() as &[u8]).to_vec();
@@ -193,7 +194,6 @@ fn parse_xml_inner(
             }
             _ => {}
         }
-        buf.clear();
     }
 
     let content = content.trim().to_string();

--- a/crates/xberg/src/extractors/docbook.rs
+++ b/crates/xberg/src/extractors/docbook.rs
@@ -26,8 +26,9 @@ use crate::types::internal_builder::InternalDocumentBuilder;
 use crate::types::uri::ExtractedUri;
 use crate::types::{Metadata, Table};
 use async_trait::async_trait;
-use quick_xml::Reader;
 use quick_xml::events::Event;
+
+use crate::utils::xml_utils::EntityReader;
 #[cfg(feature = "tokio-runtime")]
 use std::path::Path;
 
@@ -134,7 +135,7 @@ fn build_docbook_internal_document(
     budget: &mut SecurityBudget,
 ) -> Result<InternalDocument> {
     let wrapped = ensure_root_element(content);
-    let mut reader = Reader::from_str(&wrapped);
+    let mut reader = EntityReader::from_str(&wrapped);
     let mut builder = InternalDocumentBuilder::new("docbook");
 
     let mut title_extracted = false;
@@ -358,7 +359,7 @@ fn build_docbook_internal_document(
 /// Returns: (content, title, author, date, tables, publisher, copyright)
 fn parse_docbook_single_pass(content: &str, plain: bool, budget: &mut SecurityBudget) -> Result<DocBookParseResult> {
     let wrapped = ensure_root_element(content);
-    let mut reader = Reader::from_str(&wrapped);
+    let mut reader = EntityReader::from_str(&wrapped);
     let mut output = String::new();
     let mut title = String::new();
     let mut author = Option::None;
@@ -653,7 +654,7 @@ fn parse_docbook_single_pass(content: &str, plain: bool, budget: &mut SecurityBu
 /// Handles `<emphasis>`, `<emphasis role="bold">`, `<literal>`, `<command>`,
 /// `<link>`, and `<ulink>` elements.
 fn extract_element_text_with_inline(
-    reader: &mut Reader<&[u8]>,
+    reader: &mut EntityReader<'_>,
     plain: bool,
     budget: &mut SecurityBudget,
 ) -> Result<String> {
@@ -794,7 +795,7 @@ fn extract_element_text_with_inline(
 }
 
 /// Extract figure element, capturing the `<title>` as the caption.
-fn extract_figure_with_caption(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<String> {
+fn extract_figure_with_caption(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<String> {
     let mut caption = String::new();
     let mut depth = 0;
 
@@ -871,7 +872,7 @@ fn extract_figure_with_caption(reader: &mut Reader<&[u8]>, budget: &mut Security
 /// - `<subscript>` → subscript
 /// - `<superscript>` → superscript
 fn extract_para_with_annotations(
-    reader: &mut Reader<&[u8]>,
+    reader: &mut EntityReader<'_>,
     budget: &mut SecurityBudget,
 ) -> Result<(String, Vec<crate::types::document_structure::TextAnnotation>)> {
     use crate::types::builder;
@@ -1031,7 +1032,7 @@ fn extract_para_with_annotations(
 
 /// Extract text content from a DocBook element and its children.
 /// Used for extracting nested content within elements.
-fn extract_element_text(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<String> {
+fn extract_element_text(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<String> {
     let mut text = String::new();
     let mut depth = 0;
 

--- a/crates/xberg/src/extractors/fictionbook.rs
+++ b/crates/xberg/src/extractors/fictionbook.rs
@@ -25,10 +25,9 @@ use crate::types::{ExtractedImage, Metadata, Table};
 use async_trait::async_trait;
 use base64::Engine;
 use bytes::Bytes;
-use quick_xml::Reader;
 use quick_xml::events::Event;
 
-use crate::utils::xml_utils::resolve_general_ref;
+use crate::utils::xml_utils::EntityReader;
 
 /// FictionBook document extractor.
 ///
@@ -48,7 +47,7 @@ impl FictionBookExtractor {
     }
 
     /// Extract text content from a FictionBook element and its children.
-    fn extract_text_content(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<String> {
+    fn extract_text_content(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<String> {
         let mut text = String::new();
         let mut depth = 0;
 
@@ -110,12 +109,6 @@ impl FictionBookExtractor {
                         text.push('\n');
                     }
                 }
-                Ok(Event::GeneralRef(r)) => {
-                    let resolved = resolve_general_ref(r.as_ref());
-                    if !resolved.is_empty() {
-                        text.push_str(&resolved);
-                    }
-                }
                 Ok(Event::Eof) => break,
                 Err(e) => {
                     return Err(crate::error::XbergError::parsing(format!("XML parsing error: {}", e)));
@@ -136,7 +129,7 @@ impl FictionBookExtractor {
 
     /// Extract metadata from FictionBook document.
     fn extract_metadata(data: &[u8], budget: &mut SecurityBudget) -> Result<Metadata> {
-        let mut reader = Reader::from_reader(data);
+        let mut reader = EntityReader::from_bytes(data);
         let mut metadata = Metadata::default();
         let mut additional = ahash::AHashMap::new();
         let mut in_title_info = false;
@@ -393,7 +386,7 @@ impl FictionBookExtractor {
     }
 
     /// Extract a single table from the XML reader (positioned just after `<table>`).
-    fn extract_table(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<Vec<Vec<String>>> {
+    fn extract_table(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<Vec<Vec<String>>> {
         let mut table: Vec<Vec<String>> = Vec::new();
         let mut current_row: Vec<String> = Vec::new();
         let mut in_row = false;
@@ -456,7 +449,7 @@ impl FictionBookExtractor {
 
     /// Extract all tables from the FictionBook body.
     fn extract_tables_from_body(data: &[u8], budget: &mut SecurityBudget) -> Result<Vec<Table>> {
-        let mut reader = Reader::from_reader(data);
+        let mut reader = EntityReader::from_bytes(data);
         let mut tables = Vec::new();
         let mut table_index = 0;
 
@@ -501,7 +494,7 @@ impl FictionBookExtractor {
     /// <binary id="cover.jpg" content-type="image/jpeg">base64data...</binary>
     /// ```
     fn extract_binary_images(data: &[u8], budget: &mut SecurityBudget) -> Result<Vec<ExtractedImage>> {
-        let mut reader = Reader::from_reader(data);
+        let mut reader = EntityReader::from_bytes(data);
         let mut images = Vec::new();
         let mut image_index = 0;
 
@@ -608,7 +601,7 @@ impl FictionBookExtractor {
     /// <a xlink:href="#note1">footnote ref</a>
     /// ```
     fn extract_links(data: &[u8], budget: &mut SecurityBudget) -> Result<Vec<ExtractedUri>> {
-        let mut reader = Reader::from_reader(data);
+        let mut reader = EntityReader::from_bytes(data);
         let mut uris = Vec::new();
         let mut in_body = false;
 
@@ -694,7 +687,7 @@ impl FictionBookExtractor {
 
     /// Build an `InternalDocument` from FictionBook XML content.
     fn build_internal_document(data: &[u8], budget: &mut SecurityBudget) -> Result<InternalDocument> {
-        let mut reader = Reader::from_reader(data);
+        let mut reader = EntityReader::from_bytes(data);
         let mut builder = InternalDocumentBuilder::new("fictionbook");
 
         let mut in_body = false;
@@ -813,7 +806,7 @@ impl FictionBookExtractor {
 
     /// Extract paragraph text with annotation tracking for inline formatting.
     fn extract_paragraph_with_annotations(
-        reader: &mut Reader<&[u8]>,
+        reader: &mut EntityReader<'_>,
         budget: &mut SecurityBudget,
     ) -> Result<(String, Vec<crate::types::document_structure::TextAnnotation>)> {
         use crate::types::document_structure::{AnnotationKind, TextAnnotation};
@@ -881,12 +874,6 @@ impl FictionBookExtractor {
                         text.push_str(trimmed);
                     }
                 }
-                Ok(Event::GeneralRef(r)) => {
-                    let resolved = resolve_general_ref(r.as_ref());
-                    if !resolved.is_empty() {
-                        text.push_str(&resolved);
-                    }
-                }
                 Ok(Event::Eof) => break,
                 Err(e) => {
                     return Err(crate::error::XbergError::parsing(format!("XML parsing error: {}", e)));
@@ -899,7 +886,7 @@ impl FictionBookExtractor {
     }
 
     /// Extract footnote text from a notes-body section.
-    fn extract_footnote_text(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<String> {
+    fn extract_footnote_text(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<String> {
         let mut text = String::new();
         let mut section_depth = 1;
 

--- a/crates/xberg/src/extractors/fictionbook.rs
+++ b/crates/xberg/src/extractors/fictionbook.rs
@@ -28,38 +28,7 @@ use bytes::Bytes;
 use quick_xml::Reader;
 use quick_xml::events::Event;
 
-/// Resolve an XML entity reference name to its character(s).
-fn resolve_entity(name: &str) -> Option<&'static str> {
-    match name {
-        "amp" => Some("&"),
-        "lt" => Some("<"),
-        "gt" => Some(">"),
-        "quot" => Some("\""),
-        "apos" => Some("'"),
-        "nbsp" => Some("\u{00A0}"),
-        _ if name.starts_with('#') => None,
-        _ => None,
-    }
-}
-
-/// Resolve an XML general reference (entity or char ref) to a string.
-fn resolve_general_ref(ref_bytes: &[u8]) -> String {
-    let name = String::from_utf8_lossy(ref_bytes);
-    if let Some(entity) = resolve_entity(&name) {
-        return entity.to_string();
-    }
-    if let Some(num) = name.strip_prefix('#') {
-        let code = if let Some(hex) = num.strip_prefix('x') {
-            u32::from_str_radix(hex, 16).ok()
-        } else {
-            num.parse::<u32>().ok()
-        };
-        if let Some(ch) = code.and_then(char::from_u32) {
-            return ch.to_string();
-        }
-    }
-    String::new()
-}
+use crate::utils::xml_utils::resolve_general_ref;
 
 /// FictionBook document extractor.
 ///

--- a/crates/xberg/src/extractors/jats/elements.rs
+++ b/crates/xberg/src/extractors/jats/elements.rs
@@ -6,13 +6,14 @@ use crate::Result;
 use crate::extraction::cells_to_markdown;
 use crate::extractors::security::SecurityBudget;
 use crate::types::Table;
-use quick_xml::Reader;
 use quick_xml::events::Event;
+
+use crate::utils::xml_utils::EntityReader;
 
 /// Extract all content in a single optimized pass.
 /// Combines metadata extraction, content parsing, and table extraction into one pass.
 pub(super) fn extract_jats_all_in_one(content: &str) -> Result<(JatsMetadataExtracted, String, String, Vec<Table>)> {
-    let mut reader = Reader::from_str(content);
+    let mut reader = EntityReader::from_str(content);
     let mut budget = SecurityBudget::with_defaults();
     let mut metadata = JatsMetadataExtracted::default();
     let mut body_content = String::new();

--- a/crates/xberg/src/extractors/jats/mod.rs
+++ b/crates/xberg/src/extractors/jats/mod.rs
@@ -28,10 +28,11 @@ use crate::types::internal_builder::InternalDocumentBuilder;
 use crate::types::metadata::{ContributorRole, FormatMetadata, JatsMetadata};
 use crate::types::uri::ExtractedUri;
 use async_trait::async_trait;
-use quick_xml::Reader;
 use quick_xml::events::Event;
 #[cfg(feature = "tokio-runtime")]
 use std::path::Path;
+
+use crate::utils::xml_utils::EntityReader;
 
 use elements::extract_jats_all_in_one;
 use parser::extract_citation_text as jats_extract_citation;
@@ -47,7 +48,7 @@ use parser::extract_text_content as jats_extract_text;
 /// - `<sup>` → superscript
 /// - `<ext-link>` → link (with xlink:href)
 fn extract_para_with_annotations_jats(
-    reader: &mut Reader<&[u8]>,
+    reader: &mut EntityReader<'_>,
     budget: &mut SecurityBudget,
 ) -> crate::Result<(String, Vec<crate::types::document_structure::TextAnnotation>)> {
     use crate::types::builder;
@@ -172,7 +173,7 @@ fn extract_para_with_annotations_jats(
 
 /// Build an `InternalDocument` from JATS XML content.
 fn build_jats_internal_document(content: &str, budget: &mut SecurityBudget) -> crate::Result<InternalDocument> {
-    let mut reader = Reader::from_str(content);
+    let mut reader = EntityReader::from_str(content);
     let mut builder = InternalDocumentBuilder::new("jats");
 
     let mut in_article_meta = false;

--- a/crates/xberg/src/extractors/jats/parser.rs
+++ b/crates/xberg/src/extractors/jats/parser.rs
@@ -3,11 +3,12 @@
 use crate::Result;
 use crate::extractors::security::SecurityBudget;
 use crate::text::utf8_validation;
-use quick_xml::Reader;
 use quick_xml::events::Event;
 
+use crate::utils::xml_utils::EntityReader;
+
 /// Extract text content from a JATS element and its children.
-pub(super) fn extract_text_content(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<String> {
+pub(super) fn extract_text_content(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<String> {
     let mut text = String::new();
     let mut depth = 0;
 
@@ -64,7 +65,7 @@ pub(super) fn extract_text_content(reader: &mut Reader<&[u8]>, budget: &mut Secu
 /// `Brown T, Davis K. Cognitive effects of caffeine. J Neurosci. 2002;15:234-241.`
 ///
 /// Falls back to plain text extraction for `<mixed-citation>` or unrecognized structures.
-pub(super) fn extract_citation_text(reader: &mut Reader<&[u8]>, budget: &mut SecurityBudget) -> Result<String> {
+pub(super) fn extract_citation_text(reader: &mut EntityReader<'_>, budget: &mut SecurityBudget) -> Result<String> {
     let mut depth: u32 = 0;
     let mut in_element_citation = false;
     let mut in_mixed_citation = false;

--- a/crates/xberg/src/extractors/xml.rs
+++ b/crates/xberg/src/extractors/xml.rs
@@ -51,7 +51,7 @@ fn decode_xml_to_utf8(content: &[u8]) -> String {
 /// length, cumulative content size). Any limit violation is converted into a
 /// `XbergError::Security` via the `?` operator at call-site.
 fn build_internal_document(content: &[u8], mime_type: &str, budget: &mut SecurityBudget) -> Result<InternalDocument> {
-    use quick_xml::Reader;
+    use crate::utils::xml_utils::EntityReader;
     use quick_xml::events::Event;
     use std::borrow::Cow;
 
@@ -59,18 +59,19 @@ fn build_internal_document(content: &[u8], mime_type: &str, budget: &mut Securit
     let is_svg = mime_type == "image/svg+xml";
 
     let decoded = decode_xml_to_utf8(content);
-    let mut reader = Reader::from_reader(decoded.as_bytes());
-    reader.config_mut().trim_text(true);
+    // No reader-level trim_text: EntityReader coalesces text fragments around
+    // entity references, and trimming fragments first would corrupt spacing.
+    // Text is trimmed below, after coalescing.
+    let mut reader = EntityReader::from_bytes(decoded.as_bytes());
     reader.config_mut().check_end_names = false;
 
-    let mut buf = Vec::new();
     let mut depth: u16 = 0;
     let mut element_stack: Vec<String> = Vec::new();
     let mut index: u32 = 0;
 
     loop {
         budget.step()?;
-        match reader.read_event_into(&mut buf) {
+        match reader.read_event() {
             Ok(Event::Start(e)) => {
                 budget.enter()?;
                 let name_bytes = e.name().as_ref().to_vec();
@@ -110,7 +111,6 @@ fn build_internal_document(content: &[u8], mime_type: &str, budget: &mut Securit
                         .iter()
                         .any(|n| matches!(n.as_str(), "text" | "tspan" | "title" | "desc" | "textPath"));
                     if !in_text_elem {
-                        buf.clear();
                         continue;
                     }
                 }
@@ -163,7 +163,6 @@ fn build_internal_document(content: &[u8], mime_type: &str, budget: &mut Securit
             Err(_) => break,
             _ => {}
         }
-        buf.clear();
     }
 
     Ok(doc)

--- a/crates/xberg/src/utils/xml_utils.rs
+++ b/crates/xberg/src/utils/xml_utils.rs
@@ -115,3 +115,68 @@ pub(crate) fn resolve_general_ref(ref_bytes: &[u8]) -> String {
     }
     String::new()
 }
+
+#[cfg(all(test, any(feature = "xml", feature = "office")))]
+mod tests {
+    use super::*;
+    use quick_xml::events::Event;
+
+    #[test]
+    fn test_resolve_general_ref_predefined_entities() {
+        assert_eq!(resolve_general_ref(b"amp"), "&");
+        assert_eq!(resolve_general_ref(b"lt"), "<");
+        assert_eq!(resolve_general_ref(b"gt"), ">");
+        assert_eq!(resolve_general_ref(b"quot"), "\"");
+        assert_eq!(resolve_general_ref(b"apos"), "'");
+        assert_eq!(resolve_general_ref(b"nbsp"), "\u{00A0}");
+    }
+
+    #[test]
+    fn test_resolve_general_ref_character_references() {
+        assert_eq!(resolve_general_ref(b"#8212"), "\u{2014}");
+        assert_eq!(resolve_general_ref(b"#x2014"), "\u{2014}");
+        assert_eq!(resolve_general_ref(b"#65"), "A");
+    }
+
+    #[test]
+    fn test_resolve_general_ref_unknown_entity_is_empty() {
+        assert_eq!(resolve_general_ref(b"unknownentity"), "");
+        assert_eq!(resolve_general_ref(b"#xZZ"), "");
+        assert_eq!(resolve_general_ref(b"#1114112"), ""); // beyond char::MAX
+    }
+
+    /// The core contract: a text node split at references arrives as ONE Text
+    /// event with the references resolved in place, spacing intact.
+    #[test]
+    fn test_entity_reader_coalesces_text_and_references() {
+        let xml = "<root><a>Profits &amp; losses</a><b>5&gt;3</b><c/></root>";
+        let mut reader = EntityReader::from_str(xml);
+        let mut texts = Vec::new();
+        loop {
+            match reader.read_event().expect("valid XML") {
+                Event::Text(t) => texts.push(String::from_utf8_lossy(t.as_ref()).into_owned()),
+                Event::Eof => break,
+                _ => {}
+            }
+        }
+        assert_eq!(texts, vec!["Profits & losses", "5>3"]);
+    }
+
+    #[test]
+    fn test_entity_reader_preserves_non_text_events() {
+        let xml = "<root attr=\"v\">x&#65;y<child/></root>";
+        let mut reader = EntityReader::from_str(xml);
+        let mut summary = Vec::new();
+        loop {
+            match reader.read_event().expect("valid XML") {
+                Event::Start(e) => summary.push(format!("start:{}", String::from_utf8_lossy(e.name().as_ref()))),
+                Event::Empty(e) => summary.push(format!("empty:{}", String::from_utf8_lossy(e.name().as_ref()))),
+                Event::End(e) => summary.push(format!("end:{}", String::from_utf8_lossy(e.name().as_ref()))),
+                Event::Text(t) => summary.push(format!("text:{}", String::from_utf8_lossy(t.as_ref()))),
+                Event::Eof => break,
+                _ => {}
+            }
+        }
+        assert_eq!(summary, vec!["start:root", "text:xAy", "empty:child", "end:root"]);
+    }
+}

--- a/crates/xberg/src/utils/xml_utils.rs
+++ b/crates/xberg/src/utils/xml_utils.rs
@@ -7,3 +7,111 @@ use std::borrow::Cow;
 pub(crate) fn xml_tag_name(name: &[u8]) -> Cow<'_, str> {
     String::from_utf8_lossy(name)
 }
+
+/// Resolve a predefined XML entity name to its character.
+#[cfg(any(feature = "xml", feature = "office"))]
+fn resolve_entity(name: &str) -> Option<&'static str> {
+    match name {
+        "amp" => Some("&"),
+        "lt" => Some("<"),
+        "gt" => Some(">"),
+        "quot" => Some("\""),
+        "apos" => Some("'"),
+        "nbsp" => Some("\u{00A0}"),
+        _ => None,
+    }
+}
+
+/// Streaming XML reader that restores pre-quick-xml-0.37 text semantics.
+///
+/// quick-xml 0.37+ splits text nodes at entity and character references, emitting
+/// `Event::GeneralRef` between `Event::Text` fragments. Consumers that only match
+/// `Event::Text` silently drop the referenced characters (`&amp;` → nothing), and
+/// trim-and-join accumulators corrupt spacing around the fragments. This wrapper
+/// coalesces each run of `Text`/`GeneralRef` events into a single `Event::Text`
+/// with references resolved, so consumers see whole text nodes again.
+///
+/// Reader-level `trim_text` must stay off (the default) — trimming individual
+/// fragments before coalescing would destroy the whitespace around references.
+#[cfg(any(feature = "xml", feature = "office"))]
+pub(crate) struct EntityReader<'x> {
+    reader: quick_xml::Reader<&'x [u8]>,
+    pending: Option<quick_xml::events::Event<'x>>,
+}
+
+#[cfg(any(feature = "xml", feature = "office"))]
+impl<'x> EntityReader<'x> {
+    pub(crate) fn from_str(content: &'x str) -> Self {
+        Self {
+            reader: quick_xml::Reader::from_str(content),
+            pending: None,
+        }
+    }
+
+    pub(crate) fn from_bytes(content: &'x [u8]) -> Self {
+        Self {
+            reader: quick_xml::Reader::from_reader(content),
+            pending: None,
+        }
+    }
+
+    pub(crate) fn config_mut(&mut self) -> &mut quick_xml::reader::Config {
+        self.reader.config_mut()
+    }
+
+    pub(crate) fn buffer_position(&self) -> u64 {
+        self.reader.buffer_position()
+    }
+
+    /// Read the next event, merging consecutive `Text` / `GeneralRef` events into
+    /// one owned `Event::Text` whose content has all references resolved.
+    pub(crate) fn read_event(&mut self) -> quick_xml::Result<quick_xml::events::Event<'x>> {
+        use quick_xml::events::{BytesText, Event};
+
+        let first = match self.pending.take() {
+            Some(event) => event,
+            None => self.reader.read_event()?,
+        };
+        let mut text = match first {
+            Event::Text(t) => String::from_utf8_lossy(t.as_ref()).into_owned(),
+            Event::GeneralRef(r) => resolve_general_ref(r.as_ref()),
+            other => return Ok(other),
+        };
+        loop {
+            match self.reader.read_event()? {
+                Event::Text(t) => text.push_str(&String::from_utf8_lossy(t.as_ref())),
+                Event::GeneralRef(r) => text.push_str(&resolve_general_ref(r.as_ref())),
+                other => {
+                    self.pending = Some(other);
+                    break;
+                }
+            }
+        }
+        Ok(Event::Text(BytesText::from_escaped(text)))
+    }
+}
+
+/// Resolve an XML general reference (entity or character reference) to its text.
+///
+/// quick-xml 0.37+ emits `&amp;`-style references as `Event::GeneralRef` instead of
+/// including them in `Event::Text`, so every streaming reader that assembles text
+/// must append the resolved reference or the characters are silently dropped.
+/// Unknown named entities (undefined DTD entities) resolve to an empty string.
+#[cfg(any(feature = "xml", feature = "office"))]
+pub(crate) fn resolve_general_ref(ref_bytes: &[u8]) -> String {
+    let name = String::from_utf8_lossy(ref_bytes);
+    if let Some(entity) = resolve_entity(&name) {
+        return entity.to_string();
+    }
+    if let Some(num) = name.strip_prefix('#') {
+        let code = if let Some(hex) = num.strip_prefix('x') {
+            u32::from_str_radix(hex, 16).ok()
+        } else {
+            num.parse::<u32>().ok()
+        };
+        if let Some(ch) = code.and_then(char::from_u32) {
+            return ch.to_string();
+        }
+    }
+    String::new()
+}

--- a/crates/xberg/src/utils/xml_utils.rs
+++ b/crates/xberg/src/utils/xml_utils.rs
@@ -53,6 +53,11 @@ impl<'x> EntityReader<'x> {
 
     /// Read the next event, merging consecutive `Text` / `GeneralRef` events into
     /// one owned `Event::Text` whose content has all references resolved.
+    ///
+    /// The returned `Event::Text` carries already-resolved content: read it raw
+    /// (`as_ref()` / `decode()`). Never call `unescape()` on it — the content is
+    /// no longer escaped, so a resolved `&` would be misparsed as a dangling
+    /// entity reference.
     pub(crate) fn read_event(&mut self) -> quick_xml::Result<quick_xml::events::Event<'x>> {
         use quick_xml::events::{BytesText, Event};
 

--- a/crates/xberg/src/utils/xml_utils.rs
+++ b/crates/xberg/src/utils/xml_utils.rs
@@ -8,28 +8,16 @@ pub(crate) fn xml_tag_name(name: &[u8]) -> Cow<'_, str> {
     String::from_utf8_lossy(name)
 }
 
-/// Resolve a predefined XML entity name to its character.
-#[cfg(any(feature = "xml", feature = "office"))]
-fn resolve_entity(name: &str) -> Option<&'static str> {
-    match name {
-        "amp" => Some("&"),
-        "lt" => Some("<"),
-        "gt" => Some(">"),
-        "quot" => Some("\""),
-        "apos" => Some("'"),
-        "nbsp" => Some("\u{00A0}"),
-        _ => None,
-    }
-}
-
-/// Streaming XML reader that restores pre-quick-xml-0.37 text semantics.
+/// Streaming XML reader that restores pre-quick-xml-0.38 text semantics.
 ///
-/// quick-xml 0.37+ splits text nodes at entity and character references, emitting
-/// `Event::GeneralRef` between `Event::Text` fragments. Consumers that only match
+/// quick-xml 0.38 split text nodes at entity and character references, emitting
+/// `Event::GeneralRef` between `Event::Text` fragments and delegating reference
+/// resolution to the consumer (tafia/quick-xml#766). Consumers that only match
 /// `Event::Text` silently drop the referenced characters (`&amp;` → nothing), and
 /// trim-and-join accumulators corrupt spacing around the fragments. This wrapper
-/// coalesces each run of `Text`/`GeneralRef` events into a single `Event::Text`
-/// with references resolved, so consumers see whole text nodes again.
+/// does for streaming reads what quick-xml's own serde deserializer does
+/// internally: it coalesces each run of `Text`/`GeneralRef` events into a single
+/// `Event::Text` with references resolved, so consumers see whole text nodes again.
 ///
 /// Reader-level `trim_text` must stay off (the default) — trimming individual
 /// fragments before coalescing would destroy the whitespace around references.
@@ -74,13 +62,13 @@ impl<'x> EntityReader<'x> {
         };
         let mut text = match first {
             Event::Text(t) => String::from_utf8_lossy(t.as_ref()).into_owned(),
-            Event::GeneralRef(r) => resolve_general_ref(r.as_ref()),
+            Event::GeneralRef(r) => resolve_general_ref(&r),
             other => return Ok(other),
         };
         loop {
             match self.reader.read_event()? {
                 Event::Text(t) => text.push_str(&String::from_utf8_lossy(t.as_ref())),
-                Event::GeneralRef(r) => text.push_str(&resolve_general_ref(r.as_ref())),
+                Event::GeneralRef(r) => text.push_str(&resolve_general_ref(&r)),
                 other => {
                     self.pending = Some(other);
                     break;
@@ -93,25 +81,26 @@ impl<'x> EntityReader<'x> {
 
 /// Resolve an XML general reference (entity or character reference) to its text.
 ///
-/// quick-xml 0.37+ emits `&amp;`-style references as `Event::GeneralRef` instead of
-/// including them in `Event::Text`, so every streaming reader that assembles text
-/// must append the resolved reference or the characters are silently dropped.
-/// Unknown named entities (undefined DTD entities) resolve to an empty string.
+/// Resolution is upstream's: [`BytesRef::resolve_char_ref`] for `&#...;` character
+/// references and [`quick_xml::escape::resolve_predefined_entity`] for the five
+/// XML predefined entities — the same building blocks quick-xml's own serde
+/// deserializer resolves references with. On top of that, `&nbsp;` (an HTML
+/// entity that real-world FB2/DocBook files use without declaring) resolves to
+/// U+00A0, and undeclared DTD entities resolve to an empty string: extraction
+/// is best-effort, so an unresolvable reference must not fail the document.
 #[cfg(any(feature = "xml", feature = "office"))]
-pub(crate) fn resolve_general_ref(ref_bytes: &[u8]) -> String {
-    let name = String::from_utf8_lossy(ref_bytes);
-    if let Some(entity) = resolve_entity(&name) {
-        return entity.to_string();
+pub(crate) fn resolve_general_ref(reference: &quick_xml::events::BytesRef<'_>) -> String {
+    if let Ok(Some(ch)) = reference.resolve_char_ref() {
+        return ch.to_string();
     }
-    if let Some(num) = name.strip_prefix('#') {
-        let code = if let Some(hex) = num.strip_prefix('x') {
-            u32::from_str_radix(hex, 16).ok()
-        } else {
-            num.parse::<u32>().ok()
-        };
-        if let Some(ch) = code.and_then(char::from_u32) {
-            return ch.to_string();
-        }
+    let Ok(name) = reference.decode() else {
+        return String::new();
+    };
+    if let Some(resolved) = quick_xml::escape::resolve_predefined_entity(&name) {
+        return resolved.to_string();
+    }
+    if name.as_ref() == "nbsp" {
+        return "\u{00A0}".to_string();
     }
     String::new()
 }
@@ -119,30 +108,34 @@ pub(crate) fn resolve_general_ref(ref_bytes: &[u8]) -> String {
 #[cfg(all(test, any(feature = "xml", feature = "office")))]
 mod tests {
     use super::*;
-    use quick_xml::events::Event;
+    use quick_xml::events::{BytesRef, Event};
+
+    fn resolve(name: &str) -> String {
+        resolve_general_ref(&BytesRef::new(name))
+    }
 
     #[test]
     fn test_resolve_general_ref_predefined_entities() {
-        assert_eq!(resolve_general_ref(b"amp"), "&");
-        assert_eq!(resolve_general_ref(b"lt"), "<");
-        assert_eq!(resolve_general_ref(b"gt"), ">");
-        assert_eq!(resolve_general_ref(b"quot"), "\"");
-        assert_eq!(resolve_general_ref(b"apos"), "'");
-        assert_eq!(resolve_general_ref(b"nbsp"), "\u{00A0}");
+        assert_eq!(resolve("amp"), "&");
+        assert_eq!(resolve("lt"), "<");
+        assert_eq!(resolve("gt"), ">");
+        assert_eq!(resolve("quot"), "\"");
+        assert_eq!(resolve("apos"), "'");
+        assert_eq!(resolve("nbsp"), "\u{00A0}");
     }
 
     #[test]
     fn test_resolve_general_ref_character_references() {
-        assert_eq!(resolve_general_ref(b"#8212"), "\u{2014}");
-        assert_eq!(resolve_general_ref(b"#x2014"), "\u{2014}");
-        assert_eq!(resolve_general_ref(b"#65"), "A");
+        assert_eq!(resolve("#8212"), "\u{2014}");
+        assert_eq!(resolve("#x2014"), "\u{2014}");
+        assert_eq!(resolve("#65"), "A");
     }
 
     #[test]
     fn test_resolve_general_ref_unknown_entity_is_empty() {
-        assert_eq!(resolve_general_ref(b"unknownentity"), "");
-        assert_eq!(resolve_general_ref(b"#xZZ"), "");
-        assert_eq!(resolve_general_ref(b"#1114112"), ""); // beyond char::MAX
+        assert_eq!(resolve("unknownentity"), "");
+        assert_eq!(resolve("#xZZ"), "");
+        assert_eq!(resolve("#1114112"), ""); // beyond char::MAX
     }
 
     /// The core contract: a text node split at references arrives as ONE Text

--- a/crates/xberg/tests/issue_1242_xml_entities.rs
+++ b/crates/xberg/tests/issue_1242_xml_entities.rs
@@ -1,0 +1,231 @@
+//! Regression tests for #1242: XML entities (`&amp;`, `&lt;`, `&gt;`) dropped from extracted text.
+//!
+//! quick-xml 0.41 emits entity and character references as `Event::GeneralRef` instead of
+//! including them in `Event::Text`. Readers that only handle `Event::Text` silently drop the
+//! referenced characters, so `Falafel &amp; Hummus` extracts as `Falafel  Hummus`.
+//!
+//! Covers every streaming quick-xml reader that assembles document text: the DOCX body /
+//! header / footnote parsers and the DocBook, JATS, and generic XML extractors.
+
+mod helpers;
+
+#[cfg(feature = "office")]
+mod docx {
+    use std::io::{Cursor, Write};
+    use zip::CompressionMethod;
+    use zip::write::{FileOptions, ZipWriter};
+
+    use crate::helpers::extract_bytes_document;
+    use xberg::ExtractionConfig;
+
+    const DOCX_MIME: &str = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+    /// Build an in-memory DOCX whose body, table, header, and footnote all contain
+    /// XML entities and character references.
+    fn build_entity_docx() -> Vec<u8> {
+        let mut cursor = Cursor::new(Vec::new());
+        {
+            let mut zip = ZipWriter::new(&mut cursor);
+            let options: FileOptions<()> = FileOptions::default().compression_method(CompressionMethod::Stored);
+
+            zip.start_file("[Content_Types].xml", options).expect("zip write");
+            zip.write_all(br#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/header1.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml"/>
+  <Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>
+</Types>"#).expect("zip write");
+
+            zip.start_file("_rels/.rels", options).expect("zip write");
+            zip.write_all(br#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#).expect("zip write");
+
+            zip.start_file("word/_rels/document.xml.rels", options)
+                .expect("zip write");
+            zip.write_all(br#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/header" Target="header1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes" Target="footnotes.xml"/>
+</Relationships>"#).expect("zip write");
+
+            zip.start_file("word/document.xml", options).expect("zip write");
+            zip.write_all(
+                br#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+            xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:r><w:t>Falafel &amp; Hummus &lt;combo&gt; 5&gt;3</w:t></w:r></w:p>
+    <w:p><w:r><w:t>em&#8212;dash and hex&#x2014;dash</w:t></w:r></w:p>
+    <w:tbl>
+      <w:tr><w:tc><w:p><w:r><w:t>Fish &amp; Chips</w:t></w:r></w:p></w:tc></w:tr>
+    </w:tbl>
+    <w:p><w:r><w:footnoteReference w:id="2"/></w:r></w:p>
+    <w:sectPr><w:headerReference w:type="default" r:id="rId1"/></w:sectPr>
+  </w:body>
+</w:document>"#,
+            )
+            .expect("zip write");
+
+            zip.start_file("word/header1.xml", options).expect("zip write");
+            zip.write_all(
+                br#"<?xml version="1.0" encoding="UTF-8"?>
+<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:p><w:r><w:t>Header: Q&amp;A session</w:t></w:r></w:p>
+</w:hdr>"#,
+            )
+            .expect("zip write");
+
+            zip.start_file("word/footnotes.xml", options).expect("zip write");
+            zip.write_all(
+                br#"<?xml version="1.0" encoding="UTF-8"?>
+<w:footnotes xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:footnote w:id="2">
+    <w:p><w:r><w:t>Footnote: salt &amp; pepper</w:t></w:r></w:p>
+  </w:footnote>
+</w:footnotes>"#,
+            )
+            .expect("zip write");
+
+            zip.finish().expect("zip finish");
+        }
+        cursor.into_inner()
+    }
+
+    #[tokio::test]
+    async fn test_docx_body_preserves_xml_entities() {
+        let bytes = build_entity_docx();
+        let result = extract_bytes_document(&bytes, DOCX_MIME, &ExtractionConfig::default())
+            .await
+            .expect("extraction should succeed");
+
+        assert!(
+            result.content.contains("Falafel & Hummus <combo> 5>3"),
+            "body text must keep &, <, > entities; got: {:?}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_docx_body_preserves_character_references() {
+        let bytes = build_entity_docx();
+        let result = extract_bytes_document(&bytes, DOCX_MIME, &ExtractionConfig::default())
+            .await
+            .expect("extraction should succeed");
+
+        assert!(
+            result.content.contains("em\u{2014}dash and hex\u{2014}dash"),
+            "decimal and hex character references must be decoded; got: {:?}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_docx_table_cell_preserves_xml_entities() {
+        let bytes = build_entity_docx();
+        let result = extract_bytes_document(&bytes, DOCX_MIME, &ExtractionConfig::default())
+            .await
+            .expect("extraction should succeed");
+
+        assert!(
+            result.content.contains("Fish & Chips"),
+            "table cell text must keep the & entity; got: {:?}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_docx_header_and_footnote_preserve_xml_entities() {
+        let bytes = build_entity_docx();
+        let config = ExtractionConfig {
+            include_document_structure: true,
+            ..Default::default()
+        };
+        let result = extract_bytes_document(&bytes, DOCX_MIME, &config)
+            .await
+            .expect("extraction should succeed");
+
+        // Footnote definitions render into plain content as a trailing section.
+        assert!(
+            result.content.contains("salt & pepper"),
+            "footnote text must keep the & entity; got: {:?}",
+            result.content
+        );
+
+        // Header content lives on the Header layer, which plain output excludes
+        // by design; assert on the document structure instead.
+        let structure = result.document.expect("document structure requested");
+        let header_texts: Vec<String> = structure
+            .nodes
+            .iter()
+            .map(|node| format!("{:?}", node.content))
+            .collect();
+        assert!(
+            header_texts.iter().any(|text| text.contains("Header: Q&A session")),
+            "header node must keep the & entity; got nodes: {:?}",
+            header_texts
+        );
+    }
+}
+
+#[cfg(feature = "xml")]
+mod xml_family {
+    use crate::helpers::extract_bytes_document;
+    use xberg::ExtractionConfig;
+
+    #[tokio::test]
+    async fn test_generic_xml_preserves_entities() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<root><item>Cats &amp; Dogs &lt;tag&gt; 5&gt;3 em&#8212;dash</item></root>"#;
+        let result = extract_bytes_document(xml, "application/xml", &ExtractionConfig::default())
+            .await
+            .expect("extraction should succeed");
+
+        assert!(
+            result.content.contains("Cats & Dogs <tag> 5>3 em\u{2014}dash"),
+            "generic XML text must keep entities and char refs; got: {:?}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_docbook_preserves_entities() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<article xmlns="http://docbook.org/ns/docbook" version="5.0">
+  <title>R&amp;D report</title>
+  <para>Profits &amp; losses &lt;audited&gt; 5&gt;3</para>
+</article>"#;
+        let result = extract_bytes_document(xml, "application/docbook+xml", &ExtractionConfig::default())
+            .await
+            .expect("extraction should succeed");
+
+        assert!(
+            result.content.contains("Profits & losses <audited> 5>3"),
+            "DocBook para text must keep entities; got: {:?}",
+            result.content
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jats_preserves_entities() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<article>
+  <front><article-meta><title-group>
+    <article-title>Genes &amp; Development</article-title>
+  </title-group></article-meta></front>
+  <body><p>Expression &lt;0.05 &amp; significant, 5&gt;3</p></body>
+</article>"#;
+        let result = extract_bytes_document(xml, "application/x-jats+xml", &ExtractionConfig::default())
+            .await
+            .expect("extraction should succeed");
+
+        assert!(
+            result.content.contains("Expression <0.05 & significant, 5>3"),
+            "JATS body text must keep entities; got: {:?}",
+            result.content
+        );
+    }
+}

--- a/crates/xberg/tests/issue_1242_xml_entities.rs
+++ b/crates/xberg/tests/issue_1242_xml_entities.rs
@@ -1,7 +1,7 @@
 //! Regression tests for #1242: XML entities (`&amp;`, `&lt;`, `&gt;`) dropped from extracted text.
 //!
-//! quick-xml 0.41 emits entity and character references as `Event::GeneralRef` instead of
-//! including them in `Event::Text`. Readers that only handle `Event::Text` silently drop the
+//! Since quick-xml 0.38, entity and character references arrive as `Event::GeneralRef` instead
+//! of inside `Event::Text`. Readers that only handle `Event::Text` silently drop the
 //! referenced characters, so `Falafel &amp; Hummus` extracts as `Falafel  Hummus`.
 //!
 //! Covers every streaming quick-xml reader that assembles document text: the DOCX body /


### PR DESCRIPTION
## Problem

Text stored as XML entities in `word/document.xml` (`&amp;`, `&lt;`, `&gt;`) disappears from extraction output instead of being decoded. The reporter's `Falafel & Hummus <combo> 5>3` paragraph comes back as `Falafel  Hummus combo 53` in plain, markdown, and html output. The same characters vanish from DOCX tables, headers, footnotes and math runs, and the DocBook, JATS, and generic XML/SVG extractors have the same defect; FictionBook kept the characters but corrupted the spacing around them (`Bread &  salt`, `5> 3`).

## Root cause

quick-xml 0.38 intentionally changed its parsing contract (tafia/quick-xml#766): a text node containing references is no longer delivered as one `Event::Text`, but split into fragments with each reference emitted as a separate `Event::GeneralRef`, and resolution is explicitly delegated to the consumer — a document can declare custom DTD entities, so the library no longer decides resolution policy. The workspace is on quick-xml 0.41, the newest release, so this is not fixable by a version bump; no released version resolves references into text events for streaming readers (the machinery exists but is only wired into quick-xml's serde deserializer). Every streaming reader in this codebase predates 0.38 and only matches `Event::Text`, so the referenced characters fall through the catch-all arm and are dropped.

## Solution

Resolution logic is upstream's, not ours: references resolve through `BytesRef::resolve_char_ref()` (character references) and `quick_xml::escape::resolve_predefined_entity()` (the five XML predefined entities) — the same building blocks quick-xml's own deserializer uses. The one piece quick-xml delegates to streaming consumers is reassembly, and that lives in a single small adapter, `EntityReader`, which coalesces each run of `Text`/`GeneralRef` events back into one whole text event before any consumer logic runs. This mirrors what quick-xml's serde path does internally and what calamine/office_oxide did for xlsx/pptx (which is why those formats were unaffected).

Coalescing before consumption matters because the DocBook/JATS/XML readers trim each text fragment and re-join with heuristic spaces: patching `GeneralRef` arms into them individually either drops a space (`Profits& losses`) or invents one (`5 > 3`), and gated accumulators like the JATS `article-title` would truncate at the first entity. With whole text nodes restored, their existing logic is correct unchanged. The DOCX body/header/footnote/math parsers append run text raw, so they resolve `GeneralRef` in place without the wrapper. FictionBook's hand-rolled resolver and per-event arms are replaced by the shared path, fixing its spacing corruption. On top of the upstream resolvers there are two deliberate policies: undeclared `&nbsp;` (an HTML entity common in real-world FB2/DocBook) resolves to U+00A0, and unknown DTD entities resolve to empty instead of failing the document, since extraction is best-effort.

## Verification

Three layers, all red before the fix and green after:

**1. Regression tests.** New suite `crates/xberg/tests/issue_1242_xml_entities.rs` (9 tests): DOCX body, table, header, footnote, decimal and hex character references, DocBook, JATS, generic XML — including the spacing-sensitive `5>3` asserted verbatim. Unit tests pin the resolver and the coalescing contract. `cargo clippy --workspace --all-targets -- -D warnings` clean; docx/docbook/jats/fictionbook/cross-format-parity/security suites green (two FictionBook formatting tests fail identically on the base commit in this environment — pre-existing, unrelated).

**2. Synthetic sweep** ([harness](https://gist.github.com/tobocop2/9234d395e716707406a8e8c0e0ca7d55)): documents generated with python-docx exactly like the issue repro, plus a hand-built char-ref/header/footnote DOCX and DocBook / JATS / XML / FB2 fixtures, with xlsx/pptx as controls. Each check below is run against a main-built CLI (before) and this branch (after).

<details>
<summary><b>Synthetic corpus — 50 checks</b> (before: 16 pass / 34 fail → after: 50 pass)</summary>

| Document | Output | Check | Before (main) | After (branch) |
|---|---|---|---|---|
| reporter_entities.docx | plain | text survives: `Falafel & Hummus <combo> 5>3` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `Standards & Compliance <ISO-9001>` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `Terms & Conditions apply to R&D <review> drafts` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `"5>3 && 2<4"` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `Fish & Chips` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `Q&A <session>` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `a<b` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `c>d` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | text survives: `closing paragraph & done` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | corruption absent: `Falafel  Hummus` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | corruption absent: `Falafel Hummus` | ✅ pass | ✅ pass |
| reporter_entities.docx | plain | corruption absent: `5 > 3` | ✅ pass | ✅ pass |
| reporter_entities.docx | plain | corruption absent: `Terms  Conditions` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | plain | corruption absent: `Fish  Chips` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `Falafel & Hummus <combo> 5>3` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `Standards & Compliance <ISO-9001>` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `Terms & Conditions apply to R&D <review> drafts` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `"5>3 && 2<4"` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `Fish & Chips` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `Q&A <session>` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `a<b` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `c>d` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | text survives: `closing paragraph & done` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | corruption absent: `Falafel  Hummus` | ✅ pass | ✅ pass |
| reporter_entities.docx | markdown | corruption absent: `Falafel Hummus` | ❌ **fail** | ✅ pass |
| reporter_entities.docx | markdown | corruption absent: `5 > 3` | ✅ pass | ✅ pass |
| reporter_entities.docx | markdown | corruption absent: `Terms  Conditions` | ✅ pass | ✅ pass |
| reporter_entities.docx | markdown | corruption absent: `Fish  Chips` | ✅ pass | ✅ pass |
| charrefs_header_footnote.docx | plain | text survives: `em—dash and hex—dash and\xa0nbsp` | ❌ **fail** | ✅ pass |
| charrefs_header_footnote.docx | plain | text survives: `quote "q" and apos \'a\` | ❌ **fail** | ✅ pass |
| charrefs_header_footnote.docx | plain | text survives: `Footnote: salt & pepper` | ❌ **fail** | ✅ pass |
| charrefs_header_footnote.docx | plain | corruption absent: `emdash` | ❌ **fail** | ✅ pass |
| charrefs_header_footnote.docx | plain | corruption absent: `hexdash` | ❌ **fail** | ✅ pass |
| charrefs_header_footnote.docx | plain | corruption absent: `salt  pepper` | ❌ **fail** | ✅ pass |
| entities.docbook.xml | plain | text survives: `Profits & losses <audited> 5>3 em—dash` | ❌ **fail** | ✅ pass |
| entities.docbook.xml | plain | corruption absent: `Profits  losses` | ✅ pass | ✅ pass |
| entities.docbook.xml | plain | corruption absent: `5 > 3` | ✅ pass | ✅ pass |
| entities.docbook.xml | plain | corruption absent: `Profits losses` | ❌ **fail** | ✅ pass |
| entities.jats.xml | plain | text survives: `Expression <0.05 & significant, 5>3` | ❌ **fail** | ✅ pass |
| entities.jats.xml | plain | corruption absent: `Expression 0.05` | ❌ **fail** | ✅ pass |
| entities.jats.xml | plain | corruption absent: `5 > 3` | ✅ pass | ✅ pass |
| entities.generic.xml | plain | text survives: `Cats & Dogs <tag> 5>3 em—dash` | ❌ **fail** | ✅ pass |
| entities.generic.xml | plain | corruption absent: `Cats  Dogs` | ✅ pass | ✅ pass |
| entities.generic.xml | plain | corruption absent: `5 > 3` | ✅ pass | ✅ pass |
| entities.fb2 | plain | text survives: `Bread & salt <offered> 5>3` | ❌ **fail** | ✅ pass |
| entities.fb2 | plain | corruption absent: `Bread  salt` | ✅ pass | ✅ pass |
| control.xlsx | plain | text survives: `Salt & Pepper <mix> 5>3` | ✅ pass | ✅ pass |
| control.xlsx | plain | corruption absent: `Salt  Pepper` | ✅ pass | ✅ pass |
| control.pptx | plain | text survives: `Oil & Vinegar <blend> 5>3` | ✅ pass | ✅ pass |
| control.pptx | plain | corruption absent: `Oil  Vinegar` | ✅ pass | ✅ pass |

</details>


**3. Real documents** (same harness, `check-real` mode): real-world DOCX from LibreOffice's OOXML regression corpus (bug attachments) and Europe PMC open-access JATS articles. No hand-written expectations — the oracle is Python's stdlib XML parser: any parsed text containing `&`, `<`, or `>` must have been entity-encoded in the raw bytes, so each such snippet must survive extraction verbatim.

<details>
<summary><b>Real documents (LibreOffice DOCX corpus + Europe PMC JATS) — 17 oracle checks</b> (before: 0 pass / 17 fail → after: 17 pass)</summary>

| Document | Entity-encoded text that must survive | Before (main) | After (branch) |
|---|---|---|---|
| [FDO74215.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO74215.docx) | `The largest growth has been in distance learning students (>40% over 3 years), though the London-based student population (where accommodation limits growth) is at its highest level ever. Alumni are working in more than 180 countries. The School has about 1500 staff drawn from over 60 nationalities.` | ❌ **fail** | ✅ pass |
| [FDO74215.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO74215.docx) | `The London School of Hygiene & Tropical Medicine is one of Europe’s leading schools of Public Health and a leading postgraduate institution worldwide for research and postgraduate education in global health.` | ❌ **fail** | ✅ pass |
| [FDO74775.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO74775.docx) | `Kramer, J. D., & Chen, J. (2006).` | ❌ **fail** | ✅ pass |
| [FDO74775.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO74775.docx) | `(Kramer & Chen, 2006)` | ❌ **fail** | ✅ pass |
| [FDO75133.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO75133.docx) | `Kramer, J. D., & Chen, J. (2006).` | ❌ **fail** | ✅ pass |
| [FDO75133.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO75133.docx) | `(Kramer & Chen, 2006)` | ❌ **fail** | ✅ pass |
| [FDO76248.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/FDO76248.docx) | `from the data in Table 5. Years on the X-axis (count by 10’s) & population on the Y-axis (count by 25 million). Plot the curves for two-child families on the same axis as the curve for three-child families.` | ❌ **fail** | ✅ pass |
| [Unsupportedtextfields.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/Unsupportedtextfields.docx) | `Fields.Links & References.StyleRef` | ❌ **fail** | ✅ pass |
| [dont-add-new-styles.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/dont-add-new-styles.docx) | `<Style2>` | ❌ **fail** | ✅ pass |
| [dont-add-new-styles.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/dont-add-new-styles.docx) | `<Style1>` | ❌ **fail** | ✅ pass |
| [dont-add-new-styles.docx](https://github.com/LibreOffice/core/blob/master/sw/qa/extras/ooxmlexport/data/dont-add-new-styles.docx) | `<Style3>` | ❌ **fail** | ✅ pass |
| [PMC3257301.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC3257301/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC3257301)) | *(no entity-encoded visible text — skipped)* | — | — |
| [PMC5334499.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC5334499/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC5334499)) | `Disappearance of all target and nontarget lesions Nodes must regress to < 10 mm short axis No new lesions Confirmation required` | ❌ **fail** | ✅ pass |
| [PMC5334499.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC5334499/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC5334499)) | `F-FDG uptake within the target lesion (< mean liver activity and indistinguishable from background/blood pool and no new` | ❌ **fail** | ✅ pass |
| [PMC5334499.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC5334499/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC5334499)) | `PMD: An increase in SUV > 25% or appearance of new lesions` | ❌ **fail** | ✅ pass |
| [PMC5334499.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC5334499/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC5334499)) | `SMD: Increase in SUV by < 25% or decrease in SUV by < 15%` | ❌ **fail** | ✅ pass |
| [PMC5334499.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC5334499/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC5334499)) | `PMR: A decrease in SUV > 25%` | ❌ **fail** | ✅ pass |
| [PMC6205674.jats.xml](https://www.ebi.ac.uk/europepmc/webservices/rest/PMC6205674/fullTextXML) ([article](https://europepmc.org/article/PMC/PMC6205674)) | `Finally, 70% of all diabetic eyes, analyzed in this study, had an abnormal area on GCC significance map (reduced thickness; P < 1%), as classified by the device´s normative database. In 70% of eyes, the juxtafoveal area was the affected (thinned) one. Three cases representing different patterns of GCC thinning are provided in` | ❌ **fail** | ✅ pass |

</details>

Fixes #1242.
