### PR TITLE
fix: link Microsoft ONNX Runtime on glibc Linux to honor the manylinux floor

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,6 +36,10 @@ on:
   repository_dispatch:
     types: [publish-release]
 
+env:
+  # glibc floor for the Linux artifacts: zigbuild target suffix + post-build assertion.
+  GLIBC_FLOOR: "2.28"
+
 permissions:
   contents: read
   id-token: write
@@ -458,7 +462,12 @@ jobs:
             export CMAKE_CXX_FLAGS="${CXXFLAGS}"
             export CC="gcc ${CFLAGS}"
             export CXX="g++ ${CXXFLAGS}"
-          cibw-environment: 'MATURIN_BUILD_ARGS="--compatibility manylinux_2_28" CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=gcc CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc CXX_x86_64_unknown_linux_gnu=g++ CXX_aarch64_unknown_linux_gnu=g++'
+            # Link Microsoft's glibc-clean ONNX Runtime, not the pyke prebuilt; auditwheel bundles it (#1284).
+            ort_version=1.24.2
+            case "$(uname -m)" in aarch64 | arm64) ort_arch=aarch64 ;; *) ort_arch=x64 ;; esac
+            curl -fsSL -o /tmp/ort.tgz "https://github.com/microsoft/onnxruntime/releases/download/v${ort_version}/onnxruntime-linux-${ort_arch}-${ort_version}.tgz"
+            mkdir -p /opt/msort && tar -xzf /tmp/ort.tgz -C /opt/msort --strip-components=1
+          cibw-environment: 'MATURIN_BUILD_ARGS="--compatibility manylinux_2_28" CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=gcc CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=gcc CC_x86_64_unknown_linux_gnu=gcc CC_aarch64_unknown_linux_gnu=gcc CXX_x86_64_unknown_linux_gnu=g++ CXX_aarch64_unknown_linux_gnu=g++ ORT_STRATEGY=system ORT_LIB_LOCATION=/opt/msort/lib ORT_SKIP_DOWNLOAD=1 ORT_PREFER_DYNAMIC_LINK=1 LD_LIBRARY_PATH=/opt/msort/lib'
           # The deployment target is the wheel's macOS floor: 15.0 left macOS 11-14
           # with no installable wheel (#1243). delocate bundles the libheif closure,
           # so the hook builds it from source at the target and PKG_CONFIG_PATH links
@@ -467,6 +476,12 @@ jobs:
           cibw-environment-macos: 'MATURIN_BUILD_ARGS="" CARGO_BUILD_LOCKED=true MACOSX_DEPLOYMENT_TARGET=11.0 PKG_CONFIG_PATH=/tmp/xberg-heif/lib/pkgconfig'
           cibw-before-build-windows: "rustup install 1.95-x86_64-pc-windows-msvc --profile minimal --component rust-src --component rustfmt --component clippy && rustup target add x86_64-pc-windows-msvc --toolchain 1.95-x86_64-pc-windows-msvc && pip install maturin uv && set PATH=%USERPROFILE%\\.cargo\\bin;%PATH%"
           cibw-environment-windows: 'MATURIN_BUILD_ARGS="--target x86_64-pc-windows-msvc" RUSTUP_TOOLCHAIN="1.95-x86_64-pc-windows-msvc" RUSTC_WRAPPER='
+
+      - name: Verify wheel glibc floor + bundled ONNX Runtime
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          for w in wheelhouse/*.whl; do scripts/ci/verify-glibc-floor.sh "$w" "$GLIBC_FLOOR"; done
 
       - name: Upload wheels
         uses: actions/upload-artifact@v7
@@ -1122,8 +1137,9 @@ jobs:
       - name: Install system dependencies
         uses: ./.github/actions/install-system-deps
 
+      # linux-gnu links Microsoft's ONNX Runtime (system strategy), shipped beside the lib below (#1284).
       - name: Setup ONNX Runtime
-        if: contains(matrix.target, 'windows')
+        if: contains(matrix.target, 'windows') || contains(matrix.target, '-linux-gnu')
         uses: ./.github/actions/setup-onnx-runtime
         with:
           ort-version: "1.24.2"
@@ -1146,7 +1162,16 @@ jobs:
           header-path: crates/xberg-ffi/include/xberg.h
           archive-name: xberg-go-${{ matrix.platform }}.tar.gz
           output-dir: dist/go-ffi
-          glibc-version: "2.28"
+          glibc-version: ${{ env.GLIBC_FLOOR }}
+      - name: Ship + verify ONNX Runtime (glibc Linux)
+        if: contains(matrix.target, '-linux-gnu')
+        shell: bash
+        run: |
+          for t in dist/go-ffi/*.tar.gz; do
+            scripts/ci/ship-onnxruntime.sh "$t" "$ORT_LIB_LOCATION"
+            scripts/ci/verify-glibc-floor.sh "$t" "$GLIBC_FLOOR"
+          done
+
       - uses: actions/upload-artifact@v7
         with:
           name: go-ffi-${{ matrix.platform }}
@@ -1181,8 +1206,9 @@ jobs:
       - name: Install system dependencies
         uses: ./.github/actions/install-system-deps
 
+      # linux-gnu links Microsoft's ONNX Runtime (system strategy), shipped beside the lib below (#1284).
       - name: Setup ONNX Runtime
-        if: contains(matrix.target, 'windows')
+        if: contains(matrix.target, 'windows') || contains(matrix.target, '-linux-gnu')
         uses: ./.github/actions/setup-onnx-runtime
         with:
           ort-version: "1.24.2"
@@ -1201,7 +1227,7 @@ jobs:
         with:
           crate-name: xberg-ffi
           target: ${{ matrix.target }}
-          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && '2.28' || '' }}
+          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && env.GLIBC_FLOOR || '' }}
 
       - name: Stage C FFI distribution
         # Inline: bundle library + header + LICENSE into a single tarball
@@ -1219,6 +1245,15 @@ jobs:
           cp LICENSE "$STAGE/" 2>/dev/null || true
           mkdir -p dist/c-ffi
           tar -czf "dist/c-ffi/${STAGE}.tar.gz" "$STAGE"
+
+      - name: Ship + verify ONNX Runtime (glibc Linux)
+        if: contains(matrix.target, '-linux-gnu')
+        shell: bash
+        run: |
+          for t in dist/c-ffi/*.tar.gz; do
+            scripts/ci/ship-onnxruntime.sh "$t" "$ORT_LIB_LOCATION"
+            scripts/ci/verify-glibc-floor.sh "$t" "$GLIBC_FLOOR"
+          done
 
       - uses: actions/upload-artifact@v7
         with:
@@ -1254,8 +1289,9 @@ jobs:
       - name: Install system dependencies
         uses: ./.github/actions/install-system-deps
 
+      # linux-gnu links Microsoft's ONNX Runtime (system strategy), shipped beside the lib below (#1284).
       - name: Setup ONNX Runtime
-        if: contains(matrix.target, 'windows')
+        if: contains(matrix.target, 'windows') || contains(matrix.target, '-linux-gnu')
         uses: ./.github/actions/setup-onnx-runtime
         with:
           ort-version: "1.24.2"
@@ -1276,7 +1312,14 @@ jobs:
           crate-name: xberg-ffi
           lib-name: xberg_ffi
           classifier: ${{ matrix.classifier }}
-          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && '2.28' || '' }}
+          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && env.GLIBC_FLOOR || '' }}
+
+      - name: Ship + verify ONNX Runtime (glibc Linux)
+        if: contains(matrix.target, '-linux-gnu')
+        shell: bash
+        run: |
+          scripts/ci/ship-onnxruntime.sh dist/java-natives "$ORT_LIB_LOCATION"
+          scripts/ci/verify-glibc-floor.sh dist/java-natives "$GLIBC_FLOOR"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -1419,7 +1462,7 @@ jobs:
           crate-name: xberg-ffi
           lib-name: xberg_ffi
           rid: ${{ matrix.rid }}
-          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && '2.28' || '' }}
+          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && env.GLIBC_FLOOR || '' }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -1535,6 +1578,14 @@ jobs:
         shell: bash
         run: echo "RUSTC_WRAPPER=" >> "$GITHUB_ENV"
 
+      # linux-gnu links Microsoft's ONNX Runtime (system strategy), shipped beside the NIF below (#1284).
+      - name: Setup ONNX Runtime
+        if: contains(matrix.target, '-linux-gnu')
+        uses: ./.github/actions/setup-onnx-runtime
+        with:
+          ort-version: "1.24.2"
+          dest-dir: crates/xberg-ffi
+
       - uses: xberg-io/actions/build-elixir-natives@v1
         with:
           target: ${{ matrix.target }}
@@ -1543,8 +1594,17 @@ jobs:
           package-dir: packages/elixir
           nif-version: ${{ needs.prepare.outputs.version }}
           nif-api-version: ${{ matrix.nif }}
-          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && '2.28' || '' }}
+          glibc-version: ${{ contains(matrix.target, '-linux-gnu') && env.GLIBC_FLOOR || '' }}
           dry-run: ${{ needs.prepare.outputs.dry_run }}
+
+      - name: Ship + verify ONNX Runtime (glibc Linux)
+        if: contains(matrix.target, '-linux-gnu')
+        shell: bash
+        run: |
+          for t in dist/elixir-natives/*.tar.gz; do
+            scripts/ci/ship-onnxruntime.sh "$t" "$ORT_LIB_LOCATION"
+            scripts/ci/verify-glibc-floor.sh "$t" "$GLIBC_FLOOR"
+          done
 
       - uses: actions/upload-artifact@v7
         with:
@@ -1679,8 +1739,8 @@ jobs:
           # Use zigbuild for linux-gnu targets to set glibc floor to 2.28
           if [[ "$TARGET" == *"-linux-gnu" ]]; then
             BUILD_CMD="cargo zigbuild"
-            TARGET_ARG="${TARGET}.2.28"
-            echo "[publish] glibc floor: 2.28 (target: ${TARGET_ARG})"
+            TARGET_ARG="${TARGET}.${GLIBC_FLOOR}"
+            echo "[publish] glibc floor: ${GLIBC_FLOOR} (target: ${TARGET_ARG})"
           fi
           ${BUILD_CMD} --locked -p xberg-dart --release --target "${TARGET_ARG}"
       - name: Stage native library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Linux glibc artifacts no longer require a newer glibc than they advertise.** The prebuilt ONNX Runtime that was statically linked into the Python wheel and the Go/C FFI, Java, and Elixir artifacts is compiled against glibc ≥ 2.38 and pulled unversioned `__isoc23_*` and `__libc_single_threaded` symbols into the binary. Because the manylinux tag only reflects *versioned* glibc requirements, these installed everywhere but crashed at import/load on glibc 2.28–2.37 (`undefined symbol: __isoc23_strtoll`). They now link Microsoft's ONNX Runtime (glibc-clean, floors at 2.27) — the same runtime the C#, Node, and Docker builds already use — and ship it beside the binary, so the symbols are gone and the floor is honest. A CI check now fails any glibc artifact that references too-new symbols or omits the bundled runtime. musl, macOS, and Windows are unaffected.
+
 ## [1.0.0-rc.31] - 2026-07-21
 
 ### Added

--- a/scripts/ci/ship-onnxruntime.sh
+++ b/scripts/ci/ship-onnxruntime.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Copy libonnxruntime.so* beside the xberg native library in a built artifact, so
+# the runtime resolves via RPATH=$ORIGIN at load time (#1284).
+#
+# Usage: ship-onnxruntime.sh <artifact> <ort-lib-dir>
+#   <artifact>     a *.tar.gz/*.tgz or a directory
+#   <ort-lib-dir>  directory holding libonnxruntime.so* (ORT_LIB_LOCATION)
+set -euo pipefail
+
+log() { echo "ship-onnxruntime: $*" >&2; }
+die() { log "$*"; exit 1; }
+cleanup() { [ -n "${WORKDIR:-}" ] && rm -rf "$WORKDIR"; }
+
+# Copy every libonnxruntime.so* from $2 beside the first xberg native lib under $1.
+place_beside_native() {
+  local root="$1" ort_lib="$2" native dir
+  native="$(find "$root" \
+    \( -name 'libxberg_*.so' -o -name '_xberg*.so' -o -name '*.node' \
+    -o -name 'php_xberg.so' \) -type f | head -1)"
+  [ -n "$native" ] || die "no xberg native library found under $root"
+  dir="$(dirname "$native")"
+  cp -v "$ort_lib"/libonnxruntime.so* "$dir/"
+  log "shipped ONNX Runtime beside $(basename "$native")"
+}
+
+ship_tarball() {
+  local tar="$1" ort_lib="$2"
+  mkdir -p "$WORKDIR/x"
+  tar -xzf "$tar" -C "$WORKDIR/x"
+  place_beside_native "$WORKDIR/x" "$ort_lib"
+  rm -f "$tar"
+  tar -czf "$tar" -C "$WORKDIR/x" .
+}
+
+main() {
+  [ $# -eq 2 ] || die "usage: $(basename "$0") <artifact> <ort-lib-dir>"
+  local artifact="$1" ort_lib="$2"
+  if [ ! -d "$ort_lib" ] || ! ls "$ort_lib"/libonnxruntime.so* >/dev/null 2>&1; then
+    die "no libonnxruntime.so* in '$ort_lib'"
+  fi
+  WORKDIR="$(mktemp -d)"
+  trap cleanup EXIT
+
+  case "$artifact" in
+  *.tar.gz | *.tgz) ship_tarball "$artifact" "$ort_lib" ;;
+  *)
+    [ -d "$artifact" ] || die "unsupported artifact '$artifact'"
+    place_beside_native "$artifact" "$ort_lib"
+    ;;
+  esac
+  log "done"
+}
+
+main "$@"

--- a/scripts/ci/verify-glibc-floor.sh
+++ b/scripts/ci/verify-glibc-floor.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Fail a build whose glibc Linux artifact would break on an old glibc (#1284).
+# For each xberg native library it asserts:
+#   1. no __isoc23_* / __libc_single_threaded references (need glibc >= 2.32),
+#   2. highest versioned GLIBC symbol <= the floor (default 2.28),
+#   3. libonnxruntime.so bundled beside it.
+#
+# Usage: verify-glibc-floor.sh <artifact> [max-glibc]
+#   <artifact>  a *.whl, *.tar.gz/*.tgz, or a directory
+#   max-glibc   floor as MAJOR.MINOR (default 2.28)
+set -euo pipefail
+
+MAX_GLIBC="${2:-2.28}"
+
+log() { echo "verify-glibc-floor: $*" >&2; }
+die() { log "$*"; exit 1; }
+cleanup() { [ -n "${WORKDIR:-}" ] && rm -rf "$WORKDIR"; }
+
+# Compare two MAJOR.MINOR versions; return 0 if $1 > $2.
+gt() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]; }
+
+check_lib() {
+  local lib="$1" root="$2" name bad highest
+  name="$(basename "$lib")"
+
+  bad="$(objdump -T "$lib" 2>/dev/null | grep -oE '__isoc23[a-z_]*|__libc_single_threaded' | sort -u || true)"
+  [ -z "$bad" ] || die "$name references too-new symbols: $(echo "$bad" | tr '\n' ' ')"
+
+  highest="$(objdump -T "$lib" 2>/dev/null | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -V | tail -1)"
+  if [ -n "$highest" ] && gt "$highest" "$MAX_GLIBC"; then
+    die "$name requires glibc $highest > floor $MAX_GLIBC"
+  fi
+
+  if ! find "$root" -name 'libonnxruntime.so*' -type f | grep -q .; then
+    die "$name has no libonnxruntime.so bundled in the artifact"
+  fi
+  log "OK $name (floor <= $MAX_GLIBC, ORT bundled)"
+}
+
+# Run the checks against every xberg native library found under $1.
+verify_tree() {
+  local root="$1" found=0 lib
+  while IFS= read -r lib; do
+    found=1
+    check_lib "$lib" "$root"
+  done < <(find "$root" \( -name 'libxberg_*.so' -o -name '_xberg*.so' -o -name 'php_xberg.so' \) -type f)
+  [ "$found" = 1 ] || die "no xberg native library found under $root"
+}
+
+main() {
+  [ $# -ge 1 ] || die "usage: $(basename "$0") <artifact> [max-glibc]"
+  local artifact
+  artifact="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+  WORKDIR="$(mktemp -d)"
+  trap cleanup EXIT
+
+  case "$artifact" in
+  *.whl) unzip -qo "$artifact" -d "$WORKDIR"; verify_tree "$WORKDIR" ;;
+  *.tar.gz | *.tgz) tar -xzf "$artifact" -C "$WORKDIR"; verify_tree "$WORKDIR" ;;
+  *) [ -d "$artifact" ] || die "unsupported artifact '$artifact'"; verify_tree "$artifact" ;;
+  esac
+  log "artifact passes the glibc floor gate"
+}
+
+main "$@"


### PR DESCRIPTION
Fixes #1284.

## Problem

The Python wheel and the Go/C FFI and Java artifacts statically link the pyke prebuilt ONNX Runtime, which is compiled against glibc ≥ 2.38. That pulls **unversioned** `__isoc23_*` and `__libc_single_threaded` symbols into the binary.

`auditwheel` only checks *versioned* glibc requirements, so it never sees them — the wheel gets a `manylinux_2_28` tag it can't honor and dies at import on glibc 2.28–2.37:

```
undefined symbol: __isoc23_strtoll
```

## Fix

Link **Microsoft's** ONNX Runtime (glibc-clean, floors at 2.27) in those builds — the exact runtime the Docker images and the C#/Elixir/Node artifacts **already use**. No source changes; the affected builds were simply the ones that never got that treatment.

- **Wheel:** download Microsoft ORT in-container and point `ort-sys` at it (`ORT_STRATEGY=system`). `auditwheel` then bundles it, like any other native dep.
- **Go/C FFI, Java:** enable the existing `setup-onnx-runtime` step on linux-gnu (it was Windows-only), matching C#/Elixir.

C#, Elixir, and Node already link Microsoft ORT on linux-gnu and are unchanged. musl, macOS, and Windows are unaffected.

## Why not just build in an older-glibc container?

The wheel is already built in a `manylinux_2_28` (glibc 2.28) container. The bad symbols don't come from the build compiler — they're baked into a **downloaded prebuilt** ONNX Runtime compiled elsewhere against glibc 2.38. Linking a too-new prebuilt into an old container doesn't strip its symbols. The fix is to link a glibc-clean runtime instead.

## Evidence

On Ubuntu 20.04, x86_64, **glibc 2.31**:

- Before — the shipped rc30 wheel installs, then import fails: `undefined symbol: __libc_single_threaded`.
- Microsoft ORT 1.24.2 loads on the same host: `OrtGetApiBase` present, highest versioned GLIBC **2.27**, **zero** `__isoc23`.

| ONNX Runtime | Highest versioned GLIBC | `__isoc23` |
|---|---|---|
| pyke prebuilt (current, static) | 2.28 versioned, **2.38 unversioned** | 3 |
| Microsoft 1.24.2 | 2.27 | 0 |

The `publish.yaml` changes run only in release CI, so they are validated there.
