### PR TITLE
fix(cli): bundle Linux runtime dependencies

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1036,6 +1036,7 @@ jobs:
         run: |
           STAGE="xberg-cli-${TARGET}"
           mkdir -p "$STAGE"
+          cp LICENSE THIRD_PARTY_LICENSES.md "$STAGE/"
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp "$BINARY_PATH" "$STAGE/xberg.exe"
             7z a "${STAGE}.zip" "$STAGE" >/dev/null
@@ -1055,6 +1056,13 @@ jobs:
                 echo "::error::vendored ONNX Runtime links non-system libraries:"; echo "$deps"; exit 1
               fi
               codesign --force -s - "$STAGE/libonnxruntime.dylib" || true
+            fi
+            # Linux CLI builds enable the formats feature, which dynamically
+            # links libheif. Ship its complete non-system dependency closure.
+            if [[ "$TARGET" == *-unknown-linux-gnu ]]; then
+              bash scripts/ci/vendor-native-closure.sh "$STAGE/xberg"
+              compgen -G "$STAGE/libheif.so*" >/dev/null
+              env -u LD_LIBRARY_PATH "$STAGE/xberg" --version
             fi
             tar -czf "${STAGE}.tar.gz" "$STAGE"
           fi
@@ -1098,6 +1106,7 @@ jobs:
         run: |
           STAGE="xberg-cli-${TARGET}"
           mkdir -p "$STAGE/lib"
+          cp LICENSE THIRD_PARTY_LICENSES.md "$STAGE/"
           cp build-output/xberg "$STAGE/xberg"
           cp build-output/xberg.bin "$STAGE/xberg.bin"
           cp -a build-output/lib/. "$STAGE/lib/"

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -2,18 +2,18 @@
 
 Xberg itself is licensed under [MIT](LICENSE). This file documents
 notable third-party **native** libraries that Xberg links against or that are
-redistributed in the published container images, with an emphasis on copyleft
+redistributed in published release artifacts, with an emphasis on copyleft
 (LGPL/GPL) components and how Xberg stays compliant.
 
 > Rust crate dependencies and their licenses are governed by `deny.toml`
 > (`cargo deny check licenses`). This file covers the **system/native** libraries
 > that are linked at the C ABI level and are not visible to `cargo deny`.
 
-## libheif (HEIF / HEIC / AVIF decoding) — LGPL
+## libheif (HEIF / HEIC / AVIF) — LGPL
 
-- **Feature:** optional `heic` Cargo feature (part of `full`/`formats`). Disabled
-  by default. The standalone CLI release binaries (`xberg-cli-*.tar.gz`) are
-  built **without** `heic`, so they do not link `libheif` at all.
+- **Feature:** optional `heic` Cargo feature (part of `full`/`formats`). The
+  standalone CLI enables `formats`, so its release binaries link `libheif`
+  dynamically.
 - **License:** GNU Lesser General Public License (LGPL). See the upstream
   [`COPYING`](https://github.com/strukturag/libheif/blob/master/COPYING) for the
   authoritative version and text.
@@ -24,18 +24,19 @@ redistributed in the published container images, with an emphasis on copyleft
   `libheif.so` at runtime rather than embedding it. The static-build
   (`embedded-libheif`) feature has been **removed** from `xberg-libheif`, so
   there is no supported way to statically link `libheif` into a Xberg build.
-- **Redistribution (container images):** the `full`/`core` images ship the
-  unmodified upstream `libheif` (v1.23.0, built from the official release tarball)
-  as a standalone `libheif.so*` in `/usr/local/lib`. Because it is a separate,
-  dynamically-loaded shared object, you may replace it with your own build of
-  `libheif` to satisfy LGPL §6 (the "replace the library" requirement). Upstream
-  source: <https://github.com/strukturag/libheif> (release v1.23.0).
+- **Redistribution:** the Linux CLI archives and the `full`/`core` images ship
+  unmodified `libheif` shared objects separately from the Xberg executable.
+  The glibc builds use v1.23.0 from the official release tarball; musl builds
+  use Alpine's shared package. The library remains replaceable to satisfy LGPL
+  §6. Upstream source: <https://github.com/strukturag/libheif>.
 
-## libheif codec plugins (container images only)
+## libheif codec libraries
 
-`libheif` loads codec backends as separate dynamically-loaded plugin `.so`s. The
-container images install these from the distro package manager (apt/apk); each
-retains its own upstream license and is redistributed unmodified:
+Depending on how `libheif` was built, its codec backends are linked shared
+libraries or dynamically-loaded plugins. Linux CLI packaging vendors the
+non-system shared-library closure required by its `libheif` build; container
+images install the same codecs from the distro package manager. Each remains a
+separate, replaceable shared object and retains its upstream license:
 
 | Library  | Role            | License (upstream)          |
 | -------- | --------------- | --------------------------- |
@@ -44,10 +45,9 @@ retains its own upstream license and is redistributed unmodified:
 | libaom   | AV1 dec/enc     | BSD-2-Clause + patent grant |
 | libx265  | HEVC **encode** | **GPL-2.0-or-later**        |
 
-All are loaded dynamically (separate `.so`, replaceable). **Note:** Xberg only
-*decodes* HEIF/HEIC/AVIF, so the HEVC **encoder** `libx265` (GPL) is not required
-for Xberg's functionality; it is pulled in only as a default `libheif` plugin
-dependency and can be dropped from the images to avoid shipping a GPL component.
+Xberg supports both HEIF-family input decoding and optional HEIF image output.
+`libx265` is needed only for the latter and is redistributed only when the
+platform's `libheif` build links it.
 
 ## ONNX Runtime (OCR / ML features)
 

--- a/docker/Dockerfile.musl-build
+++ b/docker/Dockerfile.musl-build
@@ -42,16 +42,20 @@ RUN cargo build --release --package xberg-cli --features all && \
 
 RUN patchelf --set-rpath '$ORIGIN/lib' /build/xberg
 
+# Seed dependency discovery with the executable as well as the libraries that
+# are copied explicitly below. Otherwise direct dependencies such as libheif
+# never enter the recursive closure.
 RUN set -eu; \
-    mkdir -p /build/lib; \
+    mkdir -p /build/lib/libheif; \
     cp /usr/lib/libstdc++.so.6 /build/lib/; \
     cp /usr/lib/libgcc_s.so.1 /build/lib/; \
     cp /usr/lib/libonnxruntime.so* /build/lib/ 2>/dev/null || true; \
     cp /lib/ld-musl-*.so.1 /build/lib/ 2>/dev/null || true; \
+    cp -a /usr/lib/libheif/. /build/lib/libheif/; \
     LOADER="$(ls /build/lib/ld-musl-*.so.1 | head -n1)"; \
     while :; do \
         before=$(ls /build/lib | wc -l); \
-        for so in /build/lib/*.so*; do \
+        for so in /build/xberg /build/lib/*.so* /build/lib/libheif/*.so*; do \
             case "$so" in *ld-musl-*) continue ;; esac; \
             "$LOADER" --list "$so" 2>/dev/null \
                 | awk '/=>/ { print $3 }' \
@@ -66,7 +70,7 @@ RUN set -eu; \
         after=$(ls /build/lib | wc -l); \
         [ "$before" = "$after" ] && break; \
     done; \
-    for so in /build/lib/*.so*; do \
+    for so in /build/xberg /build/lib/*.so* /build/lib/libheif/*.so*; do \
         case "$so" in *ld-musl-*) continue ;; esac; \
         if "$LOADER" --library-path /build/lib --list "$so" 2>&1 | grep -q 'not found'; then \
             echo "FAIL: $so has unresolved dependencies inside the bundle:" >&2; \
@@ -74,19 +78,22 @@ RUN set -eu; \
             exit 1; \
         fi; \
     done; \
+    ls /build/lib/libheif.so* >/dev/null; \
+    ls /build/lib/libheif/*.so* >/dev/null; \
     echo "OK: every bundled library resolves inside /build/lib/"
 
 RUN mv /build/xberg /build/xberg.bin && \
     INTERP_NAME=$(basename /lib/ld-musl-*.so.1) && \
-    printf '#!/bin/sh\nSCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\nexec "$SCRIPT_DIR/lib/%s" --library-path "$SCRIPT_DIR/lib" "$SCRIPT_DIR/xberg.bin" "$@"\n' \
+    printf '#!/bin/sh\nSCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"\nexport LIBHEIF_PLUGIN_PATH="$SCRIPT_DIR/lib/libheif${LIBHEIF_PLUGIN_PATH:+:$LIBHEIF_PLUGIN_PATH}"\nexec "$SCRIPT_DIR/lib/%s" --library-path "$SCRIPT_DIR/lib" "$SCRIPT_DIR/xberg.bin" "$@"\n' \
         "$INTERP_NAME" > /build/xberg && \
     chmod +x /build/xberg
 
-RUN file /build/xberg && \
+RUN file /build/xberg /build/xberg.bin && \
     echo "=== Dynamic dependencies ===" && \
-    readelf -d /build/xberg 2>/dev/null | grep -E "NEEDED|RPATH|RUNPATH" || echo "No dependencies" && \
+    readelf -d /build/xberg.bin 2>/dev/null | grep -E "NEEDED|RPATH|RUNPATH" && \
     echo "=== Bundled libraries ===" && \
-    ls -la /build/lib/
+    find /build/lib -maxdepth 2 -type f -print && \
+    /build/xberg --version
 
 FROM scratch
 COPY --from=builder /build/xberg /xberg

--- a/scripts/ci/vendor-native-closure.sh
+++ b/scripts/ci/vendor-native-closure.sh
@@ -14,9 +14,57 @@ is_base_lib() {
   esac
 }
 
+set_origin_rpath() {
+  local elf="$1"
+  # Every copied library may have its own transitive DT_NEEDED entries. Giving
+  # each ELF an origin-relative RUNPATH keeps the flattened bundle relocatable.
+  # shellcheck disable=SC2016
+  patchelf --set-rpath '$ORIGIN' "$elf"
+}
+
+verify_local_closure() {
+  local native="$1" dir report lib base resolved
+  dir="$(cd "$(dirname "$native")" && pwd)"
+  report="$(mktemp)"
+
+  # install-system-deps exports /usr/local/lib for the build. Drop it here so
+  # this check proves the packaged RUNPATH works without the build environment.
+  if ! env -u LD_LIBRARY_PATH ldd "$native" >"$report" 2>&1; then
+    cat "$report" >&2
+    rm -f "$report"
+    die "$(basename "$native") has unresolved dependencies after vendoring"
+  fi
+  if grep -q 'not found' "$report"; then
+    cat "$report" >&2
+    rm -f "$report"
+    die "$(basename "$native") has unresolved dependencies after vendoring"
+  fi
+
+  while IFS= read -r lib; do
+    [ -f "$lib" ] || continue
+    base="$(basename "$lib")"
+    is_base_lib "$base" && continue
+    resolved="$(readlink -f "$lib")"
+    case "$resolved" in
+    "$dir"/*) ;;
+    *)
+      cat "$report" >&2
+      rm -f "$report"
+      die "$base still resolves outside the bundle: $resolved"
+      ;;
+    esac
+  done < <(
+    sed -n 's/.*=> *\(\/[^ ]*\).*/\1/p; s/^[[:space:]]*\(\/[^ ]*\) (0x[0-9a-f]*)$/\1/p' "$report"
+  )
+
+  rm -f "$report"
+  log "verified local dependency closure for $(basename "$native")"
+}
+
 vendor_one() {
-  local native="$1" dir queue seen bin lib base
-  dir="$(dirname "$native")"
+  local native="$1" dir queue seen bin lib base destination
+  dir="$(cd "$(dirname "$native")" && pwd)"
+  native="$dir/$(basename "$native")"
   queue="$(mktemp)"
   seen="$(mktemp)"
   printf '%s\n' "$native" >"$queue"
@@ -31,15 +79,19 @@ vendor_one() {
         is_base_lib "$base" && continue
         grep -qxF "$base" "$seen" 2>/dev/null && continue
         printf '%s\n' "$base" >>"$seen"
-        cp -L "$lib" "$dir/$base"
-        chmod u+w "$dir/$base" 2>/dev/null || true
-        printf '%s\n' "$dir/$base" >>"$queue"
+        destination="$dir/$base"
+        if [ "$(readlink -f "$lib")" != "$(readlink -f "$destination" 2>/dev/null || true)" ]; then
+          cp -L "$lib" "$destination"
+        fi
+        chmod u+w "$destination" 2>/dev/null || true
+        set_origin_rpath "$destination"
+        printf '%s\n' "$destination" >>"$queue"
         log "vendored $base beside $(basename "$native")"
       done
   done
   rm -f "$queue" "$seen"
-  # shellcheck disable=SC2016
-  patchelf --set-rpath '$ORIGIN' "$native"
+  set_origin_rpath "$native"
+  verify_local_closure "$native"
 }
 
 vendor_tree() {
@@ -63,7 +115,15 @@ main() {
     tar -czf "$artifact" -C "$WORKDIR" .
     ;;
   *.so | *.node) vendor_one "$artifact" ;;
-  *) [ -d "$artifact" ] || die "unsupported artifact '$artifact'"; vendor_tree "$artifact" ;;
+  *)
+    if [ -f "$artifact" ]; then
+      vendor_one "$artifact"
+    elif [ -d "$artifact" ]; then
+      vendor_tree "$artifact"
+    else
+      die "unsupported artifact '$artifact'"
+    fi
+    ;;
   esac
   log "done"
 }


### PR DESCRIPTION
## Related

Fixes #1307.

## Description

- Vendor the GNU CLI's complete non-system shared-library closure beside `xberg`, patch every copied ELF to use `$ORIGIN`, and verify resolution with the build-time `LD_LIBRARY_PATH` removed.
- Seed the musl closure from `xberg` itself, bundle Alpine's default libheif decoder plugins, and set `LIBHEIF_PLUGIN_PATH` in the relocatable launcher.
- Add release-time `--version` smoke checks and include the license notices in CLI archives.
- Correct the stale third-party documentation: the standalone CLI enables `formats` and therefore links libheif dynamically.

This intentionally increases the Linux archive size. The GNU closure may include libx265 when the provisioned libheif build links its HEIF encoder; `THIRD_PARTY_LICENSES.md` now calls out that GPL-licensed component explicitly for maintainer review.

## Validation

- `shellcheck scripts/ci/vendor-native-closure.sh`
- `actionlint .github/workflows/publish.yaml`
- `hadolint docker/Dockerfile.musl-build`
- Replayed the GNU packaging fix against the official v1.0.0-rc.33 binary on Ubuntu 24.04; it starts without `LD_LIBRARY_PATH` and extracts PDF, DOCX, Markdown, and text fixtures.
- Replayed the musl packaging fix against the official v1.0.0-rc.33 archive with Alpine's libheif 1.23.0 closure; it starts and extracts HEIC, HEIF, and AVIF fixtures using only bundled libraries/plugins.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable