### PR TITLE
feat(api): add job cancellation endpoint (DELETE /jobs/{job_id})

### DIFF
--- a/crates/xberg/src/api/handlers.rs
+++ b/crates/xberg/src/api/handlers.rs
@@ -1077,6 +1077,7 @@ pub(crate) async fn extract_async_handler(
     let mut effective_config = request.config.unwrap_or_else(|| (*state.default_config).clone());
     apply_multipart_config_fields(&mut effective_config, request.output_format, request.pdf_passwords);
     enforce_api_uri_policy(&request.inputs)?;
+    effective_config.cancel_token = state.job_store.cancellation_token(&job_id);
     let inputs = request.inputs;
 
     let job_store = Arc::clone(&state.job_store);
@@ -1154,6 +1155,60 @@ pub(crate) async fn job_status_handler(
     }
 }
 
+/// Cancel a pending or running async extraction job.
+///
+/// DELETE /jobs/{job_id}
+///
+/// A pending job is removed from the queue; a running job's extraction is
+/// signalled to stop cooperatively at its next checkpoint. Both transition to
+/// `cancelled` and return the updated `JobStatus`. A job that already reached
+/// `completed`, `failed`, or `cancelled` cannot be cancelled again and returns
+/// 409. Jobs expire after 5 minutes and return 404 once evicted, as with
+/// `GET /jobs/{job_id}`.
+#[cfg(feature = "api")]
+#[utoipa::path(
+    delete,
+    path = "/jobs/{job_id}",
+    tag = "extraction",
+    params(
+        ("job_id" = String, Path, description = "Job ID returned by POST /extract-async"),
+    ),
+    responses(
+        (status = 200, description = "Job cancelled", body = crate::api::types::JobStatus),
+        (status = 404, description = "Job not found or expired", body = crate::api::types::ErrorResponse),
+        (status = 409, description = "Job already reached a terminal state", body = crate::api::types::ErrorResponse),
+    )
+)]
+pub(crate) async fn cancel_job_handler(
+    State(state): State<ApiState>,
+    axum::extract::Path(job_id): axum::extract::Path<String>,
+) -> Result<axum::Json<JobStatusResponse>, ApiError> {
+    match state.job_store.cancel(&job_id, super::jobs::now_rfc3339()) {
+        super::jobs::CancelOutcome::Cancelled(status) => Ok(axum::Json(status)),
+        super::jobs::CancelOutcome::Conflict(status) => Err(ApiError {
+            status: axum::http::StatusCode::CONFLICT,
+            body: super::types::ErrorResponse {
+                error_type: "ConflictError".to_string(),
+                message: format!(
+                    "Job '{}' already reached state '{:?}' and cannot be cancelled",
+                    job_id, status.state
+                ),
+                traceback: None,
+                status_code: axum::http::StatusCode::CONFLICT.as_u16(),
+            },
+        }),
+        super::jobs::CancelOutcome::NotFound => Err(ApiError {
+            status: axum::http::StatusCode::NOT_FOUND,
+            body: super::types::ErrorResponse {
+                error_type: "NotFoundError".to_string(),
+                message: format!("Job '{}' not found or expired", job_id),
+                traceback: None,
+                status_code: axum::http::StatusCode::NOT_FOUND.as_u16(),
+            },
+        }),
+    }
+}
+
 /// Handler for 404 Not Found errors.
 ///
 /// Returns a JSON error response instead of the default plain text.
@@ -1193,7 +1248,7 @@ mod tests {
         #[cfg(feature = "api")]
         let router = router
             .route("/extract-async", post(extract_async_handler))
-            .route("/jobs/{job_id}", get(job_status_handler));
+            .route("/jobs/{job_id}", get(job_status_handler).delete(cancel_job_handler));
 
         router.with_state(state)
     }
@@ -1427,6 +1482,164 @@ mod tests {
             response.status(),
             StatusCode::NOT_FOUND,
             "expected HTTP 404 for unknown job ID"
+        );
+    }
+
+    #[cfg(feature = "api")]
+    #[tokio::test]
+    async fn test_cancel_job_not_found() {
+        let app = test_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/jobs/does-not-exist")
+                    .body(Body::empty())
+                    .expect("valid request"),
+            )
+            .await
+            .expect("handler responded");
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "expected HTTP 404 for unknown job ID"
+        );
+    }
+
+    #[cfg(feature = "api")]
+    #[tokio::test]
+    async fn test_cancel_job_immediately_after_submission() {
+        use crate::api::types::{JobState, JobStatus};
+        use tower::Service;
+
+        let mut app = test_router();
+        let boundary = "cancelboundary000";
+        let body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"files\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--{boundary}--\r\n",
+            boundary = boundary
+        );
+
+        let post_req: Request<Body> = Request::builder()
+            .method("POST")
+            .uri("/extract-async")
+            .header("content-type", format!("multipart/form-data; boundary={}", boundary))
+            .body(Body::from(body))
+            .expect("valid request");
+        let post_response = tower::ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .expect("service ready")
+            .call(post_req)
+            .await
+            .expect("POST handler responded");
+        let post_bytes = axum::body::to_bytes(post_response.into_body(), usize::MAX)
+            .await
+            .expect("POST body bytes readable");
+        let async_resp: AsyncJobResponse =
+            serde_json::from_slice(&post_bytes).expect("POST response parses as AsyncJobResponse");
+        let job_id = async_resp.job_id;
+
+        let delete_req: Request<Body> = Request::builder()
+            .method("DELETE")
+            .uri(format!("/jobs/{}", job_id))
+            .body(Body::empty())
+            .expect("valid request");
+        let delete_response = tower::ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .expect("service ready")
+            .call(delete_req)
+            .await
+            .expect("DELETE handler responded");
+
+        assert_eq!(
+            delete_response.status(),
+            StatusCode::OK,
+            "expected HTTP 200 when cancelling a job that has not yet reached a terminal state"
+        );
+        let delete_bytes = axum::body::to_bytes(delete_response.into_body(), usize::MAX)
+            .await
+            .expect("DELETE body bytes readable");
+        let status: JobStatus = serde_json::from_slice(&delete_bytes).expect("response is JobStatus");
+        assert_eq!(status.job_id, job_id);
+        assert_eq!(status.state, JobState::Cancelled);
+    }
+
+    #[cfg(feature = "api")]
+    #[tokio::test]
+    async fn test_cancel_job_conflict_after_completion() {
+        use crate::api::types::{JobState, JobStatus};
+        use tower::Service;
+
+        let mut app = test_router();
+        let boundary = "conflictboundary111";
+        let body = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"files\"; filename=\"test.txt\"\r\nContent-Type: text/plain\r\n\r\nhello world\r\n--{boundary}--\r\n",
+            boundary = boundary
+        );
+
+        let post_req: Request<Body> = Request::builder()
+            .method("POST")
+            .uri("/extract-async")
+            .header("content-type", format!("multipart/form-data; boundary={}", boundary))
+            .body(Body::from(body))
+            .expect("valid request");
+        let post_response = tower::ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .expect("service ready")
+            .call(post_req)
+            .await
+            .expect("POST handler responded");
+        let post_bytes = axum::body::to_bytes(post_response.into_body(), usize::MAX)
+            .await
+            .expect("POST body bytes readable");
+        let async_resp: AsyncJobResponse =
+            serde_json::from_slice(&post_bytes).expect("POST response parses as AsyncJobResponse");
+        let job_id = async_resp.job_id;
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let poll_req: Request<Body> = Request::builder()
+                .method("GET")
+                .uri(format!("/jobs/{}", job_id))
+                .body(Body::empty())
+                .expect("valid request");
+            let resp = tower::ServiceExt::<Request<Body>>::ready(&mut app)
+                .await
+                .expect("service ready")
+                .call(poll_req)
+                .await
+                .expect("GET responded");
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("body readable");
+            let status: JobStatus = serde_json::from_slice(&bytes).expect("response is JobStatus");
+            if matches!(status.state, JobState::Completed | JobState::Failed) {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "job did not reach terminal state within 2s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+
+        let delete_req: Request<Body> = Request::builder()
+            .method("DELETE")
+            .uri(format!("/jobs/{}", job_id))
+            .body(Body::empty())
+            .expect("valid request");
+        let delete_response = tower::ServiceExt::<Request<Body>>::ready(&mut app)
+            .await
+            .expect("service ready")
+            .call(delete_req)
+            .await
+            .expect("DELETE handler responded");
+
+        assert_eq!(
+            delete_response.status(),
+            StatusCode::CONFLICT,
+            "expected HTTP 409 when cancelling a job that already completed"
         );
     }
 

--- a/crates/xberg/src/api/handlers.rs
+++ b/crates/xberg/src/api/handlers.rs
@@ -1179,11 +1179,31 @@ pub(crate) async fn job_status_handler(
         (status = 409, description = "Job already reached a terminal state", body = crate::api::types::ErrorResponse),
     )
 )]
+#[cfg_attr(
+    feature = "otel",
+    tracing::instrument(
+        name = "api.cancel_job",
+        skip(state),
+        fields(job_id = %job_id, outcome = tracing::field::Empty)
+    )
+)]
 pub(crate) async fn cancel_job_handler(
     State(state): State<ApiState>,
     axum::extract::Path(job_id): axum::extract::Path<String>,
 ) -> Result<axum::Json<JobStatusResponse>, ApiError> {
-    match state.job_store.cancel(&job_id, super::jobs::now_rfc3339()) {
+    let outcome = state.job_store.cancel(&job_id, super::jobs::now_rfc3339());
+
+    #[cfg(feature = "otel")]
+    tracing::Span::current().record(
+        "outcome",
+        match &outcome {
+            super::jobs::CancelOutcome::Cancelled(_) => "cancelled",
+            super::jobs::CancelOutcome::Conflict(_) => "conflict",
+            super::jobs::CancelOutcome::NotFound => "not_found",
+        },
+    );
+
+    match outcome {
         super::jobs::CancelOutcome::Cancelled(status) => Ok(axum::Json(status)),
         super::jobs::CancelOutcome::Conflict(status) => Err(ApiError {
             status: axum::http::StatusCode::CONFLICT,

--- a/crates/xberg/src/api/jobs.rs
+++ b/crates/xberg/src/api/jobs.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use moka::sync::Cache;
 
 use crate::api::types::{JobState, JobStatus};
+use crate::cancellation::CancellationToken;
 
 /// Default time-to-live for completed/failed jobs (5 minutes).
 const JOB_TTL: Duration = Duration::from_secs(300);
@@ -25,6 +26,7 @@ pub const MAX_ACTIVE_JOBS: usize = 100;
 #[derive(Clone)]
 pub struct JobStore {
     jobs: Cache<String, JobStatus>,
+    tokens: Cache<String, CancellationToken>,
     active: Arc<AtomicUsize>,
 }
 
@@ -41,8 +43,13 @@ impl JobStore {
             .max_capacity(MAX_CAPACITY)
             .time_to_live(JOB_TTL)
             .build();
+        let tokens = Cache::builder()
+            .max_capacity(MAX_CAPACITY)
+            .time_to_live(JOB_TTL)
+            .build();
         Self {
             jobs,
+            tokens,
             active: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -60,7 +67,17 @@ impl JobStore {
         let now = now_rfc3339();
         self.active.fetch_add(1, Ordering::Relaxed);
         self.create(job_id.clone(), now);
+        self.tokens.insert(job_id.clone(), CancellationToken::default());
         job_id
+    }
+
+    /// Return the cancellation token associated with a job, if it still exists.
+    ///
+    /// Pass the returned token's clone to the extraction call (via
+    /// `ExtractionConfig::cancel_token`) so it observes cancellation at its
+    /// next checkpoint.
+    pub fn cancellation_token(&self, job_id: &str) -> Option<CancellationToken> {
+        self.tokens.get(job_id)
     }
 
     /// Register a new job in `Pending` state. Returns its initial `JobStatus`.
@@ -92,8 +109,14 @@ impl JobStore {
     }
 
     /// Mark a job as `Completed` and store its result.
+    ///
+    /// A no-op if the job was already cancelled, so a late-arriving result
+    /// from a cancelled extraction cannot clobber the `Cancelled` state.
     pub fn complete(&self, job_id: &str, result: serde_json::Value, timestamp: String) {
         if let Some(mut status) = self.jobs.get(job_id) {
+            if status.state == JobState::Cancelled {
+                return;
+            }
             status.state = JobState::Completed;
             status.result = Some(result);
             status.updated_at = timestamp;
@@ -103,8 +126,14 @@ impl JobStore {
     }
 
     /// Mark a job as `Failed` and store the error message.
+    ///
+    /// A no-op if the job was already cancelled, so a late-arriving error
+    /// from a cancelled extraction cannot clobber the `Cancelled` state.
     pub fn fail(&self, job_id: &str, error: String, timestamp: String) {
         if let Some(mut status) = self.jobs.get(job_id) {
+            if status.state == JobState::Cancelled {
+                return;
+            }
             status.state = JobState::Failed;
             status.error = Some(error);
             status.updated_at = timestamp;
@@ -112,6 +141,42 @@ impl JobStore {
             self.active.fetch_sub(1, Ordering::Relaxed);
         }
     }
+
+    /// Cancel a pending or running job.
+    ///
+    /// Fires the job's [`CancellationToken`] so a running extraction observes
+    /// it at its next checkpoint. Jobs that already reached a terminal state
+    /// (`Completed`, `Failed`, or `Cancelled`) cannot be cancelled again.
+    pub fn cancel(&self, job_id: &str, timestamp: String) -> CancelOutcome {
+        let Some(mut status) = self.jobs.get(job_id) else {
+            return CancelOutcome::NotFound;
+        };
+
+        match status.state {
+            JobState::Pending | JobState::Running => {
+                status.state = JobState::Cancelled;
+                status.updated_at = timestamp;
+                self.jobs.insert(job_id.to_string(), status.clone());
+                self.active.fetch_sub(1, Ordering::Relaxed);
+                if let Some(token) = self.tokens.get(job_id) {
+                    token.cancel();
+                }
+                CancelOutcome::Cancelled(status)
+            }
+            JobState::Completed | JobState::Failed | JobState::Cancelled => CancelOutcome::Conflict(status),
+        }
+    }
+}
+
+/// Outcome of a [`JobStore::cancel`] call.
+#[derive(Debug, Clone)]
+pub enum CancelOutcome {
+    /// The job was pending or running and is now cancelled.
+    Cancelled(JobStatus),
+    /// The job already reached a terminal state and cannot be cancelled.
+    Conflict(JobStatus),
+    /// No job exists with this ID (unknown or expired).
+    NotFound,
 }
 
 /// Generate a new unique job ID (UUID v4).
@@ -190,6 +255,127 @@ mod tests {
         let status = store.get("job-5").unwrap();
         assert_eq!(status.state, JobState::Failed);
         assert_eq!(status.error.as_deref(), Some("OCR unavailable"));
+    }
+
+    #[test]
+    fn test_cancel_pending_job() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        assert_eq!(store.active_count(), 1);
+
+        match store.cancel(&job_id, "2026-05-01T12:00:01Z".to_string()) {
+            CancelOutcome::Cancelled(status) => assert_eq!(status.state, JobState::Cancelled),
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+        assert_eq!(store.get(&job_id).unwrap().state, JobState::Cancelled);
+        assert_eq!(store.active_count(), 0);
+    }
+
+    #[test]
+    fn test_cancel_running_job_fires_token() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        store.set_running(&job_id, "2026-05-01T12:00:01Z".to_string());
+        let token = store.cancellation_token(&job_id).expect("token registered on create");
+        assert!(!token.is_cancelled());
+
+        match store.cancel(&job_id, "2026-05-01T12:00:02Z".to_string()) {
+            CancelOutcome::Cancelled(status) => assert_eq!(status.state, JobState::Cancelled),
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+        assert!(token.is_cancelled(), "cancelling a running job must fire its token");
+    }
+
+    #[test]
+    fn test_cancel_completed_job_is_conflict() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        store.complete(
+            &job_id,
+            serde_json::json!({"content": "done"}),
+            "2026-05-01T12:00:01Z".to_string(),
+        );
+
+        match store.cancel(&job_id, "2026-05-01T12:00:02Z".to_string()) {
+            CancelOutcome::Conflict(status) => assert_eq!(status.state, JobState::Completed),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+        assert_eq!(
+            store.get(&job_id).unwrap().state,
+            JobState::Completed,
+            "a conflicting cancel must not alter the job's state"
+        );
+    }
+
+    #[test]
+    fn test_cancel_failed_job_is_conflict() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        store.fail(&job_id, "boom".to_string(), "2026-05-01T12:00:01Z".to_string());
+
+        match store.cancel(&job_id, "2026-05-01T12:00:02Z".to_string()) {
+            CancelOutcome::Conflict(status) => assert_eq!(status.state, JobState::Failed),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cancel_already_cancelled_job_is_conflict() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        store.cancel(&job_id, "2026-05-01T12:00:01Z".to_string());
+
+        match store.cancel(&job_id, "2026-05-01T12:00:02Z".to_string()) {
+            CancelOutcome::Conflict(status) => assert_eq!(status.state, JobState::Cancelled),
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_cancel_missing_job_returns_not_found() {
+        let store = JobStore::new();
+        assert!(matches!(
+            store.cancel("nope", "2026-05-01T12:00:00Z".to_string()),
+            CancelOutcome::NotFound
+        ));
+    }
+
+    #[test]
+    fn test_complete_after_cancel_is_noop() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        store.cancel(&job_id, "2026-05-01T12:00:01Z".to_string());
+
+        store.complete(
+            &job_id,
+            serde_json::json!({"content": "late"}),
+            "2026-05-01T12:00:02Z".to_string(),
+        );
+
+        let status = store.get(&job_id).unwrap();
+        assert_eq!(
+            status.state,
+            JobState::Cancelled,
+            "a late completion must not override a cancelled job"
+        );
+        assert!(status.result.is_none());
+    }
+
+    #[test]
+    fn test_fail_after_cancel_is_noop() {
+        let store = JobStore::new();
+        let job_id = store.create_job();
+        store.cancel(&job_id, "2026-05-01T12:00:01Z".to_string());
+
+        store.fail(&job_id, "late error".to_string(), "2026-05-01T12:00:02Z".to_string());
+
+        let status = store.get(&job_id).unwrap();
+        assert_eq!(
+            status.state,
+            JobState::Cancelled,
+            "a late failure must not override a cancelled job"
+        );
+        assert!(status.error.is_none());
     }
 
     #[test]

--- a/crates/xberg/src/api/jobs.rs
+++ b/crates/xberg/src/api/jobs.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
+use moka::ops::compute::{CompResult, Op};
 use moka::sync::Cache;
 
 use crate::api::types::{JobState, JobStatus};
@@ -111,16 +112,24 @@ impl JobStore {
     /// Mark a job as `Completed` and store its result.
     ///
     /// A no-op if the job was already cancelled, so a late-arriving result
-    /// from a cancelled extraction cannot clobber the `Cancelled` state.
+    /// from a cancelled extraction cannot clobber the `Cancelled` state. The
+    /// read-modify-write against the job entry and the `active` decrement are
+    /// atomic with respect to concurrent `cancel`/`fail` calls on the same
+    /// job ID (see [`JobStore::cancel`] for why this matters).
     pub fn complete(&self, job_id: &str, result: serde_json::Value, timestamp: String) {
-        if let Some(mut status) = self.jobs.get(job_id) {
-            if status.state == JobState::Cancelled {
-                return;
+        let outcome = self.jobs.entry_by_ref(job_id).and_compute_with(|entry| match entry {
+            Some(entry) if entry.value().state == JobState::Cancelled => Op::Nop,
+            Some(entry) => {
+                let mut status = entry.into_value();
+                status.state = JobState::Completed;
+                status.result = Some(result);
+                status.updated_at = timestamp;
+                Op::Put(status)
             }
-            status.state = JobState::Completed;
-            status.result = Some(result);
-            status.updated_at = timestamp;
-            self.jobs.insert(job_id.to_string(), status);
+            None => Op::Nop,
+        });
+
+        if matches!(outcome, CompResult::ReplacedWith(_)) {
             self.active.fetch_sub(1, Ordering::Relaxed);
         }
     }
@@ -128,16 +137,22 @@ impl JobStore {
     /// Mark a job as `Failed` and store the error message.
     ///
     /// A no-op if the job was already cancelled, so a late-arriving error
-    /// from a cancelled extraction cannot clobber the `Cancelled` state.
+    /// from a cancelled extraction cannot clobber the `Cancelled` state. See
+    /// [`JobStore::complete`] for the atomicity guarantee.
     pub fn fail(&self, job_id: &str, error: String, timestamp: String) {
-        if let Some(mut status) = self.jobs.get(job_id) {
-            if status.state == JobState::Cancelled {
-                return;
+        let outcome = self.jobs.entry_by_ref(job_id).and_compute_with(|entry| match entry {
+            Some(entry) if entry.value().state == JobState::Cancelled => Op::Nop,
+            Some(entry) => {
+                let mut status = entry.into_value();
+                status.state = JobState::Failed;
+                status.error = Some(error);
+                status.updated_at = timestamp;
+                Op::Put(status)
             }
-            status.state = JobState::Failed;
-            status.error = Some(error);
-            status.updated_at = timestamp;
-            self.jobs.insert(job_id.to_string(), status);
+            None => Op::Nop,
+        });
+
+        if matches!(outcome, CompResult::ReplacedWith(_)) {
             self.active.fetch_sub(1, Ordering::Relaxed);
         }
     }
@@ -147,23 +162,44 @@ impl JobStore {
     /// Fires the job's [`CancellationToken`] so a running extraction observes
     /// it at its next checkpoint. Jobs that already reached a terminal state
     /// (`Completed`, `Failed`, or `Cancelled`) cannot be cancelled again.
+    ///
+    /// The state transition and the `active` decrement happen inside a single
+    /// [`moka::Cache::entry_by_ref`] `and_compute_with` call, which moka
+    /// serializes per key. This closes a race with the job's own background
+    /// task calling [`JobStore::complete`]/[`JobStore::fail`] concurrently:
+    /// without it, both sides could read the pre-transition state, both would
+    /// decrement `active`, and the second decrement would underflow the
+    /// counter (permanently blocking new submissions once `active_count()`
+    /// wraps past `MAX_ACTIVE_JOBS`).
     pub fn cancel(&self, job_id: &str, timestamp: String) -> CancelOutcome {
-        let Some(mut status) = self.jobs.get(job_id) else {
-            return CancelOutcome::NotFound;
-        };
+        let outcome = self.jobs.entry_by_ref(job_id).and_compute_with(|entry| match entry {
+            Some(entry) => {
+                let mut status = entry.into_value();
+                match status.state {
+                    JobState::Pending | JobState::Running => {
+                        status.state = JobState::Cancelled;
+                        status.updated_at = timestamp;
+                        Op::Put(status)
+                    }
+                    JobState::Completed | JobState::Failed | JobState::Cancelled => Op::Nop,
+                }
+            }
+            None => Op::Nop,
+        });
 
-        match status.state {
-            JobState::Pending | JobState::Running => {
-                status.state = JobState::Cancelled;
-                status.updated_at = timestamp;
-                self.jobs.insert(job_id.to_string(), status.clone());
+        match outcome {
+            CompResult::StillNone(_) => CancelOutcome::NotFound,
+            CompResult::Unchanged(entry) => CancelOutcome::Conflict(entry.into_value()),
+            CompResult::ReplacedWith(entry) => {
                 self.active.fetch_sub(1, Ordering::Relaxed);
                 if let Some(token) = self.tokens.get(job_id) {
                     token.cancel();
                 }
-                CancelOutcome::Cancelled(status)
+                CancelOutcome::Cancelled(entry.into_value())
             }
-            JobState::Completed | JobState::Failed | JobState::Cancelled => CancelOutcome::Conflict(status),
+            CompResult::Inserted(_) | CompResult::Removed(_) => {
+                unreachable!("cancel() only produces Nop/Put on an existing entry, never Remove or a fresh Insert")
+            }
         }
     }
 }
@@ -418,4 +454,53 @@ fn test_create_job_concurrent_uniqueness() {
     }
 
     assert_eq!(job_ids.len(), 100);
+}
+
+/// Regression test for a race where `cancel()` and `complete()`/`fail()` on the
+/// same job ID could both read the pre-transition state and both decrement
+/// `active`, underflowing the `AtomicUsize` counter and permanently blocking
+/// new job submissions. `entry_by_ref(..).and_compute_with(..)` serializes the
+/// two calls per key, so exactly one of them observes the pending/running
+/// state and performs the transition + decrement.
+#[test]
+fn test_concurrent_cancel_and_complete_never_double_decrements() {
+    use std::sync::Arc;
+    use std::thread;
+
+    for _ in 0..200 {
+        let store = Arc::new(JobStore::new());
+        let job_id = store.create_job();
+
+        let store_a = Arc::clone(&store);
+        let job_id_a = job_id.clone();
+        let cancel_thread = thread::spawn(move || {
+            store_a.cancel(&job_id_a, "2026-05-01T12:00:01Z".to_string());
+        });
+
+        let store_b = Arc::clone(&store);
+        let job_id_b = job_id.clone();
+        let complete_thread = thread::spawn(move || {
+            store_b.complete(
+                &job_id_b,
+                serde_json::json!({"content": "done"}),
+                "2026-05-01T12:00:01Z".to_string(),
+            );
+        });
+
+        cancel_thread.join().unwrap();
+        complete_thread.join().unwrap();
+
+        assert_eq!(
+            store.active_count(),
+            0,
+            "active must be decremented exactly once by whichever of cancel/complete won the race, \
+             never zero times (leak) or twice (underflow)"
+        );
+
+        let final_state = store.get(&job_id).unwrap().state;
+        assert!(
+            matches!(final_state, JobState::Cancelled | JobState::Completed),
+            "the job must end in whichever terminal state won the race, not a corrupted mix: got {final_state:?}"
+        );
+    }
 }

--- a/crates/xberg/src/api/router.rs
+++ b/crates/xberg/src/api/router.rs
@@ -21,9 +21,9 @@ use crate::{ExtractionConfig, core::ServerConfig, service::ExtractionServiceBuil
 
 use super::{
     handlers::{
-        cache_clear_handler, cache_manifest_handler, cache_stats_handler, cache_warm_handler, detect_handler,
-        extract_async_handler, extract_handler, formats_handler, health_handler, info_handler, job_status_handler,
-        not_found_handler, version_handler,
+        cache_clear_handler, cache_manifest_handler, cache_stats_handler, cache_warm_handler, cancel_job_handler,
+        detect_handler, extract_async_handler, extract_handler, formats_handler, health_handler, info_handler,
+        job_status_handler, not_found_handler, version_handler,
     },
     openweb::{openweb_docling_handler, openweb_external_handler},
     types::{ApiSizeLimits, ApiState},
@@ -168,7 +168,7 @@ pub(crate) fn create_router_with_limits_and_server_config(
     let mut router = Router::new()
         .route("/extract", post(extract_handler))
         .route("/extract-async", post(extract_async_handler))
-        .route("/jobs/{job_id}", get(job_status_handler))
+        .route("/jobs/{job_id}", get(job_status_handler).delete(cancel_job_handler))
         .route("/detect", post(detect_handler))
         .route("/formats", get(formats_handler))
         .route("/health", get(health_handler))

--- a/crates/xberg/src/api/types.rs
+++ b/crates/xberg/src/api/types.rs
@@ -212,6 +212,8 @@ pub enum JobState {
     Completed,
     /// The job terminated with an error.
     Failed,
+    /// The job was cancelled via `DELETE /jobs/{job_id}`.
+    Cancelled,
 }
 
 /// The status of an async extraction job returned by `GET /jobs/{id}`.


### PR DESCRIPTION
## Related

closes: #1310

## Description

Adds `DELETE /jobs/{job_id}` to cancel a pending or running async extraction job.

- Pending job: removed from the queue, state becomes `cancelled`.
- Running job: the extraction's existing `CancellationToken` is fired, so the pipeline stops cooperatively at its next checkpoint rather than being force-aborted. This frees the concurrency slot immediately instead of waiting for the job to finish or time out.
- Completed, failed, or already-cancelled jobs return 409 Conflict.
- Unknown or expired jobs return 404, matching `GET /jobs/{job_id}`.

No new dependencies: this reuses the `CancellationToken` / `ExtractionConfig.cancel_token` plumbing already used by the FFI, Python, and Node bindings.

## Checklist

- [x] CI passing
- [x] Tests added where applicable