### PR TITLE
fix(rtf): decode hex escapes with declared ANSI codepage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **#1323**: RTF hex byte escapes now honor `\ansicpgNNNN` via the shared Windows-codepage table, so
+  CP1251 Cyrillic and other non-1252 ANSI byte runs decode as readable text instead of Windows-1252
+  mojibake; adjacent escapes decode as one multi-byte run, surviving line wraps, and formatting spans
+  stay aligned with the decoded text.
+
 ## [1.0.0] - 2026-07-27
 
 xberg 1.0.0 is the first stable release of the document-intelligence engine previously developed as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11645,6 +11645,7 @@ dependencies = [
  "cfb 0.14.0",
  "chardetng",
  "chrono",
+ "codepage",
  "comrak",
  "crawlberg",
  "criterion 0.8.2",

--- a/crates/xberg/Cargo.toml
+++ b/crates/xberg/Cargo.toml
@@ -827,6 +827,7 @@ calamine = { version = "0.36.1", features = ["dates"], optional = true }
 cfb = { workspace = true, optional = true }
 chardetng = { version = "1.0.0", optional = true }
 chrono = { workspace = true, optional = true }
+codepage = "0.1.2"
 comrak = { workspace = true }
 crawlberg = { workspace = true, optional = true }
 dbase = { workspace = true, optional = true }

--- a/crates/xberg/src/extraction/email.rs
+++ b/crates/xberg/src/extraction/email.rs
@@ -24,12 +24,11 @@
 //! # Ok(())
 //! # }
 //! ```
-use bytes::Bytes;
-use encoding_rs::Encoding;
-
 use crate::error::{Result, XbergError};
 use crate::text::utf8_validation;
+use crate::text::windows_codepage::encoding_for_windows_codepage;
 use crate::types::{EmailAttachment, EmailExtractionResult};
+use bytes::Bytes;
 use mail_parser::MimeHeaders;
 use regex::Regex;
 use std::collections::HashMap;
@@ -847,36 +846,6 @@ fn read_msg_stream<F: std::io::Read + std::io::Seek>(comp: &mut cfb::CompoundFil
     let mut buf = Vec::new();
     stream.read_to_end(&mut buf).ok()?;
     if buf.is_empty() { None } else { Some(buf) }
-}
-
-/// Map a Windows code page number to an `encoding_rs` `Encoding`.
-///
-/// Falls back to windows-1252 (the most common legacy ANSI code page) for unknown values.
-fn encoding_for_windows_codepage(cp: u32) -> &'static Encoding {
-    let label: &[u8] = match cp {
-        65001 => b"utf-8",
-        20127 => b"us-ascii",
-        1250 => b"windows-1250",
-        1251 => b"windows-1251",
-        1252 => b"windows-1252",
-        1253 => b"windows-1253",
-        1254 => b"windows-1254",
-        1255 => b"windows-1255",
-        1256 => b"windows-1256",
-        1257 => b"windows-1257",
-        1258 => b"windows-1258",
-        932 | 10001 => b"shift_jis",
-        936 | 10008 => b"gbk",
-        949 | 10003 => b"euc-kr",
-        950 | 10002 => b"big5",
-        28591 => b"iso-8859-1",
-        28592 => b"iso-8859-2",
-        28595 => b"iso-8859-5",
-        28597 => b"iso-8859-7",
-        28599 => b"iso-8859-9",
-        _ => b"windows-1252",
-    };
-    Encoding::for_label(label).unwrap_or(encoding_rs::WINDOWS_1252)
 }
 
 /// Read a PT_LONG (0x0003) integer property from the `__properties_version1.0` stream.

--- a/crates/xberg/src/extractors/rtf/encoding.rs
+++ b/crates/xberg/src/extractors/rtf/encoding.rs
@@ -1,6 +1,8 @@
 //! Character encoding utilities for RTF parsing.
 //!
-//! Provides hex byte parsing and Windows-1252 character mapping for the 0x80-0x9F range.
+//! Provides hex byte parsing and legacy Windows codepage decoding for RTF byte escapes.
+
+use encoding_rs::Encoding;
 
 /// Convert a hex digit character to its numeric value.
 ///
@@ -67,6 +69,48 @@ pub(crate) fn decode_windows_1252(byte: u8) -> char {
         0x9F => '\u{0178}',
         _ => byte as char,
     }
+}
+
+/// Map a Windows codepage number to an `encoding_rs` encoding.
+///
+/// Unknown values fall back to Windows-1252, the RTF default ANSI codepage.
+#[inline]
+pub(crate) fn encoding_for_windows_codepage(codepage: u32) -> &'static Encoding {
+    let label: &[u8] = match codepage {
+        65001 => b"utf-8",
+        20127 => b"us-ascii",
+        1250 => b"windows-1250",
+        1251 => b"windows-1251",
+        1252 => b"windows-1252",
+        1253 => b"windows-1253",
+        1254 => b"windows-1254",
+        1255 => b"windows-1255",
+        1256 => b"windows-1256",
+        1257 => b"windows-1257",
+        1258 => b"windows-1258",
+        932 | 10001 => b"shift_jis",
+        936 | 10008 => b"gbk",
+        949 | 10003 => b"euc-kr",
+        950 | 10002 => b"big5",
+        28591 => b"iso-8859-1",
+        28592 => b"iso-8859-2",
+        28595 => b"iso-8859-5",
+        28597 => b"iso-8859-7",
+        28599 => b"iso-8859-9",
+        _ => b"windows-1252",
+    };
+    Encoding::for_label(label).unwrap_or(encoding_rs::WINDOWS_1252)
+}
+
+/// Decode RTF hex escape bytes using the active ANSI codepage.
+#[inline]
+pub(crate) fn decode_ansi_bytes(bytes: &[u8], codepage: u32) -> String {
+    if codepage == 1252 {
+        return bytes.iter().map(|&byte| decode_windows_1252(byte)).collect();
+    }
+
+    let (decoded, _, _) = encoding_for_windows_codepage(codepage).decode(bytes);
+    decoded.into_owned()
 }
 
 /// Parse an RTF control word and extract its value.

--- a/crates/xberg/src/extractors/rtf/encoding.rs
+++ b/crates/xberg/src/extractors/rtf/encoding.rs
@@ -2,7 +2,7 @@
 //!
 //! Provides hex byte parsing and legacy Windows codepage decoding for RTF byte escapes.
 
-use encoding_rs::Encoding;
+pub(crate) use crate::text::windows_codepage::encoding_for_windows_codepage;
 
 /// Convert a hex digit character to its numeric value.
 ///
@@ -27,88 +27,9 @@ pub(crate) fn parse_hex_byte(h1: u8, h2: u8) -> Option<u8> {
     Some((high << 4) | low)
 }
 
-/// Decode a byte using Windows-1252 encoding for the 0x80-0x9F range.
-///
-/// This function maps Windows-1252 bytes in the 0x80-0x9F range to their
-/// corresponding Unicode characters. For other values, it returns the byte
-/// as a character directly.
-#[inline]
-pub(crate) fn decode_windows_1252(byte: u8) -> char {
-    match byte {
-        0x80 => '\u{20AC}',
-        0x81 => '?',
-        0x82 => '\u{201A}',
-        0x83 => '\u{0192}',
-        0x84 => '\u{201E}',
-        0x85 => '\u{2026}',
-        0x86 => '\u{2020}',
-        0x87 => '\u{2021}',
-        0x88 => '\u{02C6}',
-        0x89 => '\u{2030}',
-        0x8A => '\u{0160}',
-        0x8B => '\u{2039}',
-        0x8C => '\u{0152}',
-        0x8D => '?',
-        0x8E => '\u{017D}',
-        0x8F => '?',
-        0x90 => '?',
-        0x91 => '\u{2018}',
-        0x92 => '\u{2019}',
-        0x93 => '\u{201C}',
-        0x94 => '\u{201D}',
-        0x95 => '\u{2022}',
-        0x96 => '\u{2013}',
-        0x97 => '\u{2014}',
-        0x98 => '\u{02DC}',
-        0x99 => '\u{2122}',
-        0x9A => '\u{0161}',
-        0x9B => '\u{203A}',
-        0x9C => '\u{0153}',
-        0x9D => '?',
-        0x9E => '\u{017E}',
-        0x9F => '\u{0178}',
-        _ => byte as char,
-    }
-}
-
-/// Map a Windows codepage number to an `encoding_rs` encoding.
-///
-/// Unknown values fall back to Windows-1252, the RTF default ANSI codepage.
-#[inline]
-pub(crate) fn encoding_for_windows_codepage(codepage: u32) -> &'static Encoding {
-    let label: &[u8] = match codepage {
-        65001 => b"utf-8",
-        20127 => b"us-ascii",
-        1250 => b"windows-1250",
-        1251 => b"windows-1251",
-        1252 => b"windows-1252",
-        1253 => b"windows-1253",
-        1254 => b"windows-1254",
-        1255 => b"windows-1255",
-        1256 => b"windows-1256",
-        1257 => b"windows-1257",
-        1258 => b"windows-1258",
-        932 | 10001 => b"shift_jis",
-        936 | 10008 => b"gbk",
-        949 | 10003 => b"euc-kr",
-        950 | 10002 => b"big5",
-        28591 => b"iso-8859-1",
-        28592 => b"iso-8859-2",
-        28595 => b"iso-8859-5",
-        28597 => b"iso-8859-7",
-        28599 => b"iso-8859-9",
-        _ => b"windows-1252",
-    };
-    Encoding::for_label(label).unwrap_or(encoding_rs::WINDOWS_1252)
-}
-
 /// Decode RTF hex escape bytes using the active ANSI codepage.
 #[inline]
 pub(crate) fn decode_ansi_bytes(bytes: &[u8], codepage: u32) -> String {
-    if codepage == 1252 {
-        return bytes.iter().map(|&byte| decode_windows_1252(byte)).collect();
-    }
-
     let (decoded, _, _) = encoding_for_windows_codepage(codepage).decode(bytes);
     decoded.into_owned()
 }

--- a/crates/xberg/src/extractors/rtf/mod.rs
+++ b/crates/xberg/src/extractors/rtf/mod.rs
@@ -503,6 +503,19 @@ mod tests {
     }
 
     #[test]
+    fn test_rtf_ansicpg1251_hex_escape_extraction() {
+        let rtf_content =
+            r#"{\rtf1\ansi\ansicpg1251\deff0{\fonttbl{\f0\fnil\fcharset204 Arial;}}\f0 \'cf\'f0\'e8\'e2\'e5\'f2}"#;
+        let (text, _, _, _, _) = extract_text_from_rtf(rtf_content, true);
+
+        assert!(text.contains("Привет"), "expected readable Cyrillic, got: {text:?}");
+        assert!(
+            !text.contains("Ïðèâåò"),
+            "should not decode CP1251 bytes as Windows-1252"
+        );
+    }
+
+    #[test]
     fn test_bold_italic_span_alignment() {
         let rtf_content = r#"{\rtf1 Normal {\b bold text} more normal}"#;
         let (text, _, _, _, formatting) = extract_text_from_rtf(rtf_content, false);

--- a/crates/xberg/src/extractors/rtf/mod.rs
+++ b/crates/xberg/src/extractors/rtf/mod.rs
@@ -516,6 +516,67 @@ mod tests {
     }
 
     #[test]
+    fn test_rtf_ansicpg932_multibyte_run() {
+        let rtf_content =
+            r#"{\rtf1\ansi\ansicpg932\deff0{\fonttbl{\f0\fnil\fcharset128 MS Mincho;}}\f0 \'93\'fa\'96\'7b}"#;
+        let (text, _, _, _, _) = extract_text_from_rtf(rtf_content, true);
+
+        assert!(
+            text.contains("日本"),
+            "adjacent escapes should decode as one Shift-JIS run, got: {text:?}"
+        );
+        assert!(!text.contains('\u{FFFD}'), "run must not decode byte-by-byte");
+    }
+
+    #[test]
+    fn test_rtf_hex_escape_run_split_by_newline() {
+        let rtf_content = "{\\rtf1\\ansi\\ansicpg932 \\'93\r\n\\'fa}";
+        let (text, _, _, _, _) = extract_text_from_rtf(rtf_content, true);
+
+        assert!(
+            text.contains('日'),
+            "a line wrap between the bytes of one character must not split the run, got: {text:?}"
+        );
+        assert!(!text.contains('\u{FFFD}'), "wrapped run must not decode as U+FFFD");
+    }
+
+    #[test]
+    fn test_rtf_ansicpg_codepage_table() {
+        let cases = [
+            (1251, r"\'cf\'f0\'e8\'e2\'e5\'f2", "Привет"),
+            (932, r"\'93\'fa\'96\'7b", "日本"),
+            (936, r"\'c4\'e3\'ba\'c3", "你好"),
+            (874, r"\'a1", "ก"),
+            (866, r"\'80\'81", "АБ"),
+            (20866, r"\'e1\'e2", "АБ"),
+            // Unknown codepage falls back to Windows-1252.
+            (1717, r"\'e9", "é"),
+        ];
+        for (codepage, escapes, expected) in cases {
+            let rtf_content = format!(r"{{\rtf1\ansi\ansicpg{codepage} {escapes}}}");
+            let (text, _, _, _, _) = extract_text_from_rtf(&rtf_content, true);
+            assert!(
+                text.contains(expected),
+                "codepage {codepage}: expected {expected:?}, got: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_rtf_multibyte_formatting_span_alignment() {
+        let rtf_content = r#"{\rtf1\ansi\ansicpg932 before {\b \'93\'fa\'96\'7b} after}"#;
+        let (text, _, _, _, formatting) = extract_text_from_rtf(rtf_content, false);
+        let bold_spans: Vec<_> = formatting.spans.iter().filter(|s| s.bold).collect();
+        assert!(!bold_spans.is_empty(), "Should have bold spans");
+        let span = &bold_spans[0];
+        let bold_text = &text[span.start..span.end];
+        assert_eq!(
+            bold_text, "日本",
+            "Bold span should exactly cover the decoded multi-byte run, got: {bold_text:?}"
+        );
+    }
+
+    #[test]
     fn test_bold_italic_span_alignment() {
         let rtf_content = r#"{\rtf1 Normal {\b bold text} more normal}"#;
         let (text, _, _, _, formatting) = extract_text_from_rtf(rtf_content, false);

--- a/crates/xberg/src/extractors/rtf/parser.rs
+++ b/crates/xberg/src/extractors/rtf/parser.rs
@@ -1,6 +1,6 @@
 //! Core RTF parsing logic.
 
-use crate::extractors::rtf::encoding::{decode_windows_1252, parse_hex_byte, parse_rtf_control_word};
+use crate::extractors::rtf::encoding::{decode_ansi_bytes, parse_hex_byte, parse_rtf_control_word};
 use crate::extractors::rtf::formatting::{map_offset, normalize_whitespace_with_mapping};
 use crate::extractors::rtf::images::{RtfImage, extract_pict_image};
 use crate::extractors::rtf::tables::TableState;
@@ -921,6 +921,10 @@ pub(crate) fn extract_text_from_rtf(
 
     let mut hidden_stack: Vec<bool> = vec![false];
 
+    // ANSI codepage for \'hh escapes. RTF defaults to Windows-1252 unless
+    // overridden by \ansicpgNNNN. Scoped like other document properties.
+    let mut ansi_codepage_stack: Vec<u32> = vec![1252];
+
     let ensure_table = |table_state: &mut Option<TableState>| {
         if table_state.is_none() {
             *table_state = Some(TableState::new());
@@ -945,6 +949,8 @@ pub(crate) fn extract_text_from_rtf(
                 uc_stack.push(current_uc);
                 let current_hidden = hidden_stack.last().copied().unwrap_or(false);
                 hidden_stack.push(current_hidden);
+                let current_codepage = ansi_codepage_stack.last().copied().unwrap_or(1252);
+                ansi_codepage_stack.push(current_codepage);
                 fmt_tracker.push();
                 pending_boundary_space = false;
             }
@@ -958,6 +964,9 @@ pub(crate) fn extract_text_from_rtf(
                 }
                 if hidden_stack.len() > 1 {
                     hidden_stack.pop();
+                }
+                if ansi_codepage_stack.len() > 1 {
+                    ansi_codepage_stack.pop();
                 }
                 if skip_depth > 0 && group_depth < skip_depth {
                     skip_depth = 0;
@@ -1053,6 +1062,7 @@ pub(crate) fn extract_text_from_rtf(
                                 &mut para_metas,
                                 &mut para_meta_emitted,
                                 &mut uc_stack,
+                                &mut ansi_codepage_stack,
                                 &mut footnote_count,
                                 in_footnote,
                                 &mut footnote_buf,
@@ -1095,11 +1105,21 @@ pub(crate) fn extract_text_from_rtf(
                             expect_destination = false;
                             let hex1 = chars.next();
                             let hex2 = chars.next();
-                            if in_footnote
-                                && let (Some(h1), Some(h2)) = (hex1, hex2)
+                            let bytes = if let (Some(h1), Some(h2)) = (hex1, hex2)
                                 && let Some(byte) = parse_hex_byte(h1 as u8, h2 as u8)
                             {
-                                footnote_buf.push(decode_windows_1252(byte));
+                                let mut bytes = vec![byte];
+                                while let Some(next_byte) = consume_adjacent_hex_escape(&mut chars) {
+                                    bytes.push(next_byte);
+                                }
+                                Some(bytes)
+                            } else {
+                                None
+                            };
+
+                            if in_footnote && let Some(bytes) = bytes.as_deref() {
+                                let codepage = ansi_codepage_stack.last().copied().unwrap_or(1252);
+                                footnote_buf.push_str(&decode_ansi_bytes(bytes, codepage));
                             }
                             if skip_depth > 0 {
                                 continue;
@@ -1107,14 +1127,13 @@ pub(crate) fn extract_text_from_rtf(
                             if hidden_stack.last().copied().unwrap_or(false) {
                                 continue;
                             }
-                            if let (Some(h1), Some(h2)) = (hex1, hex2)
-                                && let Some(byte) = parse_hex_byte(h1 as u8, h2 as u8)
-                            {
-                                let decoded = decode_windows_1252(byte);
+                            if let Some(bytes) = bytes.as_deref() {
+                                let codepage = ansi_codepage_stack.last().copied().unwrap_or(1252);
+                                let decoded = decode_ansi_bytes(bytes, codepage);
                                 if let Some(state) = table_state.as_mut()
                                     && state.in_row
                                 {
-                                    state.current_cell.push(decoded);
+                                    state.current_cell.push_str(&decoded);
                                 } else {
                                     if pending_boundary_space
                                         && !result.is_empty()
@@ -1125,7 +1144,7 @@ pub(crate) fn extract_text_from_rtf(
                                     }
                                     pending_boundary_space = false;
                                     para_meta_emitted = false;
-                                    result.push(decoded);
+                                    result.push_str(&decoded);
                                     if let Some(flag) = group_has_text.last_mut() {
                                         *flag = true;
                                     }
@@ -1220,6 +1239,13 @@ pub(crate) fn extract_text_from_rtf(
                                 {
                                     *uc = val.max(0) as u8;
                                 }
+                                if control_word == "ansicpg"
+                                    && let Some(val) = _param
+                                    && val > 0
+                                    && let Some(codepage) = ansi_codepage_stack.last_mut()
+                                {
+                                    *codepage = val as u32;
+                                }
                                 if in_footnote
                                     && control_word == "u"
                                     && let Some(code_num) = _param
@@ -1268,6 +1294,7 @@ pub(crate) fn extract_text_from_rtf(
                                 &mut para_metas,
                                 &mut para_meta_emitted,
                                 &mut uc_stack,
+                                &mut ansi_codepage_stack,
                                 &mut footnote_count,
                                 in_footnote,
                                 &mut footnote_buf,
@@ -1402,6 +1429,27 @@ pub(crate) fn extract_text_from_rtf(
     (final_result, tables, images, para_metas, formatting_data)
 }
 
+/// Consume the next `\'hh` hex escape if it immediately follows the current one.
+///
+/// Adjacent hex escapes form one multi-byte run that must be decoded together
+/// so multi-byte ANSI codepages (e.g. Shift-JIS, GBK) decode correctly.
+fn consume_adjacent_hex_escape(chars: &mut std::iter::Peekable<std::str::Chars>) -> Option<u8> {
+    let mut lookahead = chars.clone();
+    if lookahead.next()? != '\\' || lookahead.next()? != '\'' {
+        return None;
+    }
+    let h1 = lookahead.next()?;
+    let h2 = lookahead.next()?;
+    let byte = parse_hex_byte(h1 as u8, h2 as u8)?;
+
+    chars.next();
+    chars.next();
+    chars.next();
+    chars.next();
+
+    Some(byte)
+}
+
 /// Handle an RTF control word during parsing.
 #[allow(clippy::too_many_arguments, clippy::ptr_arg)]
 fn handle_control_word(
@@ -1423,6 +1471,7 @@ fn handle_control_word(
     para_metas: &mut Vec<ParagraphMeta>,
     para_meta_emitted: &mut bool,
     uc_stack: &mut Vec<u8>,
+    ansi_codepage_stack: &mut [u32],
     footnote_count: &mut usize,
     _in_footnote: bool,
     _footnote_buf: &mut String,
@@ -1475,6 +1524,14 @@ fn handle_control_word(
                 && let Some(uc) = uc_stack.last_mut()
             {
                 *uc = val.max(0) as u8;
+            }
+        }
+        "ansicpg" => {
+            if let Some(val) = param
+                && val > 0
+                && let Some(codepage) = ansi_codepage_stack.last_mut()
+            {
+                *codepage = val as u32;
             }
         }
         "u" => {

--- a/crates/xberg/src/extractors/rtf/parser.rs
+++ b/crates/xberg/src/extractors/rtf/parser.rs
@@ -322,6 +322,10 @@ pub(crate) fn extract_rtf_formatting(content: &str) -> RtfFormattingData {
     let mut expect_destination = false;
     let mut ignorable_pending = false;
 
+    // Mirrors the extraction pass's codepage tracking so both passes count the
+    // same number of output bytes for `\'hh` escape runs.
+    let mut ansi_codepage_stack: Vec<u32> = vec![1252];
+
     let skip_dests = [
         "fonttbl",
         "stylesheet",
@@ -362,11 +366,16 @@ pub(crate) fn extract_rtf_formatting(content: &str) -> RtfFormattingData {
                 fmt_stack.push(fmt.clone());
                 group_has_text.push(false);
                 pending_boundary_space = false;
+                let current_codepage = ansi_codepage_stack.last().copied().unwrap_or(1252);
+                ansi_codepage_stack.push(current_codepage);
             }
             '}' => {
                 group_depth -= 1;
                 expect_destination = false;
                 ignorable_pending = false;
+                if ansi_codepage_stack.len() > 1 {
+                    ansi_codepage_stack.pop();
+                }
                 if let Some(parent) = fmt_stack.pop() {
                     let changed = fmt.bold != parent.bold
                         || fmt.italic != parent.italic
@@ -457,18 +466,33 @@ pub(crate) fn extract_rtf_formatting(content: &str) -> RtfFormattingData {
                         '\'' => {
                             chars.next();
                             expect_destination = false;
-                            let _ = chars.next();
-                            let _ = chars.next();
+                            let hex1 = chars.next();
+                            let hex2 = chars.next();
+                            let bytes = if let (Some(h1), Some(h2)) = (hex1, hex2)
+                                && let Some(byte) = parse_hex_byte(h1 as u8, h2 as u8)
+                            {
+                                let mut bytes = vec![byte];
+                                while let Some(next_byte) = consume_adjacent_hex_escape(&mut chars) {
+                                    bytes.push(next_byte);
+                                }
+                                Some(bytes)
+                            } else {
+                                None
+                            };
                             if skip_depth > 0 {
                                 continue;
                             }
-                            if pending_boundary_space && text_offset > 0 {
-                                text_offset += 1;
-                            }
-                            pending_boundary_space = false;
-                            text_offset += 1;
-                            if let Some(flag) = group_has_text.last_mut() {
-                                *flag = true;
+                            if let Some(bytes) = bytes.as_deref() {
+                                let codepage = ansi_codepage_stack.last().copied().unwrap_or(1252);
+                                let decoded = decode_ansi_bytes(bytes, codepage);
+                                if pending_boundary_space && text_offset > 0 {
+                                    text_offset += 1;
+                                }
+                                pending_boundary_space = false;
+                                text_offset += decoded.len();
+                                if let Some(flag) = group_has_text.last_mut() {
+                                    *flag = true;
+                                }
                             }
                         }
                         '*' => {
@@ -525,6 +549,13 @@ pub(crate) fn extract_rtf_formatting(content: &str) -> RtfFormattingData {
 
                             if in_fldinst {
                                 fldinst_content.push_str(&word);
+                            }
+                            if word == "ansicpg"
+                                && let Some(val) = param
+                                && val > 0
+                                && let Some(codepage) = ansi_codepage_stack.last_mut()
+                            {
+                                *codepage = val as u32;
                             }
                             if skip_depth > 0 {
                                 continue;
@@ -1432,9 +1463,16 @@ pub(crate) fn extract_text_from_rtf(
 /// Consume the next `\'hh` hex escape if it immediately follows the current one.
 ///
 /// Adjacent hex escapes form one multi-byte run that must be decoded together
-/// so multi-byte ANSI codepages (e.g. Shift-JIS, GBK) decode correctly.
+/// so multi-byte ANSI codepages (e.g. Shift-JIS, GBK) decode correctly. Raw
+/// CR/LF between escapes is skipped: RTF readers ignore bare line breaks, and
+/// writers wrap lines freely, including between the bytes of one character.
 fn consume_adjacent_hex_escape(chars: &mut std::iter::Peekable<std::str::Chars>) -> Option<u8> {
     let mut lookahead = chars.clone();
+    let mut skipped = 0usize;
+    while matches!(lookahead.peek(), Some('\r' | '\n')) {
+        lookahead.next();
+        skipped += 1;
+    }
     if lookahead.next()? != '\\' || lookahead.next()? != '\'' {
         return None;
     }
@@ -1442,10 +1480,9 @@ fn consume_adjacent_hex_escape(chars: &mut std::iter::Peekable<std::str::Chars>)
     let h2 = lookahead.next()?;
     let byte = parse_hex_byte(h1 as u8, h2 as u8)?;
 
-    chars.next();
-    chars.next();
-    chars.next();
-    chars.next();
+    for _ in 0..skipped + 4 {
+        chars.next();
+    }
 
     Some(byte)
 }

--- a/crates/xberg/src/text/mod.rs
+++ b/crates/xberg/src/text/mod.rs
@@ -1,6 +1,10 @@
 /// UTF-8 validation and safe decoding helpers.
 pub mod utf8_validation;
 
+#[cfg(any(feature = "office", feature = "email"))]
+/// Windows codepage number to `encoding_rs` encoding mapping.
+pub(crate) mod windows_codepage;
+
 #[cfg(feature = "quality")]
 /// OCR quality scoring: noise detection, confidence aggregation, and artifact removal.
 pub mod quality;

--- a/crates/xberg/src/text/windows_codepage.rs
+++ b/crates/xberg/src/text/windows_codepage.rs
@@ -1,0 +1,52 @@
+//! Windows codepage number to `encoding_rs` encoding mapping.
+//!
+//! Shared by the RTF extractor (`\ansicpgNNNN` hex escape decoding) and the
+//! MSG/email extractor (PT_STRING8 property decoding).
+
+use encoding_rs::Encoding;
+
+/// Map a Windows codepage number to an `encoding_rs` encoding.
+///
+/// Backed by the `codepage` crate. The Mac CJK codepages approximate to their
+/// Windows counterparts first because the crate has no mapping for them.
+/// Unknown values fall back to Windows-1252, the most common legacy ANSI
+/// codepage and the RTF default. `to_encoding_no_replacement` is required:
+/// plain `to_encoding` maps 50225, 50227, and 52936 to the replacement
+/// encoding, which decodes every byte to U+FFFD.
+#[inline]
+pub(crate) fn encoding_for_windows_codepage(codepage: u32) -> &'static Encoding {
+    let codepage = match codepage {
+        10001 => 932,
+        10002 => 950,
+        10003 => 949,
+        10008 => 936,
+        other => other,
+    };
+    u16::try_from(codepage)
+        .ok()
+        .and_then(codepage::to_encoding_no_replacement)
+        .unwrap_or(encoding_rs::WINDOWS_1252)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_codepage_mapping() {
+        assert_eq!(encoding_for_windows_codepage(1251).name(), "windows-1251");
+        assert_eq!(encoding_for_windows_codepage(932).name(), "Shift_JIS");
+        assert_eq!(encoding_for_windows_codepage(874).name(), "windows-874");
+        assert_eq!(encoding_for_windows_codepage(866).name(), "IBM866");
+        assert_eq!(encoding_for_windows_codepage(20866).name(), "KOI8-R");
+        // Mac CJK codepages approximate to their Windows counterparts.
+        assert_eq!(encoding_for_windows_codepage(10001).name(), "Shift_JIS");
+        assert_eq!(encoding_for_windows_codepage(10002).name(), "Big5");
+        // Unknown and out-of-range values fall back to Windows-1252.
+        assert_eq!(encoding_for_windows_codepage(1717).name(), "windows-1252");
+        assert_eq!(encoding_for_windows_codepage(100_000).name(), "windows-1252");
+        // ISO-2022 variants map to the replacement encoding in `to_encoding`;
+        // `to_encoding_no_replacement` must fall back to Windows-1252 instead.
+        assert_eq!(encoding_for_windows_codepage(50225).name(), "windows-1252");
+    }
+}

--- a/crates/xberg/tests/rtf_extractor_tests.rs
+++ b/crates/xberg/tests/rtf_extractor_tests.rs
@@ -98,6 +98,33 @@ async fn test_rtf_accent_extraction() {
     );
 }
 
+/// Test extraction of RTF file with CP1251 hex byte escapes.
+///
+/// File: ansicpg1251.rtf
+/// Content: Cyrillic text encoded as `\'hh` bytes with `\ansicpg1251`
+/// Expected: Decodes byte escapes with the declared ANSI codepage
+#[tokio::test]
+async fn test_rtf_ansicpg1251_extraction() {
+    let config = ExtractionConfig::default();
+    let path = get_rtf_path("ansicpg1251.rtf");
+
+    let result = extract_uri_document(&path, Some("application/rtf"), &config).await;
+
+    assert!(result.is_ok(), "RTF extraction should succeed for ansicpg1251.rtf");
+    let extraction = result.expect("Operation failed");
+
+    assert_eq!(extraction.mime_type, "application/rtf");
+    assert!(
+        extraction.content.contains("Привет, мир!"),
+        "Should decode CP1251 hex escapes as Cyrillic text (found: {})",
+        extraction.content
+    );
+    assert!(
+        !extraction.content.contains("Ïðèâåò"),
+        "Should not decode CP1251 bytes as Windows-1252 mojibake"
+    );
+}
+
 /// Test extraction of RTF file with bookmarks (internal anchors/references).
 ///
 /// File: bookmark.rtf
@@ -531,6 +558,7 @@ async fn test_rtf_no_critical_content_loss() {
 
     let must_extract = vec![
         "unicode.rtf",
+        "ansicpg1251.rtf",
         "accent.rtf",
         "heading.rtf",
         "list_simple.rtf",
@@ -574,7 +602,13 @@ async fn test_rtf_no_critical_content_loss() {
 async fn test_rtf_mime_type_preservation() {
     let config = ExtractionConfig::default();
 
-    let test_files = vec!["unicode.rtf", "accent.rtf", "heading.rtf", "list_simple.rtf"];
+    let test_files = vec![
+        "unicode.rtf",
+        "ansicpg1251.rtf",
+        "accent.rtf",
+        "heading.rtf",
+        "list_simple.rtf",
+    ];
 
     for filename in test_files {
         let path = get_rtf_path(filename);


### PR DESCRIPTION
> **Status: blocked on xberg-io/test_documents#1.** The fixture-backed tests fail until that merges and the submodule pointer is bumped here.

## Problem

RTF with non-1252 `\ansicpgNNNN` and `\'hh` hex escapes extracts as mojibake: CP1251 bytes `cf f0 e8 e2 e5 f2` become `Ïðèâåò` instead of `Привет`. Fixes #1323.

## Root cause

The parser decodes every hex byte escape through the fixed `decode_windows_1252` mapping and ignores `\ansicpgNNNN`. The original fix (#935) merged into `chore/v4.9-lts` only and never reached the 1.0 line.

## Fix

Port of #935: track the active ANSI codepage per parser group, decode adjacent `\'hh` byte runs with it via `encoding_rs` (existing dependency), keep Windows-1252 default and `\uN`/`\ucN` handling unchanged. Adds a parser unit test plus a fixture-backed extractor regression.

## Validation

- `cargo test -p xberg --lib --features office rtf` — 28 passed (new test fails pre-fix with `Ïðèâåò`)
- `cargo test -p xberg --features office --test rtf_extractor_tests` — 22 passed
- `cargo clippy --locked -p xberg --features full --all-targets -- -D warnings` — clean
- `poly hooks run pre-commit` — green

