### PR TITLE
fix(pdf): layout detection no longer drops documents whose text has bullets or curly quotes, and keeps page markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Layout detection with reading order no longer crashes pages whose text contains bullets,
+  curly quotes, or other multibyte characters.** Reading-order reordering rebuilds the extracted
+  text but kept the page boundaries computed against the original string, so downstream code
+  sliced the new text at stale byte offsets — a panic whenever an offset landed inside a
+  multibyte character, silently dropping the whole document. On OCR-heavy corpora this lost the
+  majority of pages with layout detection on. Boundaries are now recomputed against the reordered
+  text (including the copy used for chunk page ranges), and the per-page OCR gate and OCR/native
+  merge skip-and-log invalid boundaries instead of panicking.
 - **macOS wheels and the npm darwin package now target macOS 11, instead of only macOS 15.**
   Wheels were built with a deployment target of 15.0, so pip and uv matched no wheel below
   macOS 15 and silently fell back to compiling the Rust sdist; the npm darwin package vendored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   multibyte character, silently dropping the whole document. On OCR-heavy corpora this lost the
   majority of pages with layout detection on. Boundaries are now recomputed against the reordered
   text (including the copy used for chunk page ranges), and the per-page OCR gate and OCR/native
-  merge skip-and-log invalid boundaries instead of panicking.
+  merge skip-and-log invalid boundaries instead of panicking. The rebuilt text also keeps
+  `insert_page_markers` markers, which reading-order reordering used to drop.
 - **macOS wheels and the npm darwin package now target macOS 11, instead of only macOS 15.**
   Wheels were built with a deployment target of 15.0, so pip and uv matched no wheel below
   macOS 15 and silently fell back to compiling the Rust sdist; the npm darwin package vendored

--- a/crates/xberg/src/extractors/pdf/extraction.rs
+++ b/crates/xberg/src/extractors/pdf/extraction.rs
@@ -55,7 +55,7 @@ pub(crate) fn extract_all_from_oxide_document(
     let mut doc = crate::pdf::oxide::OxideDocument::open_bytes_with_passwords(content, passwords)?;
 
     #[cfg_attr(not(feature = "layout-detection"), allow(unused_mut))]
-    let (mut native_text, boundaries, page_contents, pdf_metadata) =
+    let (mut native_text, mut boundaries, page_contents, mut pdf_metadata) =
         crate::pdf::oxide::text::extract_text_and_metadata(&mut doc, Some(config)).map_err(|e| {
             crate::error::XbergError::Parsing {
                 message: format!("pdf_oxide text extraction failed: {e}"),
@@ -67,16 +67,27 @@ pub(crate) fn extract_all_from_oxide_document(
     if config.pdf_options.as_ref().is_some_and(|opts| opts.reading_order)
         && let Some(hints) = layout_hints
     {
-        native_text = match apply_reading_order_reordering(&mut doc, &native_text, hints) {
-            Ok(reordered) => reordered,
+        match apply_reading_order_reordering(&mut doc, &native_text, hints) {
+            Ok((reordered, reordered_boundaries)) => {
+                native_text = reordered;
+                // Reordering rebuilds the text, so boundaries computed against
+                // the original extraction order no longer index it.
+                if !reordered_boundaries.is_empty() {
+                    if let Some(ref mut page_structure) = pdf_metadata.page_structure {
+                        page_structure.boundaries = Some(reordered_boundaries.clone());
+                    }
+                    if boundaries.is_some() {
+                        boundaries = Some(reordered_boundaries);
+                    }
+                }
+            }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
                     "reading-order reordering failed; using native text extraction order"
                 );
-                native_text
             }
-        };
+        }
     }
     #[cfg(not(feature = "layout-detection"))]
     let _ = layout_hints;
@@ -313,13 +324,16 @@ pub(crate) fn extract_all_from_oxide_document(
 /// Extracts text spans from each page, projects them onto layout regions,
 /// performs column detection, and rebuilds the text in natural reading order.
 ///
-/// Returns the reordered text string, or an error if extraction/reordering fails.
+/// Returns the reordered text string together with page boundaries recomputed
+/// against it — the rebuilt string has a different byte layout, so boundaries
+/// from the original extraction must not be used to index it. An empty
+/// boundary vector means the text was returned unchanged.
 #[cfg(feature = "layout-detection")]
 fn apply_reading_order_reordering(
     doc: &mut crate::pdf::oxide::OxideDocument,
     native_text: &str,
     layout_hints_per_page: &[Vec<crate::pdf::structure::types::LayoutHint>],
-) -> Result<String> {
+) -> Result<(String, Vec<crate::types::PageBoundary>)> {
     use crate::extractors::pdf::reading_order;
 
     let page_count = doc.doc.page_count().map_err(|e| crate::error::XbergError::Parsing {
@@ -368,15 +382,59 @@ fn apply_reading_order_reordering(
     }
 
     if reordered_pages.is_empty() {
-        return Ok(native_text.to_string());
+        return Ok((native_text.to_string(), Vec::new()));
     }
 
-    let result = reordered_pages.join("\n\n");
-    Ok(result)
+    Ok(join_pages_with_boundaries(&reordered_pages))
+}
+
+/// Join per-page texts with `"\n\n"` separators, recording each page's byte
+/// range in the combined string. The separators belong to no page, matching
+/// how `extract_text_from_oxide_document` records boundaries.
+#[cfg(feature = "layout-detection")]
+fn join_pages_with_boundaries(pages: &[String]) -> (String, Vec<crate::types::PageBoundary>) {
+    let mut content = String::new();
+    let mut boundaries = Vec::with_capacity(pages.len());
+    for (idx, page_text) in pages.iter().enumerate() {
+        if idx > 0 {
+            content.push_str("\n\n");
+        }
+        let byte_start = content.len();
+        content.push_str(page_text);
+        boundaries.push(crate::types::PageBoundary {
+            byte_start,
+            byte_end: content.len(),
+            page_number: idx as u32 + 1,
+        });
+    }
+    (content, boundaries)
 }
 
 #[cfg(test)]
 mod tests {
+
+    /// Boundaries produced alongside reordered text must index it exactly:
+    /// char-boundary-valid offsets whose slice is the page's text, with the
+    /// `"\n\n"` separators belonging to no page.
+    #[cfg(feature = "layout-detection")]
+    #[test]
+    fn test_join_pages_with_boundaries_multibyte() {
+        let pages = vec![
+            "CLASSIFICATION • Classification: SECRET".to_string(),
+            "second — page's text with curly \u{201c}quotes\u{201d}".to_string(),
+            String::new(),
+            "final page".to_string(),
+        ];
+        let (content, boundaries) = super::join_pages_with_boundaries(&pages);
+        assert_eq!(content, pages.join("\n\n"));
+        assert_eq!(boundaries.len(), pages.len());
+        for (i, b) in boundaries.iter().enumerate() {
+            assert_eq!(b.page_number, i as u32 + 1);
+            assert!(content.is_char_boundary(b.byte_start));
+            assert!(content.is_char_boundary(b.byte_end));
+            assert_eq!(&content[b.byte_start..b.byte_end], pages[i]);
+        }
+    }
 
     #[test]
     fn test_bounding_box_coordinate_conversion() {

--- a/crates/xberg/src/extractors/pdf/extraction.rs
+++ b/crates/xberg/src/extractors/pdf/extraction.rs
@@ -67,7 +67,7 @@ pub(crate) fn extract_all_from_oxide_document(
     if config.pdf_options.as_ref().is_some_and(|opts| opts.reading_order)
         && let Some(hints) = layout_hints
     {
-        match apply_reading_order_reordering(&mut doc, &native_text, hints) {
+        match apply_reading_order_reordering(&mut doc, &native_text, hints, config.pages.as_ref()) {
             Ok((reordered, reordered_boundaries)) => {
                 native_text = reordered;
                 // Reordering rebuilds the text, so boundaries computed against
@@ -327,12 +327,14 @@ pub(crate) fn extract_all_from_oxide_document(
 /// Returns the reordered text string together with page boundaries recomputed
 /// against it — the rebuilt string has a different byte layout, so boundaries
 /// from the original extraction must not be used to index it. An empty
-/// boundary vector means the text was returned unchanged.
+/// boundary vector means the text was returned unchanged. Page markers from
+/// `page_config` are preserved in the rebuilt text.
 #[cfg(feature = "layout-detection")]
 fn apply_reading_order_reordering(
     doc: &mut crate::pdf::oxide::OxideDocument,
     native_text: &str,
     layout_hints_per_page: &[Vec<crate::pdf::structure::types::LayoutHint>],
+    page_config: Option<&crate::core::config::PageConfig>,
 ) -> Result<(String, Vec<crate::types::PageBoundary>)> {
     use crate::extractors::pdf::reading_order;
 
@@ -385,18 +387,27 @@ fn apply_reading_order_reordering(
         return Ok((native_text.to_string(), Vec::new()));
     }
 
-    Ok(join_pages_with_boundaries(&reordered_pages))
+    Ok(join_pages_with_boundaries(&reordered_pages, page_config))
 }
 
-/// Join per-page texts with `"\n\n"` separators, recording each page's byte
-/// range in the combined string. The separators belong to no page, matching
-/// how `extract_text_from_oxide_document` records boundaries.
+/// Join per-page texts, recording each page's byte range in the combined
+/// string, faithful to how `extract_text_from_oxide_document` assembles it:
+/// a rendered page marker before each page when `insert_page_markers` is on,
+/// otherwise `"\n\n"` separators between pages. Markers and separators belong
+/// to no page.
 #[cfg(feature = "layout-detection")]
-fn join_pages_with_boundaries(pages: &[String]) -> (String, Vec<crate::types::PageBoundary>) {
+fn join_pages_with_boundaries(
+    pages: &[String],
+    page_config: Option<&crate::core::config::PageConfig>,
+) -> (String, Vec<crate::types::PageBoundary>) {
+    let markers = page_config.filter(|c| c.insert_page_markers);
     let mut content = String::new();
     let mut boundaries = Vec::with_capacity(pages.len());
     for (idx, page_text) in pages.iter().enumerate() {
-        if idx > 0 {
+        if let Some(config) = markers {
+            let marker = config.marker_format.replace("{page_num}", &(idx + 1).to_string());
+            content.push_str(&marker);
+        } else if idx > 0 {
             content.push_str("\n\n");
         }
         let byte_start = content.len();
@@ -425,7 +436,7 @@ mod tests {
             String::new(),
             "final page".to_string(),
         ];
-        let (content, boundaries) = super::join_pages_with_boundaries(&pages);
+        let (content, boundaries) = super::join_pages_with_boundaries(&pages, None);
         assert_eq!(content, pages.join("\n\n"));
         assert_eq!(boundaries.len(), pages.len());
         for (i, b) in boundaries.iter().enumerate() {
@@ -433,6 +444,32 @@ mod tests {
             assert!(content.is_char_boundary(b.byte_start));
             assert!(content.is_char_boundary(b.byte_end));
             assert_eq!(&content[b.byte_start..b.byte_end], pages[i]);
+        }
+    }
+
+    /// With `insert_page_markers` on, the reordered rebuild must emit the same
+    /// rendered markers as initial extraction: one before each page, outside
+    /// the page's byte range.
+    #[cfg(feature = "layout-detection")]
+    #[test]
+    fn test_join_pages_with_boundaries_page_markers() {
+        let pages = vec!["first • page".to_string(), "second page".to_string()];
+        let page_config = crate::core::config::PageConfig {
+            insert_page_markers: true,
+            marker_format: "\n\n<!-- PAGE {page_num} -->\n\n".to_string(),
+            ..Default::default()
+        };
+        let (content, boundaries) = super::join_pages_with_boundaries(&pages, Some(&page_config));
+        assert_eq!(
+            content,
+            "\n\n<!-- PAGE 1 -->\n\nfirst • page\n\n<!-- PAGE 2 -->\n\nsecond page"
+        );
+        for (i, b) in boundaries.iter().enumerate() {
+            assert_eq!(
+                &content[b.byte_start..b.byte_end],
+                pages[i],
+                "markers stay outside page ranges"
+            );
         }
     }
 

--- a/crates/xberg/src/extractors/pdf/ocr.rs
+++ b/crates/xberg/src/extractors/pdf/ocr.rs
@@ -327,7 +327,16 @@ pub(crate) fn evaluate_per_page_ocr(
     let mut failing_pages: Vec<u32> = Vec::with_capacity(boundaries.len());
     let mut valid_boundary_count: usize = 0;
     for boundary in boundaries {
-        if boundary.byte_end > native_text.len() || boundary.byte_start > boundary.byte_end {
+        if boundary.byte_start > boundary.byte_end
+            || !native_text.is_char_boundary(boundary.byte_start)
+            || !native_text.is_char_boundary(boundary.byte_end)
+        {
+            tracing::warn!(
+                page = boundary.page_number,
+                byte_start = boundary.byte_start,
+                byte_end = boundary.byte_end,
+                "skipping OCR quality evaluation for page with invalid text boundary"
+            );
             continue;
         }
         valid_boundary_count += 1;
@@ -613,6 +622,17 @@ pub(crate) fn merge_ocr_pages_into_native(
     for boundary in sorted_boundaries {
         if let Some(ocr_text) = ocr_results.get(&boundary.page_number) {
             if ocr_text.trim().is_empty() {
+                continue;
+            }
+            // Checked against `result` (not `native_text`) so that overlapping
+            // boundaries stay safe after earlier replacements shift the string.
+            if !result.is_char_boundary(boundary.byte_start) || !result.is_char_boundary(boundary.byte_end) {
+                tracing::warn!(
+                    page = boundary.page_number,
+                    byte_start = boundary.byte_start,
+                    byte_end = boundary.byte_end,
+                    "skipping OCR merge for page with invalid text boundary; keeping native text"
+                );
                 continue;
             }
             result.replace_range(boundary.byte_start..boundary.byte_end, ocr_text);
@@ -1695,6 +1715,70 @@ mod tests {
         assert!(merged.contains("PAGE ONE NATIVE"));
         assert!(merged.contains("CLEAN OCR PAGE TWO"));
         assert!(!merged.contains("garbage page two"));
+    }
+
+    /// Boundaries can go stale when the text they index is rebuilt (e.g.
+    /// reading-order reordering). A stale offset landing inside a multibyte
+    /// character must be skipped, not panic the page.
+    #[cfg(feature = "ocr")]
+    #[test]
+    fn test_per_page_ocr_non_char_boundary_offsets_skipped() {
+        use crate::types::PageBoundary;
+
+        let text = "This is a normal paragraph with meaningful words and proper structure. \
+                    It contains multiple sentences • that form a coherent text block.";
+        let mid_bullet = text.find('•').unwrap() + 1;
+        assert!(!text.is_char_boundary(mid_bullet));
+        let boundaries = vec![
+            PageBoundary {
+                page_number: 1,
+                byte_start: 0,
+                byte_end: mid_bullet,
+            },
+            PageBoundary {
+                page_number: 2,
+                byte_start: mid_bullet,
+                byte_end: text.len(),
+            },
+        ];
+        let decision = evaluate_per_page_ocr(text, Some(&boundaries), Some(2), &t());
+        assert!(
+            decision.failing_pages.is_empty(),
+            "stale non-char-boundary offsets must be skipped, not evaluated"
+        );
+    }
+
+    /// Same staleness in the mixed OCR/native merge: a boundary that does not
+    /// land on char boundaries must leave the native text untouched.
+    #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+    #[test]
+    fn test_merge_non_char_boundary_offsets_skipped() {
+        use crate::types::PageBoundary;
+
+        let native = "PAGE ONE • NATIVE\nPAGE TWO NATIVE";
+        let mid_bullet = native.find('•').unwrap() + 1;
+        assert!(!native.is_char_boundary(mid_bullet));
+        let boundaries = vec![
+            PageBoundary {
+                page_number: 1,
+                byte_start: 0,
+                byte_end: mid_bullet,
+            },
+            PageBoundary {
+                page_number: 2,
+                byte_start: mid_bullet,
+                byte_end: native.len(),
+            },
+        ];
+        let mut ocr_results: ahash::AHashMap<u32, String> = ahash::AHashMap::new();
+        ocr_results.insert(1, "OCR PAGE ONE".to_string());
+        ocr_results.insert(2, "OCR PAGE TWO".to_string());
+
+        let merged = merge_ocr_pages_into_native(native, &boundaries, &ocr_results);
+        assert_eq!(
+            merged, native,
+            "stale non-char-boundary offsets must not be spliced into the native text"
+        );
     }
 
     #[cfg(feature = "ocr")]


### PR DESCRIPTION
I was testing out layout detection in lilbee and discovered these issues.

Closes #1270. Closes #1272.

## Documents silently vanish

With layout detection and `reading_order` on, extraction crashes on PDFs whose text contains a bullet, curly quote, or similar multi-byte character. The crash is caught per document, so the document is just silently skipped. On one OCR-heavy document set this lost about 60% of pages.

## Page markers disappear

Same code path: with reading order on, `insert_page_markers` markers vanish from the output.

## Root cause

Reading-order mode rebuilds the document text, but the recorded per-page byte ranges still pointed into the old text. Later steps cut the *new* text at those outdated positions — and Rust panics when a cut lands inside a multi-byte character. The rebuild also glued pages together with plain blank lines, ignoring the marker config.

## Fix

- Page byte ranges are recalculated from the rebuilt text, so text and positions can't disagree. The OCR quality check, OCR splicing, and chunk page ranges now all see correct pages.
- The rebuilt text keeps page markers, formatted exactly as normal extraction writes them.
- Safety net: the two places that cut text by page position now skip-and-warn on an invalid position instead of crashing the document.

## Verification

New unit tests reproduce both crashes verbatim before the fix. End-to-end, the failing documents crash pre-fix with the exact reported panic and all extract cleanly post-fix with layout detection on.
