### PR TITLE
feat(wasm): detect entities in the browser with an in-binary GLiNER2 model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Entity detection runs in the browser.** The WASM package exposes `NerModel`, which loads GLiNER2
+  weights into the page and detects entities locally — no server round-trip and no ONNX Runtime.
+  The host fetches the model and hands over the bytes:
+
+  ```js
+  const model = await NerModel.load({ weights, tokenizer, encoderConfig });
+  const entities = await model.detect(text, { categories: ["person", "organization"] });
+  model.free();
+  ```
+
+  The model stays resident, so the weights are parsed once no matter how many times you call
+  `detect`. Inference is synchronous on a single-threaded target; run it in a Web Worker if you care
+  about main-thread responsiveness. The existing injected-JS `ner` backend is unchanged.
+- New `ner-candle-wasm` feature: the no-tokio sibling of `ner-candle`, now part of `wasm-target`.
+  Both resolve to the same candle GLiNER2 backend and differ only in whether the tokio runtime comes
+  along, mirroring how `layout-tract` and `auto-rotate-tract` shadow their ORT-backed counterparts.
+
 ### Fixed
 
 - PaddleOCR now applies `PaddleOcrConfig::rec_batch_num` to recognition inference.

--- a/PLATFORM_SUPPORT.md
+++ b/PLATFORM_SUPPORT.md
@@ -54,9 +54,10 @@ Legend: ✅ prebuilt shipped · ❌ not shipped · — not applicable
    document-orientation detection now run on the x86_64 emulator too, through the pure-Rust `tract`
    engine (see note 8) instead of ORT. arm64 devices get the full ORT-enabled build.
 7. **WASM** is a single `wasm32` artifact, portable across any WASM runtime (browser + Node). It uses
-   the `wasm-target` feature set (`ocr-wasm`, `excel-wasm`, `layout-tract`, `auto-rotate-tract`; no
-   native ORT, no tree-sitter). Layout detection and document-orientation run through the pure-Rust
-   `tract` engine (see note 8).
+   the `wasm-target` feature set (`ocr-wasm`, `excel-wasm`, `layout-tract`, `auto-rotate-tract`,
+   `ner-candle-wasm`; no native ORT, no tree-sitter). Layout detection and document-orientation run
+   through the pure-Rust `tract` engine (see note 8); named-entity recognition runs in the browser
+   through the pure-Rust candle GLiNER2 backend (see note 9).
 8. **Pure-Rust `tract` engine.** Where a target cannot link native ONNX Runtime, xberg's inference seam
    can compile select ONNX models against the pure-Rust `tract` engine (`tract-onnx`, no native library,
    CPU-only) instead. Document-orientation detection (`auto-rotate-tract`) and RT-DETR layout detection
@@ -66,6 +67,14 @@ Legend: ✅ prebuilt shipped · ❌ not shipped · — not applicable
    `detectLayout` / `detectOrientation`, which take the `.onnx` weights as streamed bytes (the JS host
    fetches them and hands them to the seam). PaddleOCR, TATR, SLANeXT, and PP-DocLayout-V3 remain ONNX
    Runtime-only.
+9. **In-browser entity detection.** The WASM build exposes `NerModel`, which runs GLiNER2 named-entity
+   recognition entirely inside the page — no server round-trip and no ONNX Runtime, through the
+   pure-Rust candle backend (`ner-candle-wasm`, the no-tokio sibling of the native `ner-candle`).
+   Weights are not embedded in the `.wasm`; the host fetches the safetensors, tokenizer, and encoder
+   config and passes the bytes to `NerModel.load`. Unlike the byte-oriented `detectLayout` /
+   `detectOrientation` functions, the model stays resident across calls, so the weights are parsed
+   once. Inference is synchronous CPU work on a single-threaded target — run it in a Web Worker if
+   main-thread responsiveness matters.
 
 ## Cross-cutting gaps
 

--- a/crates/xberg-gliner/src/v2/tokenizer.rs
+++ b/crates/xberg-gliner/src/v2/tokenizer.rs
@@ -1,3 +1,4 @@
+#[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 
 use crate::{GlinerError, Result};
@@ -26,6 +27,9 @@ pub struct V2Tokenizer {
 }
 
 impl V2Tokenizer {
+    /// Not built for wasm32: there is no filesystem there, and every caller is
+    /// itself native-only, so it would be dead code.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let inner = tokenizers::Tokenizer::from_file(path)
             .map_err(|error| GlinerError::Tokenizer(format!("failed to load tokenizer from file: {error}")))?;

--- a/crates/xberg-wasm/src/bridge/mod.rs
+++ b/crates/xberg-wasm/src/bridge/mod.rs
@@ -1,9 +1,16 @@
-//! JS bridge utilities for injected backends.
+//! JS-facing backend plumbing.
+//!
+//! Two ways a capability gets satisfied here: an *injected* JS backend the host
+//! supplies ([`ner`], [`ocr`]), or an *in-binary* model the host feeds bytes to
+//! ([`ner_model`]). Both report failures through [`js_from_any`]. The timeout
+//! race below serves only the injected paths: in-binary inference is synchronous,
+//! so a `Promise.race` could not interrupt it even if one were armed.
 //!
 //! Hand-written module (declared via `custom_rust_modules` in `alef.toml`),
 //! not managed by alef.
 
 pub mod ner;
+pub mod ner_model;
 pub mod ocr;
 
 use std::sync::OnceLock;

--- a/crates/xberg-wasm/src/bridge/ner.rs
+++ b/crates/xberg-wasm/src/bridge/ner.rs
@@ -5,8 +5,11 @@
 //! match [`call_injected_ner`]. The host returns a promise resolving to an
 //! array of entities (`{ category, text, start, end, confidence? }`).
 //!
-//! There is no in-binary fallback: when no backend is injected, NER is
-//! unavailable and calls return an error saying so.
+//! The *injected* path only; with nothing injected the engine reports NER as
+//! unavailable. To run a model inside the binary instead see
+//! [`crate::bridge::ner_model::NerModel`], a separate entry point that does not
+//! route through this bridge: local inference is synchronous, so the timeout here
+//! could not interrupt it.
 
 use js_sys::{Function, Object, Promise, Reflect};
 use wasm_bindgen::prelude::*;
@@ -14,6 +17,30 @@ use wasm_bindgen::prelude::*;
 use xberg::types::entity::{Entity, EntityCategory};
 
 use crate::bridge::js_from_any;
+
+/// Read the `categories` option off a JS options bag.
+///
+/// Missing, `null`, `undefined`, a non-array, or a non-string element degrade to
+/// an empty list, which backends read as "use the defaults", not "detect
+/// nothing". Unknown names become [`EntityCategory::Custom`] zero-shot labels.
+///
+/// Shared by [`crate::engine::XbergEngine::ner`] and
+/// [`crate::bridge::ner_model::NerModel::detect`] so they cannot drift.
+pub(crate) fn categories_from_opts(opts: &JsValue) -> Vec<EntityCategory> {
+    if opts.is_undefined() || opts.is_null() {
+        return Vec::new();
+    }
+    Reflect::get(opts, &JsValue::from_str("categories"))
+        .ok()
+        .and_then(|v| v.dyn_into::<js_sys::Array>().ok())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_string())
+                .map(EntityCategory::from)
+                .collect()
+        })
+        .unwrap_or_default()
+}
 
 /// Resolve NER through the injected backend, with a configurable bridge timeout.
 pub async fn resolve_ner_with_timeout(
@@ -25,7 +52,8 @@ pub async fn resolve_ner_with_timeout(
     match injected {
         Some(obj) => call_injected_ner(obj, text, categories, timeout_ms).await,
         None => Err(js_from_any(
-            "NER unavailable: no NER backend injected; pass a `ner` object in the engine injection",
+            "NER unavailable: no NER backend injected. Pass a `ner` object in the engine injection, \
+             or run a model in the browser with NerModel.load({ weights, tokenizer, encoderConfig })",
         )),
     }
 }

--- a/crates/xberg-wasm/src/bridge/ner_model.rs
+++ b/crates/xberg-wasm/src/bridge/ner_model.rs
@@ -1,0 +1,208 @@
+//! In-binary NER: a GLiNER2 model resident in WASM linear memory.
+//!
+//! Counterpart to [`crate::bridge::ner`], which calls out to injected JS. Here
+//! inference runs inside the binary via the pure-Rust candle GLiNER2 backend.
+//!
+//! Exported as a class, not a free function like `detectLayout`: the weights run
+//! to hundreds of MB, so the model is loaded once and stays resident, and `free()`
+//! lets the host reclaim it.
+//!
+//! Inference is synchronous and wasm32 is single-threaded, so `detect` holds the
+//! thread until it returns; drive it from a Web Worker to avoid main-thread jank.
+//! The methods are `async` to match the rest of the JS surface, not because they
+//! yield.
+
+use wasm_bindgen::prelude::*;
+
+use xberg::text::ner::NerBackend;
+use xberg::text::ner::candle::CandleBackend;
+
+use crate::bridge::js_from_any;
+use crate::bridge::ner::categories_from_opts;
+
+/// Read a required byte-buffer field off a JS options object.
+///
+/// Accepts `Uint8Array` or `ArrayBuffer`. Rejects by field name: the three
+/// buffers share a type, so a transposition would otherwise surface later as an
+/// opaque parse failure.
+fn required_bytes(obj: &JsValue, field: &str) -> Result<Vec<u8>, JsValue> {
+    let value = js_sys::Reflect::get(obj, &JsValue::from_str(field))
+        .map_err(|_| js_from_any(format!("failed to read '{field}'")))?;
+
+    if value.is_undefined() || value.is_null() {
+        return Err(js_from_any(format!(
+            "missing '{field}': expected a Uint8Array or ArrayBuffer of model bytes"
+        )));
+    }
+
+    let bytes = if value.is_instance_of::<js_sys::Uint8Array>() {
+        value.unchecked_into::<js_sys::Uint8Array>().to_vec()
+    } else if value.is_instance_of::<js_sys::ArrayBuffer>() {
+        js_sys::Uint8Array::new(&value).to_vec()
+    } else {
+        return Err(js_from_any(format!(
+            "'{field}' must be a Uint8Array or ArrayBuffer"
+        )));
+    };
+
+    if bytes.is_empty() {
+        return Err(js_from_any(format!("'{field}' is empty")));
+    }
+
+    Ok(bytes)
+}
+
+/// A GLiNER2 model loaded into WASM memory, detecting entities locally.
+///
+/// Construct with [`NerModel::load`], call [`NerModel::detect`] as many times as
+/// needed, and call `free()` from JS when finished to release the weights.
+///
+/// ```js
+/// const model = await NerModel.load({ weights, tokenizer, encoderConfig });
+/// const entities = await model.detect("Alice works at Acme Corp", {
+///   categories: ["person", "organization"],
+/// });
+/// model.free();
+/// ```
+#[wasm_bindgen(js_name = "NerModel")]
+pub struct NerModel {
+    backend: CandleBackend,
+}
+
+#[wasm_bindgen(js_class = "NerModel")]
+impl NerModel {
+    /// Load a GLiNER2 model from bytes the host has already fetched.
+    ///
+    /// `options` takes three byte buffers, each a `Uint8Array` or `ArrayBuffer`:
+    /// `weights` (`model.safetensors`), `tokenizer` (`tokenizer.json`), and
+    /// `encoderConfig` (the encoder `config.json`). Named rather than positional
+    /// so a transposition cannot be silent.
+    ///
+    /// Weights are never embedded in the `.wasm`; the host fetches them.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if a field is missing, is not a byte buffer, is
+    /// empty, or if the bytes do not parse as a GLiNER2 model.
+    pub async fn load(options: JsValue) -> Result<NerModel, JsValue> {
+        if !options.is_object() {
+            return Err(js_from_any(
+                "NerModel.load expects an object with `weights`, `tokenizer`, and `encoderConfig` byte buffers",
+            ));
+        }
+
+        let weights = required_bytes(&options, "weights")?;
+        let tokenizer = required_bytes(&options, "tokenizer")?;
+        let encoder_config = required_bytes(&options, "encoderConfig")?;
+
+        let backend = CandleBackend::from_bytes(&weights, &tokenizer, &encoder_config)
+            .map_err(|e| js_from_any(format!("NerModel.load: {e}")))?;
+
+        Ok(NerModel { backend })
+    }
+
+    /// Detect entities in `text`, running inference inside the binary.
+    ///
+    /// `opts` may contain `categories`, an array of category names; unknown
+    /// names become custom zero-shot labels. Omitting it uses the backend's
+    /// default label set.
+    ///
+    /// Resolves to an array of `{ category, text, start, end, confidence }`,
+    /// with `start` and `end` as byte offsets into `text`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a JS error if inference fails.
+    pub async fn detect(&self, text: String, opts: JsValue) -> Result<JsValue, JsValue> {
+        let categories = categories_from_opts(&opts);
+
+        let entities = self
+            .backend
+            .detect(&text, &categories)
+            .await
+            .map_err(|e| js_from_any(format!("NerModel.detect: {e}")))?;
+
+        serde_wasm_bindgen::to_value(&entities).map_err(|e| js_from_any(e.to_string()))
+    }
+}
+
+/// In-crate tests, run under Node via `scripts/ci/wasm/run-crate-tests.sh`.
+///
+/// Argument contract and failure paths only; real weights are too large for CI.
+#[cfg(all(test, target_arch = "wasm32"))]
+mod tests {
+    use wasm_bindgen_test::*;
+
+    use super::*;
+
+    fn eval(src: &str) -> JsValue {
+        js_sys::eval(src).expect("test JS snippet must evaluate")
+    }
+
+    fn err_text(err: JsValue) -> String {
+        err.as_string().unwrap_or_else(|| format!("{err:?}"))
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_rejects_non_object() {
+        let err = NerModel::load(JsValue::from_f64(42.0)).await.err().expect("must fail");
+        assert!(err_text(err).contains("expects an object"));
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_names_the_missing_field() {
+        let err = NerModel::load(eval("({})")).await.err().expect("must fail");
+        let text = err_text(err);
+        assert!(text.contains("weights"), "error must name the field: {text}");
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_names_a_later_missing_field() {
+        let options = eval("({ weights: new Uint8Array([1, 2, 3]) })");
+        let err = NerModel::load(options).await.err().expect("must fail");
+        let text = err_text(err);
+        assert!(text.contains("tokenizer"), "error must name the field: {text}");
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_rejects_wrong_type_by_name() {
+        let options = eval("({ weights: 'not bytes', tokenizer: new Uint8Array([1]), encoderConfig: new Uint8Array([1]) })");
+        let err = NerModel::load(options).await.err().expect("must fail");
+        let text = err_text(err);
+        assert!(text.contains("weights") && text.contains("Uint8Array"), "got: {text}");
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_rejects_empty_buffer() {
+        let options =
+            eval("({ weights: new Uint8Array([]), tokenizer: new Uint8Array([1]), encoderConfig: new Uint8Array([1]) })");
+        let err = NerModel::load(options).await.err().expect("must fail");
+        assert!(err_text(err).contains("empty"));
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_accepts_array_buffer_and_fails_on_content_not_type() {
+        // ArrayBuffer must pass the type check and fail on the bytes instead. ~keep
+        let options = eval(
+            "({ weights: new ArrayBuffer(8), tokenizer: new ArrayBuffer(8), encoderConfig: new ArrayBuffer(8) })",
+        );
+        let err = NerModel::load(options).await.err().expect("must fail");
+        let text = err_text(err);
+        assert!(text.contains("NerModel.load:"), "expected a parse failure, got: {text}");
+        assert!(!text.contains("must be a Uint8Array"), "ArrayBuffer must be accepted: {text}");
+    }
+
+    #[wasm_bindgen_test]
+    async fn load_reports_malformed_model_input_without_trapping() {
+        // Malformed bytes must surface as a JS error, never a panic or wasm trap.
+        // `from_bytes` parses the tokenizer first, so this stops there rather than
+        // reaching the safetensors loader; that path needs a valid tokenizer blob,
+        // too large to inline. ~keep
+        let options = eval(
+            "({ weights: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]), tokenizer: new Uint8Array([123, 125]), encoderConfig: new Uint8Array([123, 125]) })",
+        );
+        let err = NerModel::load(options).await.err().expect("must fail");
+        let text = err_text(err);
+        assert!(text.contains("NerModel.load:"), "must be a load failure, got: {text}");
+    }
+}

--- a/crates/xberg-wasm/src/bridge/ner_model.rs
+++ b/crates/xberg-wasm/src/bridge/ner_model.rs
@@ -4,8 +4,9 @@
 //! inference runs inside the binary via the pure-Rust candle GLiNER2 backend.
 //!
 //! Exported as a class, not a free function like `detectLayout`: the weights run
-//! to hundreds of MB, so the model is loaded once and stays resident, and `free()`
-//! lets the host reclaim it.
+//! to hundreds of MB, so the model is loaded once and stays resident. wasm-bindgen's
+//! generated `free()` is optional (a FinalizationRegistry reclaims it), but worth
+//! calling at this size — GC timing is unobservable and linear memory never shrinks.
 //!
 //! Inference is synchronous and wasm32 is single-threaded, so `detect` holds the
 //! thread until it returns; drive it from a Web Worker to avoid main-thread jank.

--- a/crates/xberg-wasm/src/engine.rs
+++ b/crates/xberg-wasm/src/engine.rs
@@ -121,22 +121,15 @@ impl XbergEngine {
     /// Perform Named Entity Recognition on `text` through the injected NER
     /// backend. `opts` may contain `categories`, an array of category names;
     /// unknown names are treated as custom zero-shot labels.
+    ///
+    /// This is the injected-backend path. To run a model inside the browser
+    /// instead, load one with
+    /// [`NerModel`](crate::bridge::ner_model::NerModel) and call its `detect`
+    /// method directly — it needs none of the promise bridging or timeout this
+    /// path provides.
     #[allow(clippy::missing_errors_doc)]
     pub async fn ner(&self, text: String, opts: JsValue) -> Result<JsValue, JsValue> {
-        let categories: Vec<xberg::types::entity::EntityCategory> = if opts.is_undefined() || opts.is_null() {
-            Vec::new()
-        } else {
-            js_sys::Reflect::get(&opts, &JsValue::from_str("categories"))
-                .ok()
-                .and_then(|v| v.dyn_into::<js_sys::Array>().ok())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_string())
-                        .map(xberg::types::entity::EntityCategory::from)
-                        .collect()
-                })
-                .unwrap_or_default()
-        };
+        let categories = crate::bridge::ner::categories_from_opts(&opts);
 
         let entities = resolve_ner_with_timeout(self.ner.clone(), &text, &categories, self.bridge_timeout_ms)
             .await

--- a/crates/xberg/Cargo.toml
+++ b/crates/xberg/Cargo.toml
@@ -369,7 +369,16 @@ diff = ["dep:similar"]
 # Each feature lands in its own module under `crates/xberg/src/text/` (or
 # `crates/xberg/src/extractors/` for QR) and is wired through a built-in
 # post-processor under `crates/xberg/src/plugins/processor/builtin/`.
-ner-candle = ["ner", "dep:xberg-gliner", "xberg-gliner/candle", "tokio-runtime"]
+# The candle GLiNER2 backend (`crate::text::ner::candle`), runtime-neutral. Enable one
+# of the two siblings below rather than this directly; they differ only in tokio.
+ner-candle-backend = ["ner", "dep:xberg-gliner", "xberg-gliner/candle"]
+# Needs the multi-threaded runtime: `CandleBackend::detect` uses `block_in_place`.
+ner-candle = ["ner-candle-backend", "tokio-runtime"]
+# The sibling that does not pull `tokio-runtime` in, mirroring `layout-tract` /
+# `auto-rotate-tract`. This is about what the feature requires, not what ends up in the
+# build — `layout-tract` already enables `tokio-runtime` inside `wasm-target`. Builds
+# natively too, for callers wanting candle NER without a runtime dependency.
+ner-candle-wasm = ["ner-candle-backend"]
 ner = [] # NER result types only; safe on every target.
 ner-llm-types = ["ner"] # LlmBackend stub for targets without full ner-llm (Windows, Android x86_64, WASM).
 ner-llm = ["ner", "liter-llm"] # LLM-driven zero-shot NER (no ORT).
@@ -505,7 +514,14 @@ no-ort-target = [
 # past ~100 MB, over jsDelivr's 50 MB per-file limit, which broke the live demo
 # (the CDN 403s the oversized .wasm). Code intelligence is therefore unavailable
 # in the WASM build; native targets keep `tree-sitter`. See docs (WASM limitations).
-wasm-target = ["no-ort-target", "excel-wasm", "ocr-wasm", "layout-tract", "auto-rotate-tract"]
+wasm-target = [
+    "no-ort-target",
+    "excel-wasm",
+    "ocr-wasm",
+    "layout-tract",
+    "auto-rotate-tract",
+    "ner-candle-wasm",
+]
 # android-target: no-ort-target plus native-Linux variants that work on Android ABI
 # (excel with tokio, native tree-sitter, Tesseract OCR, and API/MCP transport).
 # Excludes ORT-dependent ML (paddle-ocr, embeddings, reranker, transcription); document

--- a/crates/xberg/src/text/ner/candle.rs
+++ b/crates/xberg/src/text/ner/candle.rs
@@ -2,16 +2,16 @@
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 use std::path::PathBuf;
 use std::sync::Mutex;
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 use std::sync::{Arc, LazyLock};
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 use ahash::AHashMap;
 use async_trait::async_trait;
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 use parking_lot::RwLock;
 use xberg_gliner::candle::Gliner2Candle;
 
@@ -26,15 +26,15 @@ const DEFAULT_THRESHOLD: f32 = 0.5;
 /// the independent `ner-onnx` feature, so a `ner-candle`-only build must not depend on
 /// it) so a given (model, adapter) pair is loaded and LoRA-merged at most once per
 /// process, instead of on every `process()` call.
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 type CandleBackendCacheKey = (PathBuf, Option<PathBuf>);
 
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 static CANDLE_BACKEND_CACHE: LazyLock<RwLock<AHashMap<CandleBackendCacheKey, Arc<CandleBackend>>>> =
     LazyLock::new(|| RwLock::new(AHashMap::default()));
 
 /// Return the cached backend for `key`, or build and cache one via `build`.
-#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+#[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
 fn get_or_insert_arc(
     key: CandleBackendCacheKey,
     build: impl FnOnce() -> crate::Result<CandleBackend>,
@@ -107,7 +107,7 @@ impl CandleBackend {
     /// is the entry point [`crate::plugins::processor::builtin::ner::make_backend`]
     /// should use so a document-processing pipeline pays the model-load + LoRA-merge
     /// cost once per (model, adapter) pair, not once per document.
-    #[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
     pub fn get_or_init(model_dir: &Path, lora_adapter_dir: Option<&Path>) -> crate::Result<Arc<Self>> {
         let key: CandleBackendCacheKey = (model_dir.to_path_buf(), lora_adapter_dir.map(Path::to_path_buf));
         get_or_insert_arc(key, || Self::from_local(model_dir, lora_adapter_dir))
@@ -159,11 +159,13 @@ impl NerBackend for CandleBackend {
             plugin_name: "ner-candle".to_string(),
         })?;
 
-        // extract_ner is CPU-bound (tensor inference). On native targets, block_in_place
-        // signals tokio to move other tasks off this thread for the duration without
-        // requiring Send. wasm32 has no multi-threaded tokio runtime (and is single-threaded
-        // regardless), so extract_ner is called directly; it is already synchronous. ~keep
-        #[cfg(not(target_arch = "wasm32"))]
+        // extract_ner is CPU-bound and already synchronous; block_in_place lets tokio move
+        // other tasks off this thread without requiring Send.
+        //
+        // Gated on tokio's presence, not the target: `ner-candle-wasm` omits `tokio-runtime`
+        // and builds natively too, so a `target_arch` gate alone would reach `block_in_place`
+        // with no tokio in the graph. The arms are exact complements. ~keep
+        #[cfg(all(not(target_arch = "wasm32"), feature = "tokio-runtime"))]
         let spans =
             tokio::task::block_in_place(|| model.extract_ner(text, &labels, DEFAULT_THRESHOLD)).map_err(|e| {
                 crate::XbergError::Plugin {
@@ -172,7 +174,7 @@ impl NerBackend for CandleBackend {
                 }
             })?;
 
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(not(all(not(target_arch = "wasm32"), feature = "tokio-runtime")))]
         let spans = model
             .extract_ner(text, &labels, DEFAULT_THRESHOLD)
             .map_err(|e| crate::XbergError::Plugin {
@@ -266,7 +268,7 @@ mod tests {
         }
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "ner-candle-backend"))]
     #[test]
     fn get_or_init_propagates_load_errors_without_panicking() {
         let missing_dir = std::path::Path::new("/nonexistent/xberg-candle-cache-test-model-dir");

--- a/crates/xberg/src/text/ner/mod.rs
+++ b/crates/xberg/src/text/ner/mod.rs
@@ -19,7 +19,7 @@
 #![cfg(feature = "ner")]
 
 pub mod backend;
-#[cfg(feature = "ner-candle")]
+#[cfg(feature = "ner-candle-backend")]
 pub mod candle;
 #[cfg(feature = "ner-onnx")]
 pub mod gline;

--- a/docs-site/src/content/docs/concepts/platform-support.md
+++ b/docs-site/src/content/docs/concepts/platform-support.md
@@ -55,11 +55,12 @@ Legend: ✅ prebuilt shipped · ❌ not shipped · — not applicable
    now run on the x86_64 emulator too, through the pure-Rust `tract` engine (see note 8) instead of
    ORT. arm64 devices get the full ORT-enabled build.
 7. **WASM** is a single `wasm32` artifact, portable across any WASM runtime (browser and Node). It uses
-   the `wasm-target` feature set (`ocr-wasm`, `excel-wasm`, `layout-tract`, `auto-rotate-tract`; no
-   native ORT). Tree-sitter code intelligence is **excluded**: the 306-language grammar pack pushes the
-   `.wasm` past the 50 MB per-file limit of public CDNs (jsDelivr), so source files extract as text but
-   are not parsed. Layout detection and document-orientation run through the pure-Rust `tract` engine
-   (see note 8).
+   the `wasm-target` feature set (`ocr-wasm`, `excel-wasm`, `layout-tract`, `auto-rotate-tract`,
+   `ner-candle-wasm`; no native ORT). Tree-sitter code intelligence is **excluded**: the 306-language
+   grammar pack pushes the `.wasm` past the 50 MB per-file limit of public CDNs (jsDelivr), so source
+   files extract as text but are not parsed. Layout detection and document-orientation run through the
+   pure-Rust `tract` engine (see note 8). Named-entity recognition runs in the browser through the
+   pure-Rust candle GLiNER2 backend (see note 9).
 8. **Pure-Rust `tract` engine.** Where a target cannot link native ONNX Runtime, xberg's inference seam
    can compile select ONNX models against the pure-Rust `tract` engine (`tract-onnx`, no native library,
    CPU-only) instead. Document-orientation detection (`auto-rotate-tract`) and RT-DETR layout detection
@@ -69,6 +70,14 @@ Legend: ✅ prebuilt shipped · ❌ not shipped · — not applicable
    `detectLayout` / `detectOrientation`, which take the `.onnx` weights as streamed bytes (the JS host
    fetches them and hands them to the seam). PaddleOCR, TATR, SLANeXT, and PP-DocLayout-V3 remain ONNX
    Runtime-only.
+9. **In-browser entity detection.** The WASM build exposes `NerModel`, which runs GLiNER2 named-entity
+   recognition entirely inside the page — no server round-trip and no ONNX Runtime, through the
+   pure-Rust candle backend (`ner-candle-wasm`, the no-tokio sibling of the native `ner-candle`).
+   Weights are not embedded in the `.wasm`; the host fetches the safetensors, tokenizer, and encoder
+   config and passes the bytes to `NerModel.load`. Unlike the byte-oriented `detectLayout` /
+   `detectOrientation` functions, the model stays resident across calls, so the weights are parsed
+   once. Inference is synchronous CPU work on a single-threaded target — run it in a Web Worker if
+   main-thread responsiveness matters.
 
 ## Cross-cutting gaps
 

--- a/docs-site/src/content/docs/guides/ner.mdx
+++ b/docs-site/src/content/docs/guides/ner.mdx
@@ -25,6 +25,22 @@ The result types ship in the `ner` Cargo feature (included in `no-ort-target`, `
 | `Onnx` (`xberg-gliner`) | `ner-onnx` | High throughput, local inference, deterministic | Available. |
 | `Llm` (liter-llm) | `ner-llm` | Domain-specific zero-shot labels, any of 143 providers | Available today. |
 
+### In the browser
+
+The WASM build detects entities inside the page, with no server round-trip. This is a direct API
+rather than a `backend` selection: load the GLiNER2 weights once and call the model.
+
+```js
+const model = await NerModel.load({ weights, tokenizer, encoderConfig });
+const entities = await model.detect(text, { categories: ["person", "organization"] });
+model.free();
+```
+
+Weights are not embedded in the `.wasm`, so the host fetches the safetensors, tokenizer, and encoder
+config and passes the bytes. The model stays resident, so repeated `detect` calls do not re-parse it.
+Inference is synchronous on a single-threaded target — run it in a Web Worker if main-thread
+responsiveness matters.
+
 The ONNX backend downloads supported Xberg GLiNER aliases and catalog ids from
 `xberg-io/gliner-models`. The runtime consumes exported ONNX artifacts and
 tokenizer files; it does not load arbitrary source PyTorch model repositories.

--- a/docs-site/src/content/docs/guides/ner.mdx
+++ b/docs-site/src/content/docs/guides/ner.mdx
@@ -41,6 +41,10 @@ config and passes the bytes. The model stays resident, so repeated `detect` call
 Inference is synchronous on a single-threaded target — run it in a Web Worker if main-thread
 responsiveness matters.
 
+`free()` is optional: like every class in the package it is reclaimed by the garbage collector.
+Calling it is still worth it here, because GC timing is unobservable and WASM linear memory only ever
+grows, so a few hundred megabytes of weights can sit allocated long after the last `detect`.
+
 The ONNX backend downloads supported Xberg GLiNER aliases and catalog ids from
 `xberg-io/gliner-models`. The runtime consumes exported ONNX artifacts and
 tokenizer files; it does not load arbitrary source PyTorch model repositories.

--- a/e2e/wasm/tests/ner_model.test.ts
+++ b/e2e/wasm/tests/ner_model.test.ts
@@ -1,0 +1,75 @@
+// Hand-written e2e coverage for the in-binary NerModel (not alef-generated).
+//
+// Argument contract and failure paths only: the success path needs real GLiNER2
+// weights, which are not checked into CI.
+import { describe, expect, it } from "vitest";
+import { NerModel, XbergEngine } from "@xberg-io/xberg-wasm";
+
+const someBytes = () => new Uint8Array([1, 2, 3, 4]);
+
+describe("NerModel.load argument contract", () => {
+	it("rejects a non-object argument", async () => {
+		await expect(NerModel.load(42)).rejects.toMatch(/expects an object/);
+	});
+
+	it("names the field that is missing", async () => {
+		await expect(NerModel.load({})).rejects.toMatch(/weights/);
+	});
+
+	it("names a later missing field rather than the first", async () => {
+		await expect(NerModel.load({ weights: someBytes() })).rejects.toMatch(/tokenizer/);
+	});
+
+	it("names the field that has the wrong type", async () => {
+		const options = {
+			weights: "not bytes",
+			tokenizer: someBytes(),
+			encoderConfig: someBytes(),
+		};
+
+		await expect(NerModel.load(options)).rejects.toMatch(/weights.*Uint8Array/);
+	});
+
+	it("rejects an empty buffer", async () => {
+		const options = {
+			weights: new Uint8Array([]),
+			tokenizer: someBytes(),
+			encoderConfig: someBytes(),
+		};
+
+		await expect(NerModel.load(options)).rejects.toMatch(/empty/);
+	});
+
+	it("accepts ArrayBuffer as well as Uint8Array", async () => {
+		const options = {
+			weights: new ArrayBuffer(8),
+			tokenizer: new ArrayBuffer(8),
+			encoderConfig: new ArrayBuffer(8),
+		};
+
+		// Must pass the type check and fail on the bytes instead.
+		await expect(NerModel.load(options)).rejects.toMatch(/NerModel\.load:/);
+	});
+});
+
+describe("NerModel.load failure handling", () => {
+	// The tokenizer parses before the weights, so malformed input stops there.
+	// This pins that a bad model rejects rather than trapping.
+	it("reports malformed model input as an error, not a trap", async () => {
+		const options = {
+			weights: new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]),
+			tokenizer: new Uint8Array([123, 125]),
+			encoderConfig: new Uint8Array([123, 125]),
+		};
+
+		await expect(NerModel.load(options)).rejects.toMatch(/NerModel\.load:/);
+	});
+});
+
+describe("XbergEngine.ner without a backend", () => {
+	it("points at both the injection and the in-binary route", async () => {
+		const engine = new XbergEngine({}, {});
+
+		await expect(engine.ner("text", undefined)).rejects.toMatch(/NerModel\.load/);
+	});
+});

--- a/scripts/ci/rust/run-unit-tests.sh
+++ b/scripts/ci/rust/run-unit-tests.sh
@@ -23,7 +23,7 @@ echo "  CARGO_TERM_COLOR: ${CARGO_TERM_COLOR:-not set}"
 
 echo "Workspace information:"
 echo "  Repository: $REPO_ROOT"
-echo "  Excluded packages: xberg-e2e-generator, xberg-py, xberg-node, xberg-candle-ocr, xberg-gliner, xberg-cli, benchmark-harness"
+echo "  Excluded packages: xberg-e2e-generator, xberg-py, xberg-node, xberg-candle-ocr, xberg-gliner, xberg-cli, xberg-wasm, benchmark-harness"
 
 if [ ! -d "$TESSDATA_PREFIX" ]; then
   echo "WARNING: TESSDATA_PREFIX directory not found: $TESSDATA_PREFIX"
@@ -75,6 +75,12 @@ if ! {
   extra_excludes+=(--exclude xberg-gliner)
   extra_excludes+=(--exclude xberg-cli)
   extra_excludes+=(--exclude benchmark-harness)
+  # xberg-wasm: a cdylib whose tests are all cfg(target_arch = "wasm32"), so a native
+  # run covers nothing; they run under Node in the ci-e2e wasm leg. Excluding it also
+  # keeps candle out of this build: its xberg dependency is not target-gated, so
+  # wasm-target's ner-candle-wasm would pull gemm-f16 in on aarch64 (no fullfp16),
+  # past the --exclude xberg-gliner guard above. Matches every Taskfile path. ~keep
+  extra_excludes+=(--exclude xberg-wasm)
   RUST_BACKTRACE=full cargo test --locked \
     --workspace \
     --exclude xberg \

--- a/scripts/ci/wasm/run-crate-tests.sh
+++ b/scripts/ci/wasm/run-crate-tests.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Run the in-crate #[wasm_bindgen_test] suites for xberg-wasm under Node.
 #
-# The suites live in the crate's hand-written modules (src/engine.rs) because
+# The suites live in the crate's hand-written modules (src/engine.rs,
+# src/bridge/ner_model.rs) because
 # the generated manifest builds only a cdylib, which integration tests under
 # tests/ cannot link against. They run under Node because wasm-bindgen's test
 # glue carries the same unresolvable "env" / "wasi_snapshot_preview1" imports


### PR DESCRIPTION
Closes #1268. No longer blocked on candle#3751 / safetensors#818: the vendored ORT-free candle GLiNER2 backend already compiles and runs on `wasm32`. Original path designed and browser-verified by @jamon8888 in #1253.

## What this adds

`NerModel` in the WASM package. The host fetches the GLiNER2 weights and passes the bytes; detection runs inside the page, with no server round-trip and no ONNX Runtime.

```js
const model = await NerModel.load({ weights, tokenizer, encoderConfig });
const entities = await model.detect(text, { categories: ["person", "organization"] });
model.free();
```

A class rather than a free function like `detectLayout`: the weights run to hundreds of megabytes, so the model loads once, stays resident across `detect` calls, and `free()` reclaims it. Named fields because all three arguments are the same JS type. Inference is synchronous on a single-threaded target, so hosts should drive it from a Web Worker.

The injected-JS NER bridge is unchanged. `NerModel` does not route through it — local inference is synchronous, so the bridge's `Promise.race` timeout could not interrupt it, and that timeout is `eval`-based and CSP-blocked.

Routing `extract()`'s `config.ner` here needs a `NerBackendKind::Candle` variant across every binding, so that stays the separate NER dispatch follow-up.

## Feature split

`ner-candle` becomes a runtime-neutral `ner-candle-backend` marker plus two siblings differing only in whether they require tokio: `ner-candle` (native) and `ner-candle-wasm` (now in `wasm-target`), mirroring `layout-tract` / `auto-rotate-tract`. Two consequences:

- `CandleBackend::detect` gates `block_in_place` on `all(not(wasm32), feature = "tokio-runtime")`, with the fallback arm as its exact complement. `target_arch` alone reaches `block_in_place` with no tokio in the graph, since `ner-candle-wasm` omits `tokio-runtime` and builds natively.
- `xberg-wasm` is excluded from the native workspace test run. Its `xberg` dependency is not target-gated, so `wasm-target`'s candle stack pulled `gemm-f16` into native aarch64 codegen, which lacks `fullfp16` — the same reason the sweep excludes `xberg-gliner` and `xberg-candle-ocr`. Every Taskfile path already excluded it.

## Bundle size

Release profile plus `wasm-opt -Oz`, matching the published artifact.

| Build | Raw | Optimized |
|---|---:|---:|
| rc.37 baseline | 55.72 MB | 45.02 MB |
| with in-browser NER | 57.74 MB | 46.67 MB |
| delta | +2.02 MB | **+1.65 MB** |

3.33 MB left against jsDelivr's 50 MB cap. `main` is already at 45.02 MB before this change, up from 36.44 MB at rc.29, with no CI gate on it.

## Verification

| Check | Result |
|---|---|
| `clippy -p xberg --features ner-candle --lib -D warnings` | pass |
| `clippy -p xberg --no-default-features --features ner-candle-wasm --lib -D warnings` | pass |
| `clippy -p xberg-gliner` — wasm32+candle, native candle+ort-dynamic, native default | pass |
| `test -p xberg --features ner-candle --lib text::ner` | 6 passed |
| `scripts/ci/wasm/run-crate-tests.sh` (wasm-bindgen under Node) | 24 passed |

7 of the 24 are new, covering the argument contract and failure paths; the 17 pre-existing ones still pass, pinning the shared `categories_from_opts` extraction as behavior-preserving. Real weights are too large for CI, so the success path is not exercised.

Pre-existing and unrelated, confirmed against the base tree and ungated by CI: `tests/enrich.rs` trips `needless_update` under `--features ner-candle`, and `ocr/tesseract_wasm_backend.rs` trips `unnecessary_cast` on the wasm32 clippy cell. `V2Tokenizer::from_file` was also dead on wasm32, but became reachable once `xberg-gliner` entered the WASM build, so it is gated here.
