### PR TITLE
docs(python): show both array and list returns for plugin backends

### DIFF
--- a/docs-site/src/content/docs/guides/reranking.mdx
+++ b/docs-site/src/content/docs/guides/reranking.mdx
@@ -208,7 +208,11 @@ To wrap a model you already load — `sentence-transformers`, `llama-cpp-python`
 
 The protocol returns **raw scores in input order**. The dispatcher handles sorting and `top_k` truncation; the plugin must not sort.
 
+Scores can be any sequence of floats — a NumPy array or a plain list. The bridge reads both, so a model that already returns an array needs no conversion.
+
 ```python
+from collections.abc import Iterable
+
 from xberg import register_reranker_backend, rerank_sync, RerankerConfig, RerankerModelType
 
 class MyReranker:
@@ -228,9 +232,9 @@ class MyReranker:
     def shutdown(self) -> None:
         pass
 
-    async def rerank(self, query: str, documents: list[str]) -> list[float]:
-        scores = self._model.predict([(query, doc) for doc in documents])
-        return scores.tolist()
+    async def rerank(self, query: str, documents: list[str]) -> Iterable[float]:
+        return self._model.predict([(query, doc) for doc in documents])   # ndarray
+        # return [0.82, 0.13]   # a plain list works the same
 
 
 register_reranker_backend(MyReranker())

--- a/docs-site/src/snippets/python/plugins/embedding_backend.md
+++ b/docs-site/src/snippets/python/plugins/embedding_backend.md
@@ -1,4 +1,6 @@
 ```python title="Python"
+from collections.abc import Iterable
+
 from xberg import register_embedding_backend, EmbeddingConfig, embed_texts
 from sentence_transformers import SentenceTransformer
 
@@ -28,8 +30,11 @@ class MyEmbedder:
         # Captured once at registration; the dispatcher uses this for shape validation.
         return self._model.get_sentence_embedding_dimension()
 
-    def embed(self, texts: list[str]) -> list[list[float]]:
-        return self._model.encode(texts).tolist()
+    def embed(self, texts: list[str]) -> Iterable[Iterable[float]]:
+        # Anything sequence-like works: a NumPy array, a list of NumPy vectors, or
+        # plain nested lists. Return whatever your model already produces.
+        return self._model.encode(texts)          # ndarray, no conversion
+        # return [[0.1, 0.2, ...], [0.3, 0.4, ...]]   # nested lists, equally fine
 
 
 # Register once at startup. Reference by name in config.


### PR DESCRIPTION
Blocked on xberg-io/alef#202 (PR xberg-io/alef#203) and the pin bump that follows it. The examples here are runtime-correct today but will not type-check until the regenerated stub lands.

## What this changes

The Python plugin examples told authors to convert their vectors to nested lists:

```python
def embed(self, texts: list[str]) -> list[list[float]]:
    return self._model.encode(texts).tolist()
```

The `.tolist()` was never needed. The PyO3 bridge extracts these returns with `Vec<T>`, which accepts any object passing `PySequence_Check` — NumPy arrays included. It was there to satisfy the generated type stub, which renders the return as `list[list[float]]`.

Both examples now return whatever the model already produces, annotated with `collections.abc.Iterable` so they cover the array and the list shape without implying a NumPy dependency:

```python
def embed(self, texts: list[str]) -> Iterable[Iterable[float]]:
    return self._model.encode(texts)          # ndarray, no conversion
    # return [[0.1, 0.2, ...], [0.3, 0.4, ...]]   # nested lists, equally fine
```

Same for `RerankerBackend.rerank` in the reranking guide, where `CrossEncoder.predict` returns an array for the same reason.

## Why it's blocked

The stub is alef-generated. Until alef widens the return annotation for numeric callback returns and kreuzberg picks up the new pin, these examples type-check clean at runtime but fail mypy and pyright. The alef issue carries the generator fix and the before/after.

## Verification

Built a wheel at rc.40 and drove the plugin path end to end — `register_embedding_backend`, then `extract()` with semantic chunking against `{"type": "plugin"}` — asserting the vectors landing on the chunks are the ones the backend returned.

| Backend returns | Runtime | mypy / pyright (current stub) | mypy / pyright (regenerated stub) |
|---|---|---|---|
| `list[list[float]]` | exact vectors delivered | pass | pass |
| `np.ndarray` 2-D float32 | exact vectors delivered | reject | pass |
| `list[np.ndarray]` 1-D float32 | exact vectors delivered | reject | pass |
| `np.ndarray` 2-D float64 | exact vectors delivered | reject | pass |

The compiled extension is byte-identical across the last two columns — only the `.pyi` differs.

Docs-only; no generated files in this diff.

Both annotated forms — returning an ndarray and returning nested lists — pass `mypy --strict` and pyright.
