### PR TITLE
fix(deps): bump pdf_oxide to 0.3.74 — bordered stroke-width tables and positioned-text spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   width — scanned pages with vertical OCR layers, typeset tategaki books. The panic guard kept
   extraction alive, but the affected page came back as a per-page error with its text lost.
   pdf_oxide 0.3.73 fixes the sort, so those pages now extract normally.
+- **Bordered tables with stroke-width-rendered rules are detected (#1213).** Some print-era PDF
+  generators draw a vertical table rule as a ~1pt segment stroked with a line width equal to the
+  table height, so the rule's geometric bounding box was a speck and the Lines-strategy detector
+  saw no vertical rulings — whole fuse-chart-style tables were missed (their only detected "table"
+  being a false-positive page footer) and their text flowed out column-major, destroying row
+  associations. pdf_oxide 0.3.74 accounts for stroke width in path bounding boxes, so these grids
+  are now detected natively with their rows intact.
+- **Inter-word spaces are no longer dropped in positioned/tabular PDF text.** Words in
+  TJ-positioned runs — the header cells of rate tables and similar tabular layouts — extracted
+  glued together (`Comparisonrate`, `roadvehicles`, `transportlayer`) while the same words in
+  flowing prose on the page were spaced correctly. pdf_oxide 0.3.74 accounts for the `TJ` numeric
+  adjustment that carries the space in those runs, so positioned text is spaced too.
 - **Redaction now scrubs every text-bearing field.** The redaction pass rewrote the main content
   and a handful of fields but left table cells, page content, form-field values, image captions,
   URIs, metadata, and structured output carrying the original text — while still reporting success.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5936,9 +5936,9 @@ dependencies = [
 
 [[package]]
 name = "office_oxide"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af473f543db2d69584f3bc3a12358420c4c0111b163c8dfbc96c1717ff725e3"
+checksum = "673fefe70a9e53a74d4e4b2797cbe9fc2d778cfc1734956727db9e5b7d809e98"
 dependencies = [
  "atoi_simd",
  "encoding_rs",
@@ -6241,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "pdf_oxide"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6730b3cabd41b9e813c9ab1e536c99e685adc8c06d6755b82b66dcedd49a95"
+checksum = "1b97a8330bf3a3a4011ad84704b3bdcb9b0ef3fd5b03a1bdc371dde40bee1689"
 dependencies = [
  "aes 0.9.1",
  "base64 0.22.1",
@@ -8944,9 +8944,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfde4e2f8595f222ceaae1fb16b4963952e9b33e358869dc4cd6316b0e0790cd"
+checksum = "73afc801dd6bd47529eaa7c7e90557f107527d1b7c9c7ed7d7803c7b8d0c357f"
 dependencies = [
  "arrayvec",
  "grid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ once_cell = "1.21.4"
 
 ort = { version = "2.0.0-rc.12", default-features = false, features = ["std", "api-18"] }
 parking_lot = "0.12.5"
-pdf_oxide = { version = "0.3.73", default-features = false, features = ["rendering", "legacy-crypto"] }
+pdf_oxide = { version = "0.3.74", default-features = false, features = ["rendering", "legacy-crypto"] }
 rayon = "1.12.0"
 reqwest = { version = "0.13.4", default-features = false }
 # SVG rendering (resvg re-exports tiny_skia and usvg; default-features = false

--- a/crates/xberg/tests/pdf_heuristic_tables.rs
+++ b/crates/xberg/tests/pdf_heuristic_tables.rs
@@ -156,3 +156,74 @@ fn test_bordered_two_column_table_detected_via_pipeline() {
         "table must produce non-empty markdown"
     );
 }
+
+/// Integration test for xberg-io/xberg#1213: a 3-column grid whose vertical
+/// rules are drawn as ~1pt segments stroked with a table-height line width
+/// (the rendered geometry is a full-height vertical bar, but the path's
+/// geometric bounding box is a speck). pdf_oxide 0.3.74 accounts for stroke
+/// width in path bounding boxes, so the native tier detects this through the
+/// full public API path with row associations intact, and the heuristic tier
+/// does not add competing tables on that page.
+#[test]
+fn test_stroke_width_vertical_rules_table_detected_via_pipeline() {
+    use pdf_oxide::geometry::Rect;
+    use pdf_oxide::writer::{DocumentBuilder, LineStyle, TextAlign};
+
+    let thin = LineStyle::new(1.0, 0.0, 0.0, 0.0);
+    let rows: [[&str; 3]; 6] = [
+        ["Location", "Rating", "Circuit"],
+        ["6", "15A*", "Alternator regulator"],
+        ["7", "30A*", "PCM relay feed"],
+        ["11", "15A*", "A/C clutch relay feed"],
+        ["24", "10A*", "Heated mirrors"],
+        ["101", "40A**", "Blower relay feed"],
+    ];
+
+    let mut doc = DocumentBuilder::new();
+    let mut page = doc.a4_page();
+    // Horizontal rules: ordinary 1pt strokes at every row boundary.
+    for i in 0..=6u32 {
+        let y = 510.0 + 40.0 * i as f32;
+        page = page.stroke_line(50.0, y, 400.0, y, thin.clone());
+    }
+    // Vertical rules: 1pt-long horizontal segments at the table's vertical
+    // midpoint, stroked with the full table height (240pt).
+    for x in [50.0_f32, 150.0, 250.0, 400.0] {
+        page = page.stroke_line(x - 0.5, 630.0, x + 0.5, 630.0, LineStyle::new(240.0, 0.0, 0.0, 0.0));
+    }
+    let col_x = [50.0_f32, 150.0, 250.0];
+    let col_w = [100.0_f32, 100.0, 150.0];
+    for (i, row) in rows.iter().enumerate() {
+        let y = 750.0 - 40.0 * (i as f32 + 1.0);
+        for (c, text) in row.iter().enumerate() {
+            page = page.text_in_rect(Rect::new(col_x[c], y, col_w[c], 40.0), text, TextAlign::Left);
+        }
+    }
+    page.done();
+    let bytes = doc.build().expect("build synthetic PDF");
+
+    let config = ExtractionConfig::default();
+    let result = extract_bytes_document_blocking(&bytes, PDF_MIME, &config).expect("extraction must succeed");
+
+    assert_eq!(
+        result.tables.len(),
+        1,
+        "pipeline must detect exactly the stroke-width-ruled table (no heuristic duplicates); got: {:?}",
+        result.tables.iter().map(|t| &t.markdown).collect::<Vec<_>>()
+    );
+    let table = &result.tables[0];
+    assert!(
+        table.cells.iter().all(|row| row.len() == 3),
+        "all rows must have 3 columns; got: {:?}",
+        table.cells.iter().map(|r| r.len()).collect::<Vec<_>>()
+    );
+    let fuse_row = ["101", "40A**", "Blower relay feed"];
+    assert!(
+        table
+            .cells
+            .iter()
+            .any(|row| row.iter().map(String::as_str).eq(fuse_row)),
+        "row association must survive extraction; got cells: {:?}",
+        table.cells
+    );
+}

--- a/crates/xberg/tests/pdf_output_quality.rs
+++ b/crates/xberg/tests/pdf_output_quality.rs
@@ -235,3 +235,31 @@ fn test_pdf_structure_reading_order() {
          crates/xberg/src/pdf/oxide/hierarchy.rs"
     );
 }
+
+/// Regression test for yfedoseev/pdf_oxide#847: inter-word spaces were dropped
+/// on TJ-positioned runs, so words in this pdfplumber fixture's tabular
+/// rate-table header extracted glued (`Comparisonrate`, eight times) while the
+/// same words in flowing prose were spaced correctly. pdf_oxide 0.3.74 accounts
+/// for the `TJ` numeric adjustment that carries the space, so the header text
+/// is spaced too.
+#[test]
+fn test_tj_positioned_runs_keep_interword_spaces() {
+    if !test_documents_available() {
+        return;
+    }
+    let path = get_test_file_path("vendored/pdfplumber/pdf/pr-138-example.pdf");
+    if !path.exists() {
+        return;
+    }
+    let content = extract_uri_document_blocking(&path, None, &ExtractionConfig::default())
+        .expect("extraction should succeed")
+        .content;
+    assert!(
+        !content.contains("Comparisonrate"),
+        "TJ-positioned header still glues 'Comparisonrate' — pdf_oxide#847 regression"
+    );
+    assert!(
+        content.contains("Comparison rate"),
+        "expected the spaced phrase 'Comparison rate' in extracted text"
+    );
+}


### PR DESCRIPTION
pdf_oxide 0.3.74 lands two upstream fixes that resolve open PDF extraction bugs. Both reduce to this dependency bump plus a regression test — there is no new extraction logic in xberg.

## Bordered tables with stroke-width rules (#1213)

Some print-era PDF generators draw a vertical table rule as a ~1pt segment stroked to the full table height, so the rule's geometric bounding box was a speck and the Lines-strategy detector saw no vertical rulings — whole fuse-chart-style tables were missed and their text flowed out column-by-column with the rows destroyed. pdf_oxide 0.3.74 accounts for stroke width in path bounding boxes, so these grids are detected natively. Regression test drives the full public extraction API over a synthetic stroke-ruled grid and asserts one table with rows intact.

## Inter-word spacing on positioned text ([pdf_oxide#847](https://github.com/yfedoseev/pdf_oxide/issues/847))

Words in TJ-positioned runs — the header cells of rate tables and similar tabular layouts — extracted glued together (`Comparisonrate`, `roadvehicles`) while the same words in flowing prose on the page were spaced correctly. pdf_oxide 0.3.74 accounts for the `TJ` numeric adjustment that carries the space in those runs. Regression test extracts the pdfplumber `pr-138-example` fixture and asserts the header no longer glues `Comparisonrate`.

## What's in the change

Dependency bump only: `pdf_oxide 0.3.73 → 0.3.74`, which transitively pulls `office_oxide 0.1.6` and `taffy 0.12.1` (required by 0.3.74; office/excel compile clean against them). Plus the two regression tests and changelog entries.

Supersedes #1226, which captured the table bug and its tests while holding an interim in-tree workaround until the upstream fix landed — none of that workaround ships here. Opened on an upstream branch so CI runs.
