### PR TITLE
fix(alef): stop regeneration from silently downgrading crawlberg to 1.0.3

### DIFF
--- a/alef.toml
+++ b/alef.toml
@@ -431,7 +431,7 @@ sources = [
 roots = ["crawlberg::CrawlConfig", "crawlberg::MapResult"]
 
 [crates.extra_dependencies]
-crawlberg = { version = "1.0.3", default-features = false }
+crawlberg = { version = "1.0.5", default-features = false }
 
 [crates.python]
 module_name = "_xberg"


### PR DESCRIPTION
Closes #1264.

## Problem

Anyone who regenerates the bindings gets a surprise diff: `alef.toml` still asks for crawlberg 1.0.3, while the generated files checked into the repo were produced with 1.0.5 (bumped in 197a4a352d without updating the config). Every regeneration therefore downgrades the manifests, and the freshness check can never pass on an up-to-date tree.

## Solution

Bump the pin to 1.0.5 to match the committed manifests. One line; regeneration now reproduces the committed crawlberg version, and the `alef:hash` headers realign on the next canonical regeneration.
