### PR TITLE
feat: auto mode runs layout detection only on pages that need it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `LayoutStrategy` enum on `LayoutDetectionConfig` (`strategy` field, default `always`). `auto` pre-screens each PDF page with cheap geometry signals and runs the layout model only on pages likely to benefit; existing configs keep the every-page behavior bit-for-bit ([#1322](https://github.com/xberg-io/xberg/issues/1322)).
+- `LayoutStrategy` enum on `LayoutDetectionConfig` (`strategy` field, default `always`). `auto` pre-screens each PDF page with cheap geometry signals and runs the layout model only on pages likely to benefit; existing configs keep the every-page behavior bit-for-bit. On the OCR path only inference is skipped, since OCR consumes the layout pass's rasters. Skipped pages are auditable via `metadata.pdf.layout_gated_pages` and `layout_gate_reasons`, and the CLI gains `--layout-strategy` ([#1322](https://github.com/xberg-io/xberg/issues/1322)).
 
 ## [1.0.0] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `LayoutStrategy` enum on `LayoutDetectionConfig` (`strategy` field, default `always`). `auto` pre-screens each PDF page with cheap geometry signals and runs the layout model only on pages likely to benefit; existing configs keep the every-page behavior bit-for-bit ([#1322](https://github.com/xberg-io/xberg/issues/1322)).
+
 ## [1.0.0] - 2026-07-27
 
 xberg 1.0.0 is the first stable release of the document-intelligence engine previously developed as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `LayoutStrategy` enum on `LayoutDetectionConfig` (`strategy` field, default `always`). `auto` pre-screens each PDF page with cheap geometry signals and runs the layout model only on pages likely to benefit; existing configs keep the every-page behavior bit-for-bit. On the OCR path only inference is skipped, since OCR consumes the layout pass's rasters. Skipped pages are auditable via `metadata.pdf.layout_gated_pages` and `layout_gate_reasons`, and the CLI gains `--layout-strategy` ([#1322](https://github.com/xberg-io/xberg/issues/1322)).
+- `LayoutStrategy` enum on `LayoutDetectionConfig` (`strategy` field, default `always`). `auto` pre-screens each PDF page with cheap geometry signals and runs the layout model only on pages likely to benefit; existing configs keep the every-page behavior bit-for-bit. On the OCR path only inference is skipped, since OCR consumes the layout pass's rasters. Skipped pages are auditable via `metadata.format.layout_gated_pages` and `layout_gate_reasons`, and the CLI gains `--layout-strategy` ([#1322](https://github.com/xberg-io/xberg/issues/1322)).
 
 ## [1.0.0] - 2026-07-27
 

--- a/crates/xberg-cli/src/commands/overrides.rs
+++ b/crates/xberg-cli/src/commands/overrides.rs
@@ -259,6 +259,15 @@ pub struct ExtractionOverrides {
     #[arg(long)]
     pub layout_confidence: Option<f32>,
 
+    /// Which pages the layout model runs on: always (default, every page) or
+    /// auto (pre-screen each page and skip the model where it cannot help).
+    #[cfg(feature = "layout-detection")]
+    #[arg(
+        long,
+        help = "Layout page selection: always (default, every page) or auto (pre-screen pages)"
+    )]
+    pub layout_strategy: Option<String>,
+
     /// Table structure model: tatr (default), slanet_wired, slanet_wireless, slanet_plus, slanet_auto, disabled.
     #[cfg(feature = "layout-detection")]
     #[arg(
@@ -423,6 +432,14 @@ impl ExtractionOverrides {
             }
             if self.layout == Some(false) && (self.layout_confidence.is_some() || self.layout_table_model.is_some()) {
                 bail!("--layout false cannot be combined with --layout-confidence or --layout-table-model");
+            }
+            if self.layout == Some(false) && self.layout_strategy.is_some() {
+                bail!("--layout false cannot be combined with --layout-strategy");
+            }
+            if let Some(ref strategy) = self.layout_strategy
+                && strategy.parse::<xberg::LayoutStrategy>().is_err()
+            {
+                bail!("Invalid layout strategy: '{strategy}'. Valid: always, auto.");
             }
         }
 
@@ -764,6 +781,7 @@ impl ExtractionOverrides {
             let has_layout_flag = self.layout == Some(true)
                 || self.layout_confidence.is_some()
                 || self.layout_table_model.is_some()
+                || self.layout_strategy.is_some()
                 || self.use_layout_for_markdown;
             if has_layout_flag {
                 let mut layout = config.layout.clone().unwrap_or_default();
@@ -772,6 +790,9 @@ impl ExtractionOverrides {
                 }
                 if let Some(ref table_model) = self.layout_table_model {
                     layout.table_model = table_model.parse().unwrap_or_default();
+                }
+                if let Some(ref strategy) = self.layout_strategy {
+                    layout.strategy = strategy.parse().unwrap_or_default();
                 }
                 config.layout = Some(layout);
             }
@@ -1334,6 +1355,42 @@ mod tests {
         overrides.apply(&mut config);
         let layout = config.layout.unwrap();
         assert_eq!(layout.table_model, xberg::TableModel::SlanetWired);
+    }
+
+    #[cfg(feature = "layout-detection")]
+    #[test]
+    fn test_layout_strategy_applied() {
+        let mut config = ExtractionConfig::default();
+        let overrides = ExtractionOverrides {
+            layout_strategy: Some("auto".to_string()),
+            ..default_overrides()
+        };
+        overrides.apply(&mut config);
+        let layout = config.layout.unwrap();
+        assert_eq!(layout.strategy, xberg::LayoutStrategy::Auto);
+    }
+
+    #[cfg(feature = "layout-detection")]
+    #[test]
+    fn test_layout_strategy_rejects_unknown_value() {
+        let overrides = ExtractionOverrides {
+            layout_strategy: Some("adaptive".to_string()),
+            ..default_overrides()
+        };
+        let error = overrides.validate().expect_err("unknown strategy must fail");
+        assert!(error.to_string().contains("Invalid layout strategy"));
+    }
+
+    #[cfg(feature = "layout-detection")]
+    #[test]
+    fn test_layout_strategy_conflicts_with_layout_false() {
+        let overrides = ExtractionOverrides {
+            layout: Some(false),
+            layout_strategy: Some("auto".to_string()),
+            ..default_overrides()
+        };
+        let error = overrides.validate().expect_err("conflicting flags must fail");
+        assert!(error.to_string().contains("--layout-strategy"));
     }
 
     #[cfg(feature = "layout-detection")]

--- a/crates/xberg/src/core/config/layout.rs
+++ b/crates/xberg/src/core/config/layout.rs
@@ -261,6 +261,13 @@ mod tests {
     }
 
     #[test]
+    fn layout_strategy_deserializes_from_toml_config() {
+        let config: LayoutDetectionConfig =
+            toml::from_str("strategy = \"auto\"").expect("toml config must deserialize");
+        assert_eq!(config.strategy, LayoutStrategy::Auto);
+    }
+
+    #[test]
     fn layout_strategy_from_str_accepts_wire_names_and_rejects_unknown() {
         assert_eq!("always".parse::<LayoutStrategy>(), Ok(LayoutStrategy::Always));
         assert_eq!("auto".parse::<LayoutStrategy>(), Ok(LayoutStrategy::Auto));

--- a/crates/xberg/src/core/config/layout.rs
+++ b/crates/xberg/src/core/config/layout.rs
@@ -106,6 +106,51 @@ impl fmt::Display for TableOverlapPreference {
     }
 }
 
+/// Which PDF pages the layout model runs on.
+///
+/// Layout detection renders each selected page to a raster and runs ONNX
+/// inference on it, which dominates extraction cost. This controls page
+/// selection; [`LayoutStrategy::Always`] preserves the historical behavior of
+/// running on every page. Wire format is snake_case in all serializers
+/// (JSON, TOML, YAML).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LayoutStrategy {
+    /// Run layout detection unconditionally on every page.
+    #[default]
+    Always,
+    /// Pre-screen each page with cheap geometry signals and run the model
+    /// only on pages likely to benefit (multi-column, table-bearing,
+    /// figure-heavy, form-like, or rotated pages).
+    ///
+    /// Pages the pre-screen skips are processed exactly like pages where the
+    /// model ran and found no regions. On the OCR path only inference is
+    /// skipped; page rasters are still produced because OCR consumes them.
+    /// For non-PDF inputs `Auto` behaves as [`LayoutStrategy::Always`].
+    Auto,
+}
+
+impl std::str::FromStr for LayoutStrategy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "always" => Ok(Self::Always),
+            "auto" => Ok(Self::Auto),
+            other => Err(format!("unknown layout strategy: '{other}'. Valid: always, auto")),
+        }
+    }
+}
+
+impl fmt::Display for LayoutStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LayoutStrategy::Always => write!(f, "always"),
+            LayoutStrategy::Auto => write!(f, "auto"),
+        }
+    }
+}
+
 /// Layout detection configuration.
 ///
 /// Controls layout detection behavior in the extraction pipeline.
@@ -113,6 +158,15 @@ impl fmt::Display for TableOverlapPreference {
 /// is enabled for PDF extraction.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LayoutDetectionConfig {
+    /// Which pages the layout model runs on.
+    ///
+    /// Defaults to [`LayoutStrategy::Always`], the historical behavior:
+    /// every page is rendered and inferred. [`LayoutStrategy::Auto`]
+    /// pre-screens pages with cheap signals and skips the model where it
+    /// cannot help.
+    #[serde(default)]
+    pub strategy: LayoutStrategy,
+
     /// Confidence threshold override (None = use model default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub confidence_threshold: Option<f32>,
@@ -158,6 +212,7 @@ pub struct LayoutDetectionConfig {
 impl Default for LayoutDetectionConfig {
     fn default() -> Self {
         Self {
+            strategy: LayoutStrategy::default(),
             confidence_threshold: None,
             apply_heuristics: true,
             table_model: TableModel::default(),
@@ -179,9 +234,46 @@ mod tests {
     #[test]
     fn test_default_config() {
         let config = LayoutDetectionConfig::default();
+        assert_eq!(config.strategy, LayoutStrategy::Always);
         assert_eq!(config.table_model, TableModel::Tatr);
         assert!(config.apply_heuristics);
         assert!(config.confidence_threshold.is_none());
+    }
+
+    #[test]
+    fn layout_strategy_defaults_to_always_when_field_absent() {
+        let config: LayoutDetectionConfig = serde_json::from_str("{}").expect("empty config must deserialize");
+        assert_eq!(config.strategy, LayoutStrategy::Always);
+    }
+
+    #[test]
+    fn layout_strategy_serde_roundtrip_is_snake_case() {
+        let auto: LayoutStrategy = serde_json::from_str(r#""auto""#).expect("auto must deserialize");
+        assert_eq!(auto, LayoutStrategy::Auto);
+        assert_eq!(serde_json::to_string(&auto).expect("auto must serialize"), r#""auto""#);
+
+        let always: LayoutStrategy = serde_json::from_str(r#""always""#).expect("always must deserialize");
+        assert_eq!(always, LayoutStrategy::Always);
+        assert_eq!(
+            serde_json::to_string(&always).expect("always must serialize"),
+            r#""always""#
+        );
+    }
+
+    #[test]
+    fn layout_strategy_from_str_accepts_wire_names_and_rejects_unknown() {
+        assert_eq!("always".parse::<LayoutStrategy>(), Ok(LayoutStrategy::Always));
+        assert_eq!("auto".parse::<LayoutStrategy>(), Ok(LayoutStrategy::Auto));
+
+        let error = "adaptive".parse::<LayoutStrategy>().expect_err("unknown must fail");
+        assert!(error.contains("unknown layout strategy: 'adaptive'"));
+        assert!(error.contains("always, auto"));
+    }
+
+    #[test]
+    fn layout_strategy_display_matches_wire_format() {
+        assert_eq!(LayoutStrategy::Always.to_string(), "always");
+        assert_eq!(LayoutStrategy::Auto.to_string(), "auto");
     }
 
     #[test]

--- a/crates/xberg/src/core/config/mod.rs
+++ b/crates/xberg/src/core/config/mod.rs
@@ -50,7 +50,7 @@ pub use formats::{JupyterCellRendering, OutputFormat};
 pub use html_output::{HtmlOutputConfig, HtmlTheme};
 pub use late_interaction::{LateInteractionConfig, LateInteractionModelType};
 #[cfg(feature = "layout-types")]
-pub use layout::{LayoutDetectionConfig, TableModel};
+pub use layout::{LayoutDetectionConfig, LayoutStrategy, TableModel};
 pub use llm::{CallMode, LlmConfig, MergeMode, StructuredExtractionConfig};
 pub use ocr::{
     DEFAULT_SCANNED_MIN_CONFIDENCE, OcrConfig, OcrPipelineConfig, OcrPipelineStage, OcrQualityThresholds, OcrStrategy,

--- a/crates/xberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/xberg/src/extractors/pdf/layout_runner.rs
@@ -89,6 +89,18 @@ type LayoutForMarkdownOutput = (
     Vec<crate::layout::DetectionResult>,
 );
 
+/// Layout pass outcome plus the `Auto` gate's per-page decisions.
+///
+/// `data` is `None` when the gate skipped every page (the caller proceeds
+/// exactly as if layout were off). `gate_decisions` is `None` under strategy
+/// `Always` and always present under `Auto`, including the all-gated case, so
+/// gate behavior stays auditable from extraction metadata.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+pub(super) struct LayoutRunOutput {
+    pub data: Option<LayoutForMarkdownOutput>,
+    pub gate_decisions: Option<Vec<PageGateDecision>>,
+}
+
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 struct RenderedLayoutPage {
     page_index: usize,
@@ -116,7 +128,7 @@ async fn run_layout_for_pdf_pages_async(
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
     gated_handling: GatedPageHandling,
-) -> Result<Option<LayoutForMarkdownOutput>> {
+) -> Result<LayoutRunOutput> {
     #[cfg(feature = "tokio-runtime")]
     {
         let owned_content = content.to_vec();
@@ -330,7 +342,7 @@ pub(super) fn run_layout_for_pdf_pages(
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
     gated_handling: GatedPageHandling,
-) -> Result<Option<LayoutForMarkdownOutput>> {
+) -> Result<LayoutRunOutput> {
     let doc = pdf_oxide::PdfDocument::from_bytes(content.to_vec()).map_err(|e| XbergError::Parsing {
         message: format!("layout runner: failed to open PDF: {e}"),
         source: None,
@@ -342,7 +354,10 @@ pub(super) fn run_layout_for_pdf_pages(
     })?;
 
     if page_count == 0 {
-        return Ok(Some((Vec::new(), Vec::new(), Vec::new(), Vec::new())));
+        return Ok(LayoutRunOutput {
+            data: Some((Vec::new(), Vec::new(), Vec::new(), Vec::new())),
+            gate_decisions: None,
+        });
     }
 
     let gate_decisions = match layout_config.strategy {
@@ -360,7 +375,10 @@ pub(super) fn run_layout_for_pdf_pages(
                 // No page can benefit: behave exactly as if layout were off,
                 // with no engine init and no renders. The OCR path then
                 // produces its own rasters once, as it does without layout. ~keep
-                return Ok(None);
+                return Ok(LayoutRunOutput {
+                    data: None,
+                    gate_decisions: Some(decisions),
+                });
             }
             Some(decisions)
         }
@@ -415,7 +433,10 @@ pub(super) fn run_layout_for_pdf_pages(
 
     crate::layout::return_engine(engine);
 
-    Ok(Some((all_images, all_layout_results, all_hints, all_detections)))
+    Ok(LayoutRunOutput {
+        data: Some((all_images, all_layout_results, all_hints, all_detections)),
+        gate_decisions,
+    })
 }
 
 /// Convenience wrapper that reads `use_layout_for_markdown` and other gate
@@ -432,6 +453,7 @@ type LayoutForMarkdownOptional = (
     Option<Vec<PageLayoutResult>>,
     Option<Vec<Vec<LayoutHint>>>,
     Option<Vec<crate::layout::DetectionResult>>,
+    Option<Vec<PageGateDecision>>,
 );
 
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
@@ -440,13 +462,13 @@ pub(super) async fn maybe_run_layout_for_markdown(
     config: &ExtractionConfig,
 ) -> LayoutForMarkdownOptional {
     if !config.use_layout_for_markdown {
-        return (None, None, None, None);
+        return (None, None, None, None, None);
     }
     let Some(layout_config) = config.resolved_layout_config() else {
-        return (None, None, None, None);
+        return (None, None, None, None, None);
     };
     if config.force_ocr {
-        return (None, None, None, None);
+        return (None, None, None, None, None);
     }
     let thread_budget = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
     match run_layout_for_pdf_pages_async(
@@ -457,25 +479,37 @@ pub(super) async fn maybe_run_layout_for_markdown(
     )
     .await
     {
-        Ok(Some((images, results, hints, detections))) => {
+        Ok(LayoutRunOutput {
+            data: Some((images, results, hints, detections)),
+            gate_decisions,
+        }) => {
             let total_hints: usize = hints.iter().map(|h| h.len()).sum();
             tracing::info!(
                 pages = images.len(),
                 total_hints,
                 "layout-for-markdown: detection succeeded"
             );
-            (Some(images), Some(results), Some(hints), Some(detections))
+            (
+                Some(images),
+                Some(results),
+                Some(hints),
+                Some(detections),
+                gate_decisions,
+            )
         }
-        Ok(None) => {
+        Ok(LayoutRunOutput {
+            data: None,
+            gate_decisions,
+        }) => {
             tracing::info!("layout-for-markdown: auto gate skipped every page, continuing without layout hints");
-            (None, None, None, None)
+            (None, None, None, None, gate_decisions)
         }
         Err(e) => {
             tracing::warn!(
                 error = %e,
                 "layout-for-markdown: detection failed, continuing without layout hints"
             );
-            (None, None, None, None)
+            (None, None, None, None, None)
         }
     }
 }
@@ -486,13 +520,13 @@ pub(super) async fn maybe_run_layout_for_markdown(
     feature = "layout-detection",
     any(feature = "ocr", feature = "ocr-pipeline")
 ))]
-/// `Ok(None)` means the `Auto` gate skipped every page: the caller proceeds
+/// `data: None` means the `Auto` gate skipped every page: the caller proceeds
 /// exactly as if layout were off, rendering its own OCR rasters once.
 pub(super) async fn run_layout_for_ocr(
     content: &[u8],
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
-) -> Result<Option<LayoutForMarkdownOutput>> {
+) -> Result<LayoutRunOutput> {
     // OCR consumes the layout pass's rasters as its input images, so gated
     // pages still render; only model inference is skipped for them.
     run_layout_for_pdf_pages_async(

--- a/crates/xberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/xberg/src/extractors/pdf/layout_runner.rs
@@ -116,7 +116,7 @@ async fn run_layout_for_pdf_pages_async(
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
     gated_handling: GatedPageHandling,
-) -> Result<LayoutForMarkdownOutput> {
+) -> Result<Option<LayoutForMarkdownOutput>> {
     #[cfg(feature = "tokio-runtime")]
     {
         let owned_content = content.to_vec();
@@ -330,7 +330,7 @@ pub(super) fn run_layout_for_pdf_pages(
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
     gated_handling: GatedPageHandling,
-) -> Result<LayoutForMarkdownOutput> {
+) -> Result<Option<LayoutForMarkdownOutput>> {
     let doc = pdf_oxide::PdfDocument::from_bytes(content.to_vec()).map_err(|e| XbergError::Parsing {
         message: format!("layout runner: failed to open PDF: {e}"),
         source: None,
@@ -342,7 +342,7 @@ pub(super) fn run_layout_for_pdf_pages(
     })?;
 
     if page_count == 0 {
-        return Ok((Vec::new(), Vec::new(), Vec::new(), Vec::new()));
+        return Ok(Some((Vec::new(), Vec::new(), Vec::new(), Vec::new())));
     }
 
     let gate_decisions = match layout_config.strategy {
@@ -356,6 +356,12 @@ pub(super) fn run_layout_for_pdf_pages(
                 skipped = page_count - selected,
                 "layout gate: auto strategy page selection"
             );
+            if selected == 0 {
+                // No page can benefit: behave exactly as if layout were off,
+                // with no engine init and no renders. The OCR path then
+                // produces its own rasters once, as it does without layout. ~keep
+                return Ok(None);
+            }
             Some(decisions)
         }
     };
@@ -409,7 +415,7 @@ pub(super) fn run_layout_for_pdf_pages(
 
     crate::layout::return_engine(engine);
 
-    Ok((all_images, all_layout_results, all_hints, all_detections))
+    Ok(Some((all_images, all_layout_results, all_hints, all_detections)))
 }
 
 /// Convenience wrapper that reads `use_layout_for_markdown` and other gate
@@ -451,7 +457,7 @@ pub(super) async fn maybe_run_layout_for_markdown(
     )
     .await
     {
-        Ok((images, results, hints, detections)) => {
+        Ok(Some((images, results, hints, detections))) => {
             let total_hints: usize = hints.iter().map(|h| h.len()).sum();
             tracing::info!(
                 pages = images.len(),
@@ -459,6 +465,10 @@ pub(super) async fn maybe_run_layout_for_markdown(
                 "layout-for-markdown: detection succeeded"
             );
             (Some(images), Some(results), Some(hints), Some(detections))
+        }
+        Ok(None) => {
+            tracing::info!("layout-for-markdown: auto gate skipped every page, continuing without layout hints");
+            (None, None, None, None)
         }
         Err(e) => {
             tracing::warn!(
@@ -476,11 +486,13 @@ pub(super) async fn maybe_run_layout_for_markdown(
     feature = "layout-detection",
     any(feature = "ocr", feature = "ocr-pipeline")
 ))]
+/// `Ok(None)` means the `Auto` gate skipped every page: the caller proceeds
+/// exactly as if layout were off, rendering its own OCR rasters once.
 pub(super) async fn run_layout_for_ocr(
     content: &[u8],
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
-) -> Result<LayoutForMarkdownOutput> {
+) -> Result<Option<LayoutForMarkdownOutput>> {
     // OCR consumes the layout pass's rasters as its input images, so gated
     // pages still render; only model inference is skipped for them.
     run_layout_for_pdf_pages_async(

--- a/crates/xberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/xberg/src/extractors/pdf/layout_runner.rs
@@ -49,6 +49,10 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum GatedPageHandling {
     /// Skip both the raster render and model inference for gated pages.
+    ///
+    /// The page-aligned output still carries a small white placeholder image
+    /// for gated pages (see [`render_failure_placeholder`]); downstream
+    /// markdown consumers never read it because gated pages have no hints.
     SkipRender,
     /// Render the page raster but skip model inference for gated pages.
     ///
@@ -58,29 +62,17 @@ pub(super) enum GatedPageHandling {
     RenderWithoutInference,
 }
 
-/// Render every page of `content` to RGB (in chunks) and run layout detection.
+/// Page-aligned layout pass data: `(images, results, hints_per_page,
+/// detections_per_page)`, one entry per page at every index.
 ///
-/// Returns `(images, results, hints_per_page, detections_per_page)` where:
-/// - `images[i]` is the rendered RGB image for page `i` (or a small white placeholder
-///   if the page failed to render).
+/// - `images[i]` is the rendered RGB image for page `i`, or a small white
+///   placeholder when the page failed to render or the `Auto` gate skipped it
+///   on the markdown path.
 /// - `results[i]` holds per-region detection metadata in PDF coordinate space.
-/// - `hints_per_page[i]` holds the layout hints derived from detections on
-///   page `i` (empty for pages that failed to render or produced no detections).
-/// - `detections_per_page[i]` preserves the pixel-space detections for OCR
-///   layout assembly (empty for pages that failed to render).
-///
-/// # Memory behaviour
-///
-/// Pages are rendered and detected in chunks of [`LAYOUT_BATCH_CHUNK_SIZE`]
-/// so the peak ONNX batch tensor size is bounded.  The returned `images` vec
-/// accumulates all page images for downstream table recognition.
-///
-/// # Errors
-///
-/// Returns an error if the PDF cannot be opened, the layout engine cannot be
-/// initialised, or detection fails on any chunk.  Individual page render
-/// failures are logged and produce empty layout for that page without aborting
-/// the whole document.
+/// - `hints_per_page[i]` holds the layout hints for page `i` (empty for
+///   render-failed, gate-skipped, and no-detection pages).
+/// - `detections_per_page[i]` preserves pixel-space detections for OCR layout
+///   assembly (empty for render-failed and gate-skipped pages).
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 type LayoutForMarkdownOutput = (
     Vec<image::RgbImage>,
@@ -172,6 +164,29 @@ fn displayed_page_dimensions(width: f32, height: f32, rotation_degrees: u32) -> 
     }
 }
 
+/// Run the `Auto` gate over every page, or `None` under strategy `Always`.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+fn auto_gate_decisions(
+    doc: &pdf_oxide::PdfDocument,
+    layout_config: &LayoutDetectionConfig,
+    page_count: usize,
+) -> Option<Vec<PageGateDecision>> {
+    match layout_config.strategy {
+        LayoutStrategy::Always => None,
+        LayoutStrategy::Auto => {
+            let decisions = crate::pdf::layout_gate::decide_pages(doc, page_count);
+            let selected = decisions.iter().filter(|decision| decision.run_layout).count();
+            tracing::info!(
+                pages = page_count,
+                selected,
+                skipped = page_count - selected,
+                "layout gate: auto strategy page selection"
+            );
+            Some(decisions)
+        }
+    }
+}
+
 /// Whether the `Auto` gate selected `page_index` for the model.
 ///
 /// `None` gate decisions (strategy `Always`) select every page; a page index
@@ -251,6 +266,14 @@ fn render_layout_page(
         .ok()
 }
 
+/// Whether a page joins the ONNX batch: it must both be gate-selected and
+/// have a real raster. Render-failed and gate-skipped pages stay out and end
+/// up with empty detections.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+fn enters_inference_batch(page: &RenderedLayoutPage) -> bool {
+    page.run_inference && page.image.is_some()
+}
+
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 fn detect_layout_chunk(
     engine: &mut crate::layout::LayoutEngine,
@@ -259,7 +282,7 @@ fn detect_layout_chunk(
     let rendered_positions: Vec<usize> = pages
         .iter()
         .enumerate()
-        .filter_map(|(position, page)| (page.run_inference && page.image.is_some()).then_some(position))
+        .filter_map(|(position, page)| enters_inference_batch(page).then_some(position))
         .collect();
     if rendered_positions.is_empty() {
         return Ok((0..pages.len()).map(|_| None).collect());
@@ -360,29 +383,18 @@ pub(super) fn run_layout_for_pdf_pages(
         });
     }
 
-    let gate_decisions = match layout_config.strategy {
-        LayoutStrategy::Always => None,
-        LayoutStrategy::Auto => {
-            let decisions = crate::pdf::layout_gate::decide_pages(&doc, page_count);
-            let selected = decisions.iter().filter(|decision| decision.run_layout).count();
-            tracing::info!(
-                pages = page_count,
-                selected,
-                skipped = page_count - selected,
-                "layout gate: auto strategy page selection"
-            );
-            if selected == 0 {
-                // No page can benefit: behave exactly as if layout were off,
-                // with no engine init and no renders. The OCR path then
-                // produces its own rasters once, as it does without layout. ~keep
-                return Ok(LayoutRunOutput {
-                    data: None,
-                    gate_decisions: Some(decisions),
-                });
-            }
-            Some(decisions)
-        }
-    };
+    let gate_decisions = auto_gate_decisions(&doc, layout_config, page_count);
+    if let Some(decisions) = &gate_decisions
+        && decisions.iter().all(|decision| !decision.run_layout)
+    {
+        // No page can benefit: behave exactly as if layout were off, with no
+        // engine init and no renders. The OCR path then produces its own
+        // rasters once, as it does without layout. ~keep
+        return Ok(LayoutRunOutput {
+            data: None,
+            gate_decisions,
+        });
+    }
 
     let mut engine = crate::layout::take_or_create_engine(layout_config, thread_budget)
         .map_err(|e| XbergError::Other(format!("layout runner: engine init failed: {e}")))?;
@@ -443,9 +455,11 @@ pub(super) fn run_layout_for_pdf_pages(
 /// conditions from `config` and, when they are all satisfied, runs
 /// [`run_layout_for_pdf_pages`].
 ///
-/// Returns four `None` values when the feature is not requested, or on soft
-/// failure (logged as a warning so the markdown path can continue without
-/// layout hints). Rendering and inference run off the async executor when a
+/// The first four values are `None` when the feature is not requested, when
+/// the `Auto` gate skipped every page, or on soft failure (logged so the
+/// markdown path continues without layout hints). The fifth value carries the
+/// `Auto` gate's per-page decisions whenever the gate ran, including the
+/// all-gated case. Rendering and inference run off the async executor when a
 /// Tokio runtime is enabled.
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 type LayoutForMarkdownOptional = (
@@ -515,13 +529,14 @@ pub(super) async fn maybe_run_layout_for_markdown(
 }
 
 /// Run the layout pass used by OCR without blocking a Tokio worker thread.
+///
+/// `data: None` means the `Auto` gate skipped every page: the caller proceeds
+/// exactly as if layout were off, rendering its own OCR rasters once.
 #[cfg(all(
     feature = "pdf",
     feature = "layout-detection",
     any(feature = "ocr", feature = "ocr-pipeline")
 ))]
-/// `data: None` means the `Auto` gate skipped every page: the caller proceeds
-/// exactly as if layout were off, rendering its own OCR rasters once.
 pub(super) async fn run_layout_for_ocr(
     content: &[u8],
     layout_config: &LayoutDetectionConfig,
@@ -701,6 +716,115 @@ mod tests {
                 crate::pdf::layout_gate::GateReason::PlainText
             },
         }
+    }
+
+    /// A one-page single-column prose PDF with a real text content stream:
+    /// the gate must classify it as plain text and skip the model.
+    fn prose_pdf(lines: usize) -> Vec<u8> {
+        use lopdf::{Document, Object, Stream, dictionary};
+
+        let mut document = Document::with_version("1.5");
+        let pages_id = document.new_object_id();
+        let font_id = document.add_object(dictionary! {
+            "Type" => "Font",
+            "Subtype" => "Type1",
+            "BaseFont" => "Helvetica",
+        });
+        let mut content = String::from("BT /F1 10 Tf 72 720 Td 14 TL\n");
+        for line in 0..lines {
+            content.push_str(&format!(
+                "(Line {line} of steady single column prose with enough characters to pass the floor.) Tj T*\n"
+            ));
+        }
+        content.push_str("ET");
+        let content_id = document.add_object(Stream::new(dictionary! {}, content.into_bytes()));
+        let page_id = document.new_object_id();
+        document.objects.insert(
+            page_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Page",
+                "Parent" => pages_id,
+                "MediaBox" => vec![0.into(), 0.into(), 612.into(), 792.into()],
+                "Resources" => dictionary! { "Font" => dictionary! { "F1" => font_id } },
+                "Contents" => content_id,
+            }),
+        );
+        document.objects.insert(
+            pages_id,
+            Object::Dictionary(dictionary! {
+                "Type" => "Pages",
+                "Kids" => vec![page_id.into()],
+                "Count" => 1,
+            }),
+        );
+        let catalog_id = document.add_object(dictionary! {
+            "Type" => "Catalog",
+            "Pages" => pages_id,
+        });
+        document.trailer.set("Root", catalog_id);
+
+        let mut bytes = Vec::new();
+        document.save_to(&mut bytes).expect("fixture PDF must serialize");
+        bytes
+    }
+
+    /// End-to-end `Auto` on real PDF bytes: the gate skips plain prose, and
+    /// the runner returns no layout data before any engine init (this test
+    /// must never need ONNX models). The gate is asserted first so a gate
+    /// regression fails here rather than in an engine-init attempt.
+    #[test]
+    fn auto_strategy_gates_prose_page_and_skips_the_layout_pass_entirely() {
+        use crate::core::config::layout::LayoutStrategy;
+
+        let bytes = prose_pdf(20);
+        let doc = pdf_oxide::PdfDocument::from_bytes(bytes.clone()).expect("fixture PDF must open");
+        let decisions = crate::pdf::layout_gate::decide_pages(&doc, 1);
+        assert_eq!(decisions.len(), 1);
+        assert!(
+            !decisions[0].run_layout,
+            "prose fixture must be gated, got {:?}",
+            decisions[0].reason
+        );
+        assert_eq!(decisions[0].reason, crate::pdf::layout_gate::GateReason::PlainText);
+
+        let config = crate::core::config::layout::LayoutDetectionConfig {
+            strategy: LayoutStrategy::Auto,
+            ..Default::default()
+        };
+        let output = super::run_layout_for_pdf_pages(&bytes, &config, 1, GatedPageHandling::SkipRender)
+            .expect("all-gated run must succeed without a layout engine");
+        assert!(output.data.is_none(), "all-gated prose must skip the layout pass");
+        let recorded = output.gate_decisions.expect("auto strategy must record decisions");
+        assert_eq!(recorded, decisions);
+    }
+
+    #[test]
+    fn only_gate_selected_pages_with_real_rasters_enter_the_inference_batch() {
+        let selected_with_image = rendered_page(0, 10, 100.0);
+        let mut gated_with_image = rendered_page(1, 10, 100.0);
+        gated_with_image.run_inference = false;
+        let mut selected_render_failed = rendered_page(2, 10, 100.0);
+        selected_render_failed.image = None;
+
+        assert!(super::enters_inference_batch(&selected_with_image));
+        assert!(!super::enters_inference_batch(&gated_with_image));
+        assert!(!super::enters_inference_batch(&selected_render_failed));
+    }
+
+    #[test]
+    fn gated_page_assembles_placeholder_image_with_empty_detection_and_hints() {
+        let mut gated = rendered_page(0, 10, 100.0);
+        gated.image = None;
+        gated.run_inference = false;
+
+        let assembled = assemble_layout_chunk(vec![gated], vec![None]).expect("gated page must stay aligned");
+
+        assert_eq!(
+            assembled[0].image.dimensions(),
+            (FAILED_RENDER_PLACEHOLDER_SIDE, FAILED_RENDER_PLACEHOLDER_SIDE)
+        );
+        assert!(assembled[0].detection.detections.is_empty());
+        assert!(assembled[0].hints.is_empty());
     }
 
     #[test]

--- a/crates/xberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/xberg/src/extractors/pdf/layout_runner.rs
@@ -30,10 +30,33 @@ const FAILED_RENDER_PLACEHOLDER_SIDE: u32 = 64;
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 use crate::{
     Result, XbergError,
-    core::config::{ExtractionConfig, layout::LayoutDetectionConfig},
+    core::config::{
+        ExtractionConfig,
+        layout::{LayoutDetectionConfig, LayoutStrategy},
+    },
     extractors::pdf::layout_hints::pixel_detection_to_layout_hints_pdf_space,
+    pdf::layout_gate::PageGateDecision,
     pdf::structure::types::{LayoutHint, PageLayoutResult},
 };
+
+/// How [`run_layout_for_pdf_pages`] treats pages the `Auto` gate skips.
+///
+/// The markdown path only needs rasters for pages the model inspects, so it
+/// skips rendering entirely. The OCR path reuses the layout pass's rasters as
+/// OCR input images, so gated pages must still render; only inference is
+/// skipped there.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GatedPageHandling {
+    /// Skip both the raster render and model inference for gated pages.
+    SkipRender,
+    /// Render the page raster but skip model inference for gated pages.
+    ///
+    /// Only the OCR entry point constructs this, so builds without an OCR
+    /// feature see the variant as unused.
+    #[cfg_attr(not(any(feature = "ocr", feature = "ocr-pipeline")), allow(dead_code))]
+    RenderWithoutInference,
+}
 
 /// Render every page of `content` to RGB (in chunks) and run layout detection.
 ///
@@ -73,6 +96,10 @@ struct RenderedLayoutPage {
     page_height_pts: f32,
     rotation: u32,
     image: Option<image::RgbImage>,
+    /// `false` when the `Auto` gate skipped this page: it stays out of the
+    /// ONNX batch and keeps an empty detection, exactly like a page where the
+    /// model ran and found nothing.
+    run_inference: bool,
 }
 
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
@@ -88,18 +115,21 @@ async fn run_layout_for_pdf_pages_async(
     content: &[u8],
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
+    gated_handling: GatedPageHandling,
 ) -> Result<LayoutForMarkdownOutput> {
     #[cfg(feature = "tokio-runtime")]
     {
         let owned_content = content.to_vec();
         let owned_config = layout_config.clone();
-        tokio::task::spawn_blocking(move || run_layout_for_pdf_pages(&owned_content, &owned_config, thread_budget))
-            .await
-            .map_err(|error| XbergError::Other(format!("layout runner task failed: {error}")))?
+        tokio::task::spawn_blocking(move || {
+            run_layout_for_pdf_pages(&owned_content, &owned_config, thread_budget, gated_handling)
+        })
+        .await
+        .map_err(|error| XbergError::Other(format!("layout runner task failed: {error}")))?
     }
 
     #[cfg(not(feature = "tokio-runtime"))]
-    run_layout_for_pdf_pages(content, layout_config, thread_budget)
+    run_layout_for_pdf_pages(content, layout_config, thread_budget, gated_handling)
 }
 
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
@@ -130,12 +160,24 @@ fn displayed_page_dimensions(width: f32, height: f32, rotation_degrees: u32) -> 
     }
 }
 
+/// Whether the `Auto` gate selected `page_index` for the model.
+///
+/// `None` gate decisions (strategy `Always`) select every page; a page index
+/// beyond the decision vector also runs, so a gate bug can only ever cost
+/// speed, never coverage.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+fn gate_selects_page(gate_decisions: Option<&[PageGateDecision]>, page_index: usize) -> bool {
+    gate_decisions.is_none_or(|decisions| decisions.get(page_index).is_none_or(|decision| decision.run_layout))
+}
+
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 fn render_layout_chunk(
     doc: &pdf_oxide::PdfDocument,
     page_rotations: &[u32],
     chunk_start: usize,
     chunk_end: usize,
+    gate_decisions: Option<&[PageGateDecision]>,
+    gated_handling: GatedPageHandling,
 ) -> Vec<RenderedLayoutPage> {
     (chunk_start..chunk_end)
         .map(|page_index| {
@@ -145,7 +187,13 @@ fn render_layout_chunk(
                 .unwrap_or((612.0, 792.0));
             let rotation = page_rotations.get(page_index).copied().unwrap_or(0);
             let (page_width_pts, page_height_pts) = displayed_page_dimensions(media_width, media_height, rotation);
-            let image = render_layout_page(doc, page_index, page_width_pts, page_height_pts);
+            let run_inference = gate_selects_page(gate_decisions, page_index);
+            let skip_render = !run_inference && gated_handling == GatedPageHandling::SkipRender;
+            let image = if skip_render {
+                None
+            } else {
+                render_layout_page(doc, page_index, page_width_pts, page_height_pts)
+            };
 
             RenderedLayoutPage {
                 page_index,
@@ -153,6 +201,7 @@ fn render_layout_chunk(
                 page_height_pts,
                 rotation,
                 image,
+                run_inference,
             }
         })
         .collect()
@@ -198,7 +247,7 @@ fn detect_layout_chunk(
     let rendered_positions: Vec<usize> = pages
         .iter()
         .enumerate()
-        .filter_map(|(position, page)| page.image.as_ref().map(|_| position))
+        .filter_map(|(position, page)| (page.run_inference && page.image.is_some()).then_some(position))
         .collect();
     if rendered_positions.is_empty() {
         return Ok((0..pages.len()).map(|_| None).collect());
@@ -280,6 +329,7 @@ pub(super) fn run_layout_for_pdf_pages(
     content: &[u8],
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
+    gated_handling: GatedPageHandling,
 ) -> Result<LayoutForMarkdownOutput> {
     let doc = pdf_oxide::PdfDocument::from_bytes(content.to_vec()).map_err(|e| XbergError::Parsing {
         message: format!("layout runner: failed to open PDF: {e}"),
@@ -295,6 +345,21 @@ pub(super) fn run_layout_for_pdf_pages(
         return Ok((Vec::new(), Vec::new(), Vec::new(), Vec::new()));
     }
 
+    let gate_decisions = match layout_config.strategy {
+        LayoutStrategy::Always => None,
+        LayoutStrategy::Auto => {
+            let decisions = crate::pdf::layout_gate::decide_pages(&doc, page_count);
+            let selected = decisions.iter().filter(|decision| decision.run_layout).count();
+            tracing::info!(
+                pages = page_count,
+                selected,
+                skipped = page_count - selected,
+                "layout gate: auto strategy page selection"
+            );
+            Some(decisions)
+        }
+    };
+
     let mut engine = crate::layout::take_or_create_engine(layout_config, thread_budget)
         .map_err(|e| XbergError::Other(format!("layout runner: engine init failed: {e}")))?;
 
@@ -309,7 +374,14 @@ pub(super) fn run_layout_for_pdf_pages(
 
     for (chunk_idx, chunk_start) in (0..page_count).step_by(LAYOUT_BATCH_CHUNK_SIZE).enumerate() {
         let chunk_end = (chunk_start + LAYOUT_BATCH_CHUNK_SIZE).min(page_count);
-        let pages = render_layout_chunk(&doc, &page_rotations, chunk_start, chunk_end);
+        let pages = render_layout_chunk(
+            &doc,
+            &page_rotations,
+            chunk_start,
+            chunk_end,
+            gate_decisions.as_deref(),
+            gated_handling,
+        );
         let rendered = pages.iter().filter(|page| page.image.is_some()).count();
         tracing::debug!(
             chunk_idx,
@@ -371,7 +443,14 @@ pub(super) async fn maybe_run_layout_for_markdown(
         return (None, None, None, None);
     }
     let thread_budget = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
-    match run_layout_for_pdf_pages_async(content, layout_config.as_ref(), thread_budget).await {
+    match run_layout_for_pdf_pages_async(
+        content,
+        layout_config.as_ref(),
+        thread_budget,
+        GatedPageHandling::SkipRender,
+    )
+    .await
+    {
         Ok((images, results, hints, detections)) => {
             let total_hints: usize = hints.iter().map(|h| h.len()).sum();
             tracing::info!(
@@ -402,15 +481,25 @@ pub(super) async fn run_layout_for_ocr(
     layout_config: &LayoutDetectionConfig,
     thread_budget: usize,
 ) -> Result<LayoutForMarkdownOutput> {
-    run_layout_for_pdf_pages_async(content, layout_config, thread_budget).await
+    // OCR consumes the layout pass's rasters as its input images, so gated
+    // pages still render; only model inference is skipped for them.
+    run_layout_for_pdf_pages_async(
+        content,
+        layout_config,
+        thread_budget,
+        GatedPageHandling::RenderWithoutInference,
+    )
+    .await
 }
 
 #[cfg(all(test, feature = "pdf", feature = "layout-detection"))]
 mod tests {
     use super::{
-        FAILED_RENDER_PLACEHOLDER_SIDE, RenderedLayoutPage, assemble_layout_chunk, displayed_page_dimensions,
-        render_failure_placeholder, validate_batch_cardinality,
+        FAILED_RENDER_PLACEHOLDER_SIDE, GatedPageHandling, RenderedLayoutPage, assemble_layout_chunk,
+        displayed_page_dimensions, gate_selects_page, render_failure_placeholder, render_layout_chunk,
+        validate_batch_cardinality,
     };
+    use crate::pdf::layout_gate::PageGateDecision;
 
     fn rendered_page(page_index: usize, width: u32, page_width_pts: f32) -> RenderedLayoutPage {
         RenderedLayoutPage {
@@ -419,6 +508,7 @@ mod tests {
             page_height_pts: 200.0,
             rotation: 0,
             image: Some(image::RgbImage::new(width, 20)),
+            run_inference: true,
         }
     }
 
@@ -554,6 +644,59 @@ mod tests {
             .expect("missing detection slot must fail");
 
         assert!(error.to_string().contains("0 results for 1 rendered pages"));
+    }
+
+    fn gate_decision(run_layout: bool) -> PageGateDecision {
+        PageGateDecision {
+            run_layout,
+            reason: if run_layout {
+                crate::pdf::layout_gate::GateReason::MultiColumn
+            } else {
+                crate::pdf::layout_gate::GateReason::PlainText
+            },
+        }
+    }
+
+    #[test]
+    fn absent_gate_decisions_select_every_page() {
+        assert!(gate_selects_page(None, 0));
+        assert!(gate_selects_page(None, 7));
+    }
+
+    #[test]
+    fn gate_decisions_beyond_the_vector_fail_open_to_running_the_model() {
+        let decisions = vec![gate_decision(false)];
+        assert!(gate_selects_page(Some(&decisions), 1));
+    }
+
+    #[test]
+    fn gated_page_is_excluded_and_selected_page_is_kept() {
+        let decisions = vec![gate_decision(false), gate_decision(true)];
+        assert!(!gate_selects_page(Some(&decisions), 0));
+        assert!(gate_selects_page(Some(&decisions), 1));
+    }
+
+    /// SkipRender must not rasterise gated pages; RenderWithoutInference must.
+    #[test]
+    fn gated_handling_controls_whether_gated_pages_render() {
+        let bytes = rotated_pdf(false);
+        let doc = pdf_oxide::PdfDocument::from_bytes(bytes).expect("fixture PDF must open");
+        let decisions = vec![gate_decision(false)];
+
+        let skipped = render_layout_chunk(&doc, &[0], 0, 1, Some(&decisions), GatedPageHandling::SkipRender);
+        assert!(skipped[0].image.is_none(), "gated page must not render");
+        assert!(!skipped[0].run_inference);
+
+        let rendered = render_layout_chunk(
+            &doc,
+            &[0],
+            0,
+            1,
+            Some(&decisions),
+            GatedPageHandling::RenderWithoutInference,
+        );
+        assert!(rendered[0].image.is_some(), "OCR-path gated page must still render");
+        assert!(!rendered[0].run_inference, "gated page must stay out of the ONNX batch");
     }
 
     #[test]

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -253,6 +253,33 @@ fn prepare_ocr_layout_inputs(
     (images, detections)
 }
 
+/// Auto layout gate audit trail: 1-indexed skipped pages and per-page
+/// decision reasons, both `None` unless the `Auto` gate ran.
+///
+/// Referenced by the OCR helper's return tuple, so builds without an OCR
+/// feature see the alias as unused.
+#[cfg_attr(not(any(feature = "ocr", feature = "ocr-pipeline")), allow(dead_code))]
+type OcrLayoutGateDecisions = (Option<Vec<u32>>, Option<Vec<String>>);
+
+/// Convert gate decisions into the metadata representation.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+fn layout_gate_metadata(decisions: Option<&[crate::pdf::layout_gate::PageGateDecision]>) -> OcrLayoutGateDecisions {
+    let Some(decisions) = decisions else {
+        return (None, None);
+    };
+    let gated = decisions
+        .iter()
+        .enumerate()
+        .filter(|(_, decision)| !decision.run_layout)
+        .map(|(page_index, _)| page_index as u32 + 1)
+        .collect();
+    let reasons = decisions
+        .iter()
+        .map(|decision| decision.reason.wire_name().to_string())
+        .collect();
+    (Some(gated), Some(reasons))
+}
+
 /// Run OCR with optional layout detection on PDF bytes.
 ///
 /// Reuses detections from native extraction when available. Otherwise, when
@@ -274,18 +301,34 @@ async fn run_ocr_with_layout(
     Vec<String>,
     Option<Vec<crate::types::ExtractedImage>>,
     Vec<crate::types::Formula>,
+    OcrLayoutGateDecisions,
 )> {
     let default_ocr_config = crate::core::config::OcrConfig::default();
     let ocr_config = config.ocr.as_ref().unwrap_or(&default_ocr_config);
+
+    #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+    let mut ocr_layout_gate_decisions: OcrLayoutGateDecisions = (None, None);
+    #[cfg(not(all(feature = "pdf", feature = "layout-detection")))]
+    let ocr_layout_gate_decisions: OcrLayoutGateDecisions = (None, None);
 
     #[cfg(all(feature = "pdf", feature = "layout-detection"))]
     let owned_layout = if precomputed_layout_detections.is_none() || precomputed_layout_images.is_none() {
         if let Some(layout_config) = config.resolved_layout_config() {
             let thread_budget = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
             match layout_runner::run_layout_for_ocr(content, layout_config.as_ref(), thread_budget).await {
-                Ok(Some(layout)) => Some(layout),
-                Ok(None) => {
+                Ok(layout_runner::LayoutRunOutput {
+                    data: Some(layout),
+                    gate_decisions,
+                }) => {
+                    ocr_layout_gate_decisions = layout_gate_metadata(gate_decisions.as_deref());
+                    Some(layout)
+                }
+                Ok(layout_runner::LayoutRunOutput {
+                    data: None,
+                    gate_decisions,
+                }) => {
                     tracing::info!("OCR layout: auto gate skipped every page, continuing without layout assembly");
+                    ocr_layout_gate_decisions = layout_gate_metadata(gate_decisions.as_deref());
                     None
                 }
                 Err(error) => {
@@ -345,6 +388,7 @@ async fn run_ocr_with_layout(
             ocr_pts,
             pipeline_rasters,
             pipeline_formulas,
+            ocr_layout_gate_decisions,
         ));
     }
 
@@ -370,6 +414,7 @@ async fn run_ocr_with_layout(
         ocr_pts,
         ocr_rasters,
         formulas,
+        ocr_layout_gate_decisions,
     ))
 }
 
@@ -475,6 +520,7 @@ impl PdfExtractor {
             markdown_layout_results,
             markdown_layout_hints,
             mut markdown_layout_detections,
+            markdown_layout_gate_decisions,
         ) = layout_runner::maybe_run_layout_for_markdown(content, config).await;
 
         #[cfg(all(feature = "pdf", feature = "layout-detection"))]
@@ -590,12 +636,15 @@ impl PdfExtractor {
         let mut ocr_formulas: Vec<crate::types::Formula> = Vec::new();
         #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
         let mut ocr_fallback_warnings: Vec<crate::types::ProcessingWarning> = Vec::new();
+        #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+        #[allow(unused_assignments)]
+        let mut ocr_layout_gate_audit: OcrLayoutGateDecisions = (None, None);
 
         #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
         let (text, extraction_method) = if config.effective_disable_ocr() {
             (native_text, ExtractionMethod::Native)
         } else if config.force_ocr {
-            let (ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage, ocr_pts, ocr_rstrs, formulas) =
+            let (ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage, ocr_pts, ocr_rstrs, formulas, gate_audit) =
                 run_ocr_with_layout(
                     content,
                     config,
@@ -606,6 +655,7 @@ impl PdfExtractor {
                     markdown_layout_detections.take(),
                 )
                 .await?;
+            ocr_layout_gate_audit = gate_audit;
             ocr_tables = ocr_tbls;
             ocr_elements = ocr_elems;
             ocr_internal_doc = ocr_doc;
@@ -741,7 +791,18 @@ impl PdfExtractor {
                         )
                         .await
                         {
-                            Ok((ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage, ocr_pts, ocr_rstrs, formulas)) => {
+                            Ok((
+                                ocr_text,
+                                ocr_tbls,
+                                ocr_elems,
+                                ocr_doc,
+                                llm_usage,
+                                ocr_pts,
+                                ocr_rstrs,
+                                formulas,
+                                gate_audit,
+                            )) => {
+                                ocr_layout_gate_audit = gate_audit;
                                 ocr_tables = ocr_tbls;
                                 ocr_elements = ocr_elems;
                                 ocr_internal_doc = ocr_doc;
@@ -959,6 +1020,21 @@ impl PdfExtractor {
 
         #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
         doc.processing_warnings.append(&mut ocr_fallback_warnings);
+
+        // Record the auto layout gate's audit trail from whichever pass ran it. ~keep
+        #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+        {
+            #[allow(unused_mut)]
+            let (mut gated_pages, mut gate_reasons) = layout_gate_metadata(markdown_layout_gate_decisions.as_deref());
+            #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
+            if gated_pages.is_none() {
+                let (ocr_gated_pages, ocr_gate_reasons) = ocr_layout_gate_audit;
+                gated_pages = ocr_gated_pages;
+                gate_reasons = ocr_gate_reasons;
+            }
+            pdf_metadata.pdf_specific.layout_gated_pages = gated_pages;
+            pdf_metadata.pdf_specific.layout_gate_reasons = gate_reasons;
+        }
 
         doc.metadata = Metadata {
             output_format: pre_formatted_output,

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -256,10 +256,23 @@ fn prepare_ocr_layout_inputs(
 /// Auto layout gate audit trail: 1-indexed skipped pages and per-page
 /// decision reasons, both `None` unless the `Auto` gate ran.
 ///
-/// Referenced by the OCR helper's return tuple, so builds without an OCR
-/// feature see the alias as unused.
+/// Unused only when both OCR features and the pdf + layout-detection pair
+/// are off; the allow is scoped wider because cfg algebra for "either user
+/// present" is not worth the noise.
 #[cfg_attr(not(any(feature = "ocr", feature = "ocr-pipeline")), allow(dead_code))]
 type OcrLayoutGateDecisions = (Option<Vec<u32>>, Option<Vec<String>>);
+
+/// Whether the markdown layout pass's rasters may be reused as OCR input.
+///
+/// Under `LayoutStrategy::Auto` with `SkipRender`, gate-skipped pages carry
+/// 64x64 white placeholders. Reusing those as OCR rasters would OCR blank
+/// squares (silent empty pages), so reuse is allowed only when every page ran
+/// the model. When it is refused, the OCR path runs its own layout pass in
+/// `RenderWithoutInference` mode, which renders gated pages correctly.
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+fn markdown_layout_reusable_for_ocr(decisions: Option<&[crate::pdf::layout_gate::PageGateDecision]>) -> bool {
+    decisions.is_none_or(|decisions| decisions.iter().all(|decision| decision.run_layout))
+}
 
 /// Convert gate decisions into the metadata representation.
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
@@ -639,6 +652,12 @@ impl PdfExtractor {
         #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
         #[allow(unused_assignments)]
         let mut ocr_layout_gate_audit: OcrLayoutGateDecisions = (None, None);
+
+        #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+        if !markdown_layout_reusable_for_ocr(markdown_layout_gate_decisions.as_deref()) {
+            markdown_layout_images = None;
+            markdown_layout_detections = None;
+        }
 
         #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
         let (text, extraction_method) = if config.effective_disable_ocr() {
@@ -1303,6 +1322,52 @@ mod tests {
     use crate::core::config::OcrQualityThresholds;
     #[cfg(all(feature = "pdf", feature = "ocr"))]
     use serial_test::serial;
+
+    #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+    fn gate_decision(run_layout: bool) -> crate::pdf::layout_gate::PageGateDecision {
+        crate::pdf::layout_gate::PageGateDecision {
+            run_layout,
+            reason: if run_layout {
+                crate::pdf::layout_gate::GateReason::MultiColumn
+            } else {
+                crate::pdf::layout_gate::GateReason::PlainText
+            },
+        }
+    }
+
+    /// Gate-skipped pages carry placeholder rasters; any skip must refuse
+    /// raster reuse so OCR never reads a blank square.
+    #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+    #[test]
+    fn markdown_layout_rasters_are_reusable_for_ocr_only_when_no_page_was_gated() {
+        assert!(markdown_layout_reusable_for_ocr(None));
+        assert!(markdown_layout_reusable_for_ocr(Some(&[
+            gate_decision(true),
+            gate_decision(true)
+        ])));
+        assert!(!markdown_layout_reusable_for_ocr(Some(&[
+            gate_decision(true),
+            gate_decision(false)
+        ])));
+    }
+
+    #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+    #[test]
+    fn layout_gate_metadata_reports_one_indexed_skipped_pages_and_all_reasons() {
+        let decisions = [gate_decision(true), gate_decision(false), gate_decision(false)];
+        let (gated, reasons) = layout_gate_metadata(Some(&decisions));
+        assert_eq!(gated, Some(vec![2, 3]));
+        assert_eq!(
+            reasons,
+            Some(vec![
+                "multi_column".to_string(),
+                "plain_text".to_string(),
+                "plain_text".to_string()
+            ])
+        );
+
+        assert_eq!(layout_gate_metadata(None), (None, None));
+    }
 
     #[cfg(feature = "pdf")]
     fn catalog(

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -269,7 +269,11 @@ type OcrLayoutGateDecisions = (Option<Vec<u32>>, Option<Vec<String>>);
 /// squares (silent empty pages), so reuse is allowed only when every page ran
 /// the model. When it is refused, the OCR path runs its own layout pass in
 /// `RenderWithoutInference` mode, which renders gated pages correctly.
-#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+#[cfg(all(
+    feature = "pdf",
+    feature = "layout-detection",
+    any(feature = "ocr", feature = "ocr-pipeline")
+))]
 fn markdown_layout_reusable_for_ocr(decisions: Option<&[crate::pdf::layout_gate::PageGateDecision]>) -> bool {
     decisions.is_none_or(|decisions| decisions.iter().all(|decision| decision.run_layout))
 }
@@ -653,7 +657,11 @@ impl PdfExtractor {
         #[allow(unused_assignments)]
         let mut ocr_layout_gate_audit: OcrLayoutGateDecisions = (None, None);
 
-        #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+        #[cfg(all(
+            feature = "pdf",
+            feature = "layout-detection",
+            any(feature = "ocr", feature = "ocr-pipeline")
+        ))]
         if !markdown_layout_reusable_for_ocr(markdown_layout_gate_decisions.as_deref()) {
             markdown_layout_images = None;
             markdown_layout_detections = None;
@@ -1337,7 +1345,11 @@ mod tests {
 
     /// Gate-skipped pages carry placeholder rasters; any skip must refuse
     /// raster reuse so OCR never reads a blank square.
-    #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+    #[cfg(all(
+        feature = "pdf",
+        feature = "layout-detection",
+        any(feature = "ocr", feature = "ocr-pipeline")
+    ))]
     #[test]
     fn markdown_layout_rasters_are_reusable_for_ocr_only_when_no_page_was_gated() {
         assert!(markdown_layout_reusable_for_ocr(None));

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -1048,11 +1048,17 @@ impl PdfExtractor {
         #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
         doc.processing_warnings.append(&mut ocr_fallback_warnings);
 
-        // Record the auto layout gate's audit trail from whichever pass ran it. ~keep
-        #[cfg(all(feature = "pdf", feature = "layout-detection"))]
+        // Record the auto layout gate's audit trail from whichever pass ran
+        // it. Compiled whenever `pdf` is on so `ocr_layout_gate_audit` keeps
+        // a reader in profiles without layout-detection (it is always
+        // `(None, None)` there and the fields stay `None`). ~keep
         {
+            #[cfg(feature = "layout-detection")]
             #[allow(unused_mut)]
             let (mut gated_pages, mut gate_reasons) = layout_gate_metadata(markdown_layout_gate_decisions.as_deref());
+            #[cfg(not(feature = "layout-detection"))]
+            #[allow(unused_mut)]
+            let (mut gated_pages, mut gate_reasons): OcrLayoutGateDecisions = (None, None);
             #[cfg(any(feature = "ocr", feature = "ocr-pipeline"))]
             if gated_pages.is_none() {
                 let (ocr_gated_pages, ocr_gate_reasons) = ocr_layout_gate_audit;

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -283,7 +283,11 @@ async fn run_ocr_with_layout(
         if let Some(layout_config) = config.resolved_layout_config() {
             let thread_budget = crate::core::config::concurrency::resolve_thread_budget(config.concurrency.as_ref());
             match layout_runner::run_layout_for_ocr(content, layout_config.as_ref(), thread_budget).await {
-                Ok(layout) => Some(layout),
+                Ok(Some(layout)) => Some(layout),
+                Ok(None) => {
+                    tracing::info!("OCR layout: auto gate skipped every page, continuing without layout assembly");
+                    None
+                }
                 Err(error) => {
                     tracing::warn!(
                         error = %error,

--- a/crates/xberg/src/lib.rs
+++ b/crates/xberg/src/lib.rs
@@ -358,7 +358,7 @@ pub use paddle_ocr::{ModelCacheStats, ModelManager, ModelManifestEntry, PaddleOc
 pub use cache::CacheStats;
 
 #[cfg(feature = "layout-types")]
-pub use core::config::{LayoutDetectionConfig, TableModel};
+pub use core::config::{LayoutDetectionConfig, LayoutStrategy, TableModel};
 
 #[cfg(feature = "layout-types")]
 pub use layout::types::{BBox, DetectionResult, LayoutClass, LayoutDetection};

--- a/crates/xberg/src/pdf/layout_gate.rs
+++ b/crates/xberg/src/pdf/layout_gate.rs
@@ -57,6 +57,9 @@ const GRID_MIN_COLS: usize = 2;
 /// Rows are clustered on span vertical centers within this tolerance, points.
 const GRID_ROW_TOLERANCE_PTS: f32 = 5.0;
 
+/// Row clustering widens to this fraction of the span height for large fonts.
+const GRID_ROW_TOLERANCE_HEIGHT_FRACTION: f32 = 0.6;
+
 /// Straight lines shorter than this are decoration, not rules, in points.
 const RULED_LINE_MIN_LENGTH_PTS: f32 = 20.0;
 
@@ -216,6 +219,11 @@ pub(crate) fn decide_page(signals: &PageGateSignals) -> PageGateDecision {
 /// [`COLUMN_GUTTER_MIN_WIDTH_PTS`] with [`COLUMN_SIDE_MIN_SPANS`] spans on
 /// each side, both sides covering [`COLUMN_SIDE_MIN_HEIGHT_FRACTION`] of the
 /// text height, reads as a column gutter.
+///
+/// A single full-width span crossing the gutter (a heading over two columns)
+/// hides the gap from this projection; such pages are still selected through
+/// the [`has_aligned_grid`] backstop, since column bodies share left anchors
+/// across many rows.
 fn has_column_split(spans: &[SpanBox]) -> bool {
     if spans.len() < COLUMN_SIDE_MIN_SPANS * 2 {
         return false;
@@ -287,7 +295,7 @@ fn cluster_rows(spans: &[SpanBox]) -> Vec<Vec<&SpanBox>> {
         match rows.last_mut() {
             Some(row)
                 if (span.vertical_center() - row[0].vertical_center()).abs()
-                    <= GRID_ROW_TOLERANCE_PTS.max(span.height() * 0.6) =>
+                    <= GRID_ROW_TOLERANCE_PTS.max(span.height() * GRID_ROW_TOLERANCE_HEIGHT_FRACTION) =>
             {
                 row.push(span);
             }
@@ -299,8 +307,10 @@ fn cluster_rows(spans: &[SpanBox]) -> Vec<Vec<&SpanBox>> {
 
 /// Count edge positions that recur on at least [`GRID_MIN_ROWS`] rows.
 ///
-/// Edges are clustered within [`GRID_EDGE_ALIGN_TOLERANCE_PTS`]; each cluster
-/// counts the number of distinct rows contributing to it.
+/// Edges are clustered within [`GRID_EDGE_ALIGN_TOLERANCE_PTS`] of the
+/// cluster's first edge, anchored rather than chained: adjacent edges 3pt
+/// apart must not link scattered prose-span edges into one wide false anchor.
+/// Each cluster counts the number of distinct rows contributing to it.
 fn recurring_edge_clusters(rows: &[&Vec<&SpanBox>], edge: fn(&SpanBox) -> f32) -> usize {
     let mut edges: Vec<(f32, usize)> = rows
         .iter()
@@ -312,7 +322,8 @@ fn recurring_edge_clusters(rows: &[&Vec<&SpanBox>], edge: fn(&SpanBox) -> f32) -
     let mut anchors = 0usize;
     let mut cluster_start = 0usize;
     for index in 1..=edges.len() {
-        let cluster_ended = index == edges.len() || edges[index].0 - edges[index - 1].0 > GRID_EDGE_ALIGN_TOLERANCE_PTS;
+        let cluster_ended =
+            index == edges.len() || edges[index].0 - edges[cluster_start].0 > GRID_EDGE_ALIGN_TOLERANCE_PTS;
         if cluster_ended {
             let mut row_indices: Vec<usize> = edges[cluster_start..index].iter().map(|(_, row)| *row).collect();
             row_indices.sort_unstable();
@@ -357,43 +368,48 @@ fn page_signals(doc: &PdfDocument, page_index: usize) -> Option<PageGateSignals>
         .map(|span| span.text.chars().filter(|c| !c.is_whitespace()).count())
         .sum();
 
-    let (horizontal_rules, vertical_rules) = count_rules(doc, page_index)?;
+    // One content-stream path parse serves both the rule counter and the
+    // vector-coverage signal; pdf_oxide's extract_lines would re-run
+    // extract_paths internally. ~keep
+    let paths = super::oxide::guard_oxide_panic(
+        || doc.extract_paths(page_index).map_err(|error| error.to_string()),
+        |message| message,
+    )
+    .ok()?;
+    let (horizontal_rules, vertical_rules) = count_rules(&paths);
 
     Some(PageGateSignals {
         spans,
         text_chars,
         horizontal_rules,
         vertical_rules,
-        graphics_coverage: graphics_coverage(doc, page_index)?,
+        graphics_coverage: graphics_coverage(doc, page_index, &paths)?,
         has_form_widgets: has_form_widgets(doc, page_index)?,
     })
 }
 
-/// Count horizontal and vertical rules at least [`RULED_LINE_MIN_LENGTH_PTS`] long.
-fn count_rules(doc: &PdfDocument, page_index: usize) -> Option<(usize, usize)> {
-    let lines = super::oxide::guard_oxide_panic(
-        || doc.extract_lines(page_index).map_err(|error| error.to_string()),
-        |message| message,
-    )
-    .ok()?;
-
+/// Count horizontal and vertical rules at least [`RULED_LINE_MIN_LENGTH_PTS`]
+/// long. A rule must also be thin (minor bbox dimension within
+/// [`GRID_EDGE_ALIGN_TOLERANCE_PTS`]) so long diagonals on chart-heavy pages
+/// do not count.
+fn count_rules(paths: &[pdf_oxide::elements::PathContent]) -> (usize, usize) {
     let mut horizontal = 0usize;
     let mut vertical = 0usize;
-    for line in &lines {
-        let width = line.bbox.width.abs();
-        let height = line.bbox.height.abs();
-        if width >= RULED_LINE_MIN_LENGTH_PTS && width > height {
+    for path in paths.iter().filter(|path| path.is_straight_line()) {
+        let width = path.bbox.width.abs();
+        let height = path.bbox.height.abs();
+        if width >= RULED_LINE_MIN_LENGTH_PTS && height <= GRID_EDGE_ALIGN_TOLERANCE_PTS {
             horizontal += 1;
-        } else if height >= RULED_LINE_MIN_LENGTH_PTS && height > width {
+        } else if height >= RULED_LINE_MIN_LENGTH_PTS && width <= GRID_EDGE_ALIGN_TOLERANCE_PTS {
             vertical += 1;
         }
     }
-    Some((horizontal, vertical))
+    (horizontal, vertical)
 }
 
 /// Fraction of the page under raster images plus stroked or filled vector
 /// paths, without decoding pixels. Summed, not unioned: an upper bound.
-fn graphics_coverage(doc: &PdfDocument, page_index: usize) -> Option<f32> {
+fn graphics_coverage(doc: &PdfDocument, page_index: usize, paths: &[pdf_oxide::elements::PathContent]) -> Option<f32> {
     let (x0, y0, x1, y1) = doc.get_page_media_box(page_index).ok()?;
     let page_area = ((x1 - x0) * (y1 - y0)).abs();
     if page_area <= f32::EPSILON {
@@ -406,15 +422,11 @@ fn graphics_coverage(doc: &PdfDocument, page_index: usize) -> Option<f32> {
         .iter()
         .map(|handle| (handle.bbox.width * handle.bbox.height).abs())
         .sum();
-    let vector: f32 = super::oxide::guard_oxide_panic(
-        || doc.extract_paths(page_index).map_err(|error| error.to_string()),
-        |message| message,
-    )
-    .ok()?
-    .iter()
-    .filter(|path| !path.is_straight_line())
-    .map(|path| (path.bbox.width * path.bbox.height).abs())
-    .sum();
+    let vector: f32 = paths
+        .iter()
+        .filter(|path| !path.is_straight_line())
+        .map(|path| (path.bbox.width * path.bbox.height).abs())
+        .sum();
 
     Some(((raster + vector) / page_area).clamp(0.0, 1.0))
 }
@@ -569,6 +581,58 @@ mod tests {
         // Every prose line shares one left anchor; one anchor is below
         // GRID_MIN_COLS so justified prose must not read as a table. ~keep
         assert!(!has_aligned_grid(&prose_spans(40)));
+    }
+
+    #[test]
+    fn prose_lines_split_into_scattered_spans_are_not_a_grid() {
+        // Kerning and style changes split real prose lines into several
+        // spans whose edges land at unaligned x positions. Anchored edge
+        // clustering must not chain them into false column anchors. ~keep
+        let mut spans = Vec::new();
+        for line in 0..20 {
+            let top = 720.0 - line as f32 * 14.0;
+            // Left anchor plus two mid-line breaks drifting 2pts per line:
+            // chained clustering would merge the drift into wide anchors. ~keep
+            let drift = line as f32 * 2.0;
+            spans.push(span(72.0, top - 10.0, 200.0 + drift, top));
+            spans.push(span(202.0 + drift, top - 10.0, 380.0 - drift, top));
+            spans.push(span(382.0 - drift, top - 10.0, 540.0, top));
+        }
+        let signals = PageGateSignals {
+            spans,
+            text_chars: 2_000,
+            horizontal_rules: 0,
+            vertical_rules: 0,
+            graphics_coverage: 0.0,
+            has_form_widgets: false,
+        };
+        let decision = decide_page(&signals);
+        assert!(
+            !decision.run_layout,
+            "drifting mid-line span edges must not read as a table grid, got {:?}",
+            decision.reason
+        );
+    }
+
+    #[test]
+    fn full_width_heading_over_two_columns_still_runs_the_model() {
+        // The heading span crosses the gutter, hiding it from the
+        // x-projection; the aligned-grid backstop must still select the page. ~keep
+        let mut spans = vec![span(72.0, 710.0, 540.0, 726.0)];
+        for line in 0..20 {
+            let top = 690.0 - line as f32 * 14.0;
+            spans.push(span(72.0, top - 10.0, 290.0, top));
+            spans.push(span(322.0, top - 10.0, 540.0, top));
+        }
+        let signals = PageGateSignals {
+            spans,
+            text_chars: 2_000,
+            horizontal_rules: 0,
+            vertical_rules: 0,
+            graphics_coverage: 0.0,
+            has_form_widgets: false,
+        };
+        assert!(decide_page(&signals).run_layout);
     }
 
     #[test]

--- a/crates/xberg/src/pdf/layout_gate.rs
+++ b/crates/xberg/src/pdf/layout_gate.rs
@@ -94,6 +94,23 @@ pub(crate) enum GateReason {
     PlainText,
 }
 
+impl GateReason {
+    /// Snake_case wire name recorded in extraction metadata.
+    pub(crate) fn wire_name(self) -> &'static str {
+        match self {
+            Self::SparseText => "sparse_text",
+            Self::NoTextLayer => "no_text_layer",
+            Self::MultiColumn => "multi_column",
+            Self::TableGrid => "table_grid",
+            Self::RuledLines => "ruled_lines",
+            Self::GraphicsHeavy => "graphics_heavy",
+            Self::FormWidgets => "form_widgets",
+            Self::SignalsUnavailable => "signals_unavailable",
+            Self::PlainText => "plain_text",
+        }
+    }
+}
+
 /// One page's gate outcome.
 #[cfg_attr(alef, alef(skip))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/xberg/src/pdf/layout_gate.rs
+++ b/crates/xberg/src/pdf/layout_gate.rs
@@ -1,0 +1,609 @@
+//! Per-page pre-screen for adaptive layout detection ([`LayoutStrategy::Auto`]).
+//!
+//! Grades every page from cheap geometry the PDF already carries (text-span
+//! boxes, straight lines, raster and vector graphics, widget annotations) and
+//! decides whether the expensive render + ONNX layout pass can pay off there.
+//!
+//! The gate is recall-biased: any structure evidence, sparse or absent text,
+//! or a failure to gather signals selects the page for the model. Only pages
+//! that positively look like plain single-column text are skipped, and a
+//! skipped page processes exactly like a page where the model ran and found
+//! no regions.
+//!
+//! All signal gathering is advisory and pixel-free, in the same shape as
+//! [`super::scan_detect`]: a page that cannot be inspected must never abort
+//! extraction, it just runs the model.
+//!
+//! [`LayoutStrategy::Auto`]: crate::core::config::layout::LayoutStrategy::Auto
+
+use pdf_oxide::PdfDocument;
+use pdf_oxide::annotation_types::AnnotationSubtype;
+use pdf_oxide::document::ReadingOrder;
+
+/// Pages with fewer spans than this look like slides, posters, or covers:
+/// too little text to trust geometry, so the model runs.
+const SPARSE_PAGE_MAX_SPANS: usize = 8;
+
+/// Pages whose text layer carries fewer non-whitespace characters than this
+/// are treated as having no usable text layer, so the model runs.
+const TEXT_LAYER_MIN_CHARS: usize = 40;
+
+/// Minimum width of an empty vertical band read as a column gutter, in points.
+const COLUMN_GUTTER_MIN_WIDTH_PTS: f32 = 12.0;
+
+/// Minimum spans fully on each side of a candidate gutter.
+///
+/// Deliberately far below the production column splitter's floor: a missed
+/// split corrupts reading order, so the gate over-selects rather than trusts
+/// the precision-tuned extraction constants.
+const COLUMN_SIDE_MIN_SPANS: usize = 4;
+
+/// Each side of a gutter must span at least this fraction of the text height.
+const COLUMN_SIDE_MIN_HEIGHT_FRACTION: f32 = 0.15;
+
+/// Horizontal tolerance when clustering span edges into table column anchors.
+const GRID_EDGE_ALIGN_TOLERANCE_PTS: f32 = 3.0;
+
+/// A span edge cluster must recur on this many distinct rows to count as a
+/// table column anchor.
+const GRID_MIN_ROWS: usize = 3;
+
+/// Distinct aligned column anchors needed to read a page as table-bearing.
+///
+/// Two suffices (key-value blocks, two-column financial tables); the
+/// production detector requires three, which the gate deliberately relaxes.
+const GRID_MIN_COLS: usize = 2;
+
+/// Rows are clustered on span vertical centers within this tolerance, points.
+const GRID_ROW_TOLERANCE_PTS: f32 = 5.0;
+
+/// Straight lines shorter than this are decoration, not rules, in points.
+const RULED_LINE_MIN_LENGTH_PTS: f32 = 20.0;
+
+/// Ruled-line evidence needs at least this many rules per orientation, so a
+/// single underline or divider does not select the page.
+const RULED_LINES_MIN_PER_ORIENTATION: usize = 2;
+
+/// Combined raster and vector coverage at or above this fraction reads the
+/// page as figure- or chart-bearing.
+const GRAPHICS_COVERAGE_MIN: f32 = 0.15;
+
+/// Why the gate selected (or skipped) a page.
+///
+/// Recorded per page so `Auto` runs are auditable from extraction metadata.
+#[cfg_attr(alef, alef(skip))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum GateReason {
+    /// Too little text to trust geometry signals.
+    SparseText,
+    /// No usable native text layer; the model is the only structure source.
+    NoTextLayer,
+    /// An empty vertical band splits the text into two populated columns.
+    MultiColumn,
+    /// Span edges align into recurring column anchors across rows.
+    TableGrid,
+    /// Horizontal and vertical rules suggest a grid or form.
+    RuledLines,
+    /// Raster plus vector graphics cover a meaningful page fraction.
+    GraphicsHeavy,
+    /// The page carries interactive form widgets.
+    FormWidgets,
+    /// Signal gathering failed; the gate must not guess.
+    SignalsUnavailable,
+    /// Plain single-column text: the model has nothing to find.
+    PlainText,
+}
+
+/// One page's gate outcome.
+#[cfg_attr(alef, alef(skip))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PageGateDecision {
+    /// Whether the layout model runs on this page.
+    pub run_layout: bool,
+    /// The dominant reason for the decision.
+    pub reason: GateReason,
+}
+
+impl PageGateDecision {
+    fn run(reason: GateReason) -> Self {
+        Self {
+            run_layout: true,
+            reason,
+        }
+    }
+
+    fn skip() -> Self {
+        Self {
+            run_layout: false,
+            reason: GateReason::PlainText,
+        }
+    }
+}
+
+/// Axis-aligned span box in PDF points, the only geometry the gate reads.
+#[cfg_attr(alef, alef(skip))]
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct SpanBox {
+    pub left: f32,
+    pub bottom: f32,
+    pub right: f32,
+    pub top: f32,
+}
+
+impl SpanBox {
+    fn height(&self) -> f32 {
+        (self.top - self.bottom).abs()
+    }
+
+    fn vertical_center(&self) -> f32 {
+        (self.top + self.bottom) / 2.0
+    }
+}
+
+/// Everything [`decide_page`] needs, gathered without decoding any pixels.
+#[cfg_attr(alef, alef(skip))]
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PageGateSignals {
+    /// Text-span boxes in PDF points.
+    pub spans: Vec<SpanBox>,
+    /// Non-whitespace characters in the native text layer.
+    pub text_chars: usize,
+    /// Horizontal rules at least [`RULED_LINE_MIN_LENGTH_PTS`] long.
+    pub horizontal_rules: usize,
+    /// Vertical rules at least [`RULED_LINE_MIN_LENGTH_PTS`] long.
+    pub vertical_rules: usize,
+    /// Fraction of the page under raster images plus vector paths, `[0, 1]`.
+    ///
+    /// Overlaps are summed, not unioned: an upper bound that can over-select
+    /// a page for the model, never under-select one.
+    pub graphics_coverage: f32,
+    /// Whether the page carries widget (form field) annotations.
+    pub has_form_widgets: bool,
+}
+
+/// Decide one page from its signals. Pure, so it is testable without a
+/// [`PdfDocument`].
+///
+/// Checks are ordered cheapest-first; the page is skipped only when every
+/// run-condition stays quiet.
+pub(crate) fn decide_page(signals: &PageGateSignals) -> PageGateDecision {
+    if signals.text_chars < TEXT_LAYER_MIN_CHARS {
+        return PageGateDecision::run(GateReason::NoTextLayer);
+    }
+    if signals.spans.len() < SPARSE_PAGE_MAX_SPANS {
+        return PageGateDecision::run(GateReason::SparseText);
+    }
+    if signals.has_form_widgets {
+        return PageGateDecision::run(GateReason::FormWidgets);
+    }
+    if signals.horizontal_rules >= RULED_LINES_MIN_PER_ORIENTATION
+        && signals.vertical_rules >= RULED_LINES_MIN_PER_ORIENTATION
+    {
+        return PageGateDecision::run(GateReason::RuledLines);
+    }
+    if signals.graphics_coverage >= GRAPHICS_COVERAGE_MIN {
+        return PageGateDecision::run(GateReason::GraphicsHeavy);
+    }
+    if has_column_split(&signals.spans) {
+        return PageGateDecision::run(GateReason::MultiColumn);
+    }
+    if has_aligned_grid(&signals.spans) {
+        return PageGateDecision::run(GateReason::TableGrid);
+    }
+    PageGateDecision::skip()
+}
+
+/// Whether an empty vertical band splits the spans into two populated sides.
+///
+/// Sweeps the x-projection of all span intervals: a maximal gap wider than
+/// [`COLUMN_GUTTER_MIN_WIDTH_PTS`] with [`COLUMN_SIDE_MIN_SPANS`] spans on
+/// each side, both sides covering [`COLUMN_SIDE_MIN_HEIGHT_FRACTION`] of the
+/// text height, reads as a column gutter.
+fn has_column_split(spans: &[SpanBox]) -> bool {
+    if spans.len() < COLUMN_SIDE_MIN_SPANS * 2 {
+        return false;
+    }
+    let text_height = vertical_extent(spans.iter());
+    if text_height <= f32::EPSILON {
+        return false;
+    }
+
+    let mut by_left: Vec<&SpanBox> = spans.iter().collect();
+    by_left.sort_by(|a, b| a.left.total_cmp(&b.left));
+
+    let mut covered_right = by_left[0].right;
+    for (index, span) in by_left.iter().enumerate().skip(1) {
+        let gap = span.left - covered_right;
+        if gap >= COLUMN_GUTTER_MIN_WIDTH_PTS && sides_populated(&by_left, index, text_height) {
+            return true;
+        }
+        covered_right = covered_right.max(span.right);
+    }
+    false
+}
+
+/// Whether both sides of the gap before `split_index` hold enough spans and
+/// vertical coverage to be real columns.
+fn sides_populated(by_left: &[&SpanBox], split_index: usize, text_height: f32) -> bool {
+    let (left, right) = by_left.split_at(split_index);
+    if left.len() < COLUMN_SIDE_MIN_SPANS || right.len() < COLUMN_SIDE_MIN_SPANS {
+        return false;
+    }
+    let min_height = text_height * COLUMN_SIDE_MIN_HEIGHT_FRACTION;
+    vertical_extent(left.iter().copied()) >= min_height && vertical_extent(right.iter().copied()) >= min_height
+}
+
+fn vertical_extent<'a>(spans: impl Iterator<Item = &'a SpanBox>) -> f32 {
+    let mut bottom = f32::INFINITY;
+    let mut top = f32::NEG_INFINITY;
+    for span in spans {
+        bottom = bottom.min(span.bottom);
+        top = top.max(span.top);
+    }
+    if top > bottom { top - bottom } else { 0.0 }
+}
+
+/// Whether span left or right edges recur in aligned column anchors across
+/// enough rows to look table-bearing.
+fn has_aligned_grid(spans: &[SpanBox]) -> bool {
+    let rows = cluster_rows(spans);
+    let multi_span_rows: Vec<&Vec<&SpanBox>> = rows.iter().filter(|row| row.len() >= GRID_MIN_COLS).collect();
+    if multi_span_rows.len() < GRID_MIN_ROWS {
+        return false;
+    }
+
+    let left_anchors = recurring_edge_clusters(&multi_span_rows, |span| span.left);
+    if left_anchors >= GRID_MIN_COLS {
+        return true;
+    }
+    let right_anchors = recurring_edge_clusters(&multi_span_rows, |span| span.right);
+    right_anchors >= GRID_MIN_COLS
+}
+
+/// Group spans into rows on vertical centers within [`GRID_ROW_TOLERANCE_PTS`].
+fn cluster_rows(spans: &[SpanBox]) -> Vec<Vec<&SpanBox>> {
+    let mut by_center: Vec<&SpanBox> = spans.iter().collect();
+    by_center.sort_by(|a, b| a.vertical_center().total_cmp(&b.vertical_center()));
+
+    let mut rows: Vec<Vec<&SpanBox>> = Vec::new();
+    for span in by_center {
+        match rows.last_mut() {
+            Some(row)
+                if (span.vertical_center() - row[0].vertical_center()).abs()
+                    <= GRID_ROW_TOLERANCE_PTS.max(span.height() * 0.6) =>
+            {
+                row.push(span);
+            }
+            _ => rows.push(vec![span]),
+        }
+    }
+    rows
+}
+
+/// Count edge positions that recur on at least [`GRID_MIN_ROWS`] rows.
+///
+/// Edges are clustered within [`GRID_EDGE_ALIGN_TOLERANCE_PTS`]; each cluster
+/// counts the number of distinct rows contributing to it.
+fn recurring_edge_clusters(rows: &[&Vec<&SpanBox>], edge: fn(&SpanBox) -> f32) -> usize {
+    let mut edges: Vec<(f32, usize)> = rows
+        .iter()
+        .enumerate()
+        .flat_map(|(row_index, row)| row.iter().map(move |span| (edge(span), row_index)))
+        .collect();
+    edges.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+    let mut anchors = 0usize;
+    let mut cluster_start = 0usize;
+    for index in 1..=edges.len() {
+        let cluster_ended = index == edges.len() || edges[index].0 - edges[index - 1].0 > GRID_EDGE_ALIGN_TOLERANCE_PTS;
+        if cluster_ended {
+            let mut row_indices: Vec<usize> = edges[cluster_start..index].iter().map(|(_, row)| *row).collect();
+            row_indices.sort_unstable();
+            row_indices.dedup();
+            if row_indices.len() >= GRID_MIN_ROWS {
+                anchors += 1;
+            }
+            cluster_start = index;
+        }
+    }
+    anchors
+}
+
+/// Gather one page's signals from `doc`, or `None` when inspection fails.
+///
+/// Failures are advisory (matching [`super::scan_detect`]): the caller maps
+/// `None` to [`GateReason::SignalsUnavailable`] and runs the model.
+fn page_signals(doc: &PdfDocument, page_index: usize) -> Option<PageGateSignals> {
+    let page_text = super::oxide::guard_oxide_panic(
+        || {
+            doc.extract_page_text_with_options(page_index, ReadingOrder::ColumnAware)
+                .map_err(|error| error.to_string())
+        },
+        |message| message,
+    )
+    .ok()?;
+
+    let spans: Vec<SpanBox> = page_text
+        .spans
+        .iter()
+        .filter(|span| !span.text.trim().is_empty())
+        .map(|span| SpanBox {
+            left: span.bbox.x,
+            bottom: span.bbox.y,
+            right: span.bbox.x + span.bbox.width,
+            top: span.bbox.y + span.bbox.height,
+        })
+        .collect();
+    let text_chars = page_text
+        .spans
+        .iter()
+        .map(|span| span.text.chars().filter(|c| !c.is_whitespace()).count())
+        .sum();
+
+    let (horizontal_rules, vertical_rules) = count_rules(doc, page_index)?;
+
+    Some(PageGateSignals {
+        spans,
+        text_chars,
+        horizontal_rules,
+        vertical_rules,
+        graphics_coverage: graphics_coverage(doc, page_index)?,
+        has_form_widgets: has_form_widgets(doc, page_index)?,
+    })
+}
+
+/// Count horizontal and vertical rules at least [`RULED_LINE_MIN_LENGTH_PTS`] long.
+fn count_rules(doc: &PdfDocument, page_index: usize) -> Option<(usize, usize)> {
+    let lines = super::oxide::guard_oxide_panic(
+        || doc.extract_lines(page_index).map_err(|error| error.to_string()),
+        |message| message,
+    )
+    .ok()?;
+
+    let mut horizontal = 0usize;
+    let mut vertical = 0usize;
+    for line in &lines {
+        let width = line.bbox.width.abs();
+        let height = line.bbox.height.abs();
+        if width >= RULED_LINE_MIN_LENGTH_PTS && width > height {
+            horizontal += 1;
+        } else if height >= RULED_LINE_MIN_LENGTH_PTS && height > width {
+            vertical += 1;
+        }
+    }
+    Some((horizontal, vertical))
+}
+
+/// Fraction of the page under raster images plus stroked or filled vector
+/// paths, without decoding pixels. Summed, not unioned: an upper bound.
+fn graphics_coverage(doc: &PdfDocument, page_index: usize) -> Option<f32> {
+    let (x0, y0, x1, y1) = doc.get_page_media_box(page_index).ok()?;
+    let page_area = ((x1 - x0) * (y1 - y0)).abs();
+    if page_area <= f32::EPSILON {
+        return None;
+    }
+
+    let raster: f32 = doc
+        .page_image_handles(page_index)
+        .ok()?
+        .iter()
+        .map(|handle| (handle.bbox.width * handle.bbox.height).abs())
+        .sum();
+    let vector: f32 = super::oxide::guard_oxide_panic(
+        || doc.extract_paths(page_index).map_err(|error| error.to_string()),
+        |message| message,
+    )
+    .ok()?
+    .iter()
+    .filter(|path| !path.is_straight_line())
+    .map(|path| (path.bbox.width * path.bbox.height).abs())
+    .sum();
+
+    Some(((raster + vector) / page_area).clamp(0.0, 1.0))
+}
+
+fn has_form_widgets(doc: &PdfDocument, page_index: usize) -> Option<bool> {
+    let annotations = super::oxide::guard_oxide_panic(
+        || doc.get_annotations(page_index).map_err(|error| error.to_string()),
+        |message| message,
+    )
+    .ok()?;
+    Some(
+        annotations
+            .iter()
+            .any(|annotation| annotation.subtype_enum == AnnotationSubtype::Widget),
+    )
+}
+
+/// Decide every page of `doc`.
+///
+/// Infallible: a page whose signals cannot be gathered runs the model with
+/// [`GateReason::SignalsUnavailable`] rather than failing extraction.
+pub(crate) fn decide_pages(doc: &PdfDocument, page_count: usize) -> Vec<PageGateDecision> {
+    (0..page_count)
+        .map(|page_index| match page_signals(doc, page_index) {
+            Some(signals) => decide_page(&signals),
+            None => PageGateDecision::run(GateReason::SignalsUnavailable),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(left: f32, bottom: f32, right: f32, top: f32) -> SpanBox {
+        SpanBox {
+            left,
+            bottom,
+            right,
+            top,
+        }
+    }
+
+    /// A believable single-column prose page: one span per line, common margins.
+    fn prose_spans(lines: usize) -> Vec<SpanBox> {
+        (0..lines)
+            .map(|line| {
+                let top = 720.0 - line as f32 * 14.0;
+                span(72.0, top - 10.0, 540.0, top)
+            })
+            .collect()
+    }
+
+    fn prose_signals() -> PageGateSignals {
+        PageGateSignals {
+            spans: prose_spans(40),
+            text_chars: 2_000,
+            horizontal_rules: 0,
+            vertical_rules: 0,
+            graphics_coverage: 0.0,
+            has_form_widgets: false,
+        }
+    }
+
+    #[test]
+    fn plain_prose_page_is_skipped() {
+        let decision = decide_page(&prose_signals());
+        assert!(!decision.run_layout);
+        assert_eq!(decision.reason, GateReason::PlainText);
+    }
+
+    #[test]
+    fn missing_text_layer_runs_the_model() {
+        let signals = PageGateSignals {
+            text_chars: 0,
+            spans: Vec::new(),
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::NoTextLayer);
+    }
+
+    #[test]
+    fn sparse_slide_like_page_runs_the_model() {
+        let signals = PageGateSignals {
+            spans: prose_spans(3),
+            text_chars: 120,
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::SparseText);
+    }
+
+    #[test]
+    fn two_column_page_runs_the_model() {
+        let mut spans = Vec::new();
+        for line in 0..20 {
+            let top = 720.0 - line as f32 * 14.0;
+            spans.push(span(72.0, top - 10.0, 290.0, top));
+            spans.push(span(322.0, top - 10.0, 540.0, top));
+        }
+        let signals = PageGateSignals {
+            spans,
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::MultiColumn);
+    }
+
+    #[test]
+    fn margin_note_alone_is_not_a_column_split() {
+        let mut spans = prose_spans(30);
+        // Three short notes in the right margin: populated side too thin. ~keep
+        for note in 0..3 {
+            let top = 700.0 - note as f32 * 200.0;
+            spans.push(span(560.0, top - 8.0, 600.0, top));
+        }
+        // The gap between body (right edge 540) and notes (left 560) is 20pts
+        // wide, but the note side has fewer than COLUMN_SIDE_MIN_SPANS spans. ~keep
+        let signals = PageGateSignals {
+            spans,
+            ..prose_signals()
+        };
+        assert!(!decide_page(&signals).run_layout);
+    }
+
+    #[test]
+    fn aligned_word_grid_runs_the_model() {
+        // A 4-row, 3-column borderless table embedded under prose. ~keep
+        let mut spans = prose_spans(20);
+        for row in 0..4 {
+            let top = 400.0 - row as f32 * 18.0;
+            for column in 0..3 {
+                let left = 90.0 + column as f32 * 150.0;
+                spans.push(span(left, top - 10.0, left + 60.0, top));
+            }
+        }
+        let signals = PageGateSignals {
+            spans,
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::TableGrid);
+    }
+
+    #[test]
+    fn prose_left_margin_alignment_is_not_a_grid() {
+        // Every prose line shares one left anchor; one anchor is below
+        // GRID_MIN_COLS so justified prose must not read as a table. ~keep
+        assert!(!has_aligned_grid(&prose_spans(40)));
+    }
+
+    #[test]
+    fn ruled_grid_runs_the_model() {
+        let signals = PageGateSignals {
+            horizontal_rules: 5,
+            vertical_rules: 4,
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::RuledLines);
+    }
+
+    #[test]
+    fn horizontal_dividers_alone_do_not_run_the_model() {
+        let signals = PageGateSignals {
+            horizontal_rules: 3,
+            vertical_rules: 0,
+            ..prose_signals()
+        };
+        assert!(!decide_page(&signals).run_layout);
+    }
+
+    #[test]
+    fn graphics_heavy_page_runs_the_model() {
+        let signals = PageGateSignals {
+            graphics_coverage: 0.4,
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::GraphicsHeavy);
+    }
+
+    #[test]
+    fn small_inline_figure_does_not_run_the_model() {
+        let signals = PageGateSignals {
+            graphics_coverage: 0.05,
+            ..prose_signals()
+        };
+        assert!(!decide_page(&signals).run_layout);
+    }
+
+    #[test]
+    fn form_widgets_run_the_model() {
+        let signals = PageGateSignals {
+            has_form_widgets: true,
+            ..prose_signals()
+        };
+        let decision = decide_page(&signals);
+        assert!(decision.run_layout);
+        assert_eq!(decision.reason, GateReason::FormWidgets);
+    }
+}

--- a/crates/xberg/src/pdf/metadata.rs
+++ b/crates/xberg/src/pdf/metadata.rs
@@ -52,6 +52,21 @@ pub struct PdfMetadata {
     /// `None` when the document could not be inspected; empty when no page qualifies.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub scanned_pages: Option<Vec<u32>>,
+
+    /// Pages the `auto` layout strategy skipped (1-indexed).
+    ///
+    /// `None` unless layout detection ran with `LayoutStrategy::Auto`; empty
+    /// when the gate selected every page.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layout_gated_pages: Option<Vec<u32>>,
+
+    /// Why the `auto` layout gate selected or skipped each page.
+    ///
+    /// Index `i` is page `i + 1`. Snake_case values such as `multi_column`,
+    /// `table_grid`, or `plain_text` (the skip reason). `None` unless layout
+    /// detection ran with `LayoutStrategy::Auto`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layout_gate_reasons: Option<Vec<String>>,
 }
 /// Complete PDF extraction metadata including common and PDF-specific fields.
 ///

--- a/crates/xberg/src/pdf/mod.rs
+++ b/crates/xberg/src/pdf/mod.rs
@@ -20,6 +20,9 @@ pub mod error;
 #[cfg(feature = "pdf")]
 /// Document hierarchy reconstruction from PDF structure trees.
 pub mod hierarchy;
+#[cfg(all(feature = "pdf", feature = "layout-detection"))]
+/// Per-page pre-screen for adaptive layout detection.
+pub(crate) mod layout_gate;
 #[cfg(feature = "pdf")]
 /// PDF metadata types: document info dictionary and page structure.
 pub mod metadata;
@@ -30,6 +33,7 @@ pub(crate) mod oxide_text;
 #[cfg(feature = "pdf")]
 /// PDF page rendering to raster images.
 pub mod render;
+
 #[cfg(feature = "pdf")]
 /// Scanned-page detection.
 pub(crate) mod scan_detect;

--- a/crates/xberg/src/pdf/mod.rs
+++ b/crates/xberg/src/pdf/mod.rs
@@ -33,7 +33,6 @@ pub(crate) mod oxide_text;
 #[cfg(feature = "pdf")]
 /// PDF page rendering to raster images.
 pub mod render;
-
 #[cfg(feature = "pdf")]
 /// Scanned-page detection.
 pub(crate) mod scan_detect;

--- a/crates/xberg/src/pdf/oxide/metadata.rs
+++ b/crates/xberg/src/pdf/oxide/metadata.rs
@@ -115,6 +115,10 @@ fn extract_pdf_specific_metadata(
         page_count: Some(page_count as u32),
         scanned_confidence,
         scanned_pages,
+        // Filled by the extractor after the layout pass runs, not here:
+        // metadata extraction never runs the layout gate itself. ~keep
+        layout_gated_pages: None,
+        layout_gate_reasons: None,
     })
 }
 

--- a/docs-site/src/content/docs/guides/layout-detection.mdx
+++ b/docs-site/src/content/docs/guides/layout-detection.mdx
@@ -117,6 +117,9 @@ xberg extract document.pdf --layout-confidence 0.5 --content-format markdown
 # Specific table model
 xberg extract document.pdf --layout --layout-table-model slanet_wired
 
+# Adaptive page selection: run the model only on pages that can benefit
+xberg extract document.pdf --layout --layout-strategy auto
+
 # Combined with GPU acceleration
 xberg extract document.pdf --layout --acceleration coreml
 ```
@@ -131,6 +134,22 @@ See [LayoutDetectionConfig](/reference/configuration/#layoutdetectionconfig) for
 `use_layout_for_markdown` feeds detected regions into the non-OCR PDF markdown pipeline to drive heading, table, list, and figure detection that would otherwise rely on font-clustering heuristics alone. It is a top-level `ExtractionConfig` field — set it alongside `layout`, not inside `LayoutDetectionConfig`.
 
 Enabling it improves structural F1 at the cost of inference latency (~150-300 ms/page CPU, ~20-50 ms/page GPU). Default: `false`. Requires the `layout-detection` feature and a set `layout` config; it is skipped when `force_ocr` is enabled. On the CLI, pass `--use-layout-for-markdown`.
+
+## Page Selection Strategy
+
+`LayoutDetectionConfig.strategy` controls which pages the layout model runs on:
+
+- `always` (default): every page is rendered and inferred, the historical behavior.
+- `auto`: a cheap per-page pre-screen runs first, and the model only processes pages likely to benefit: multi-column text, table geometry, ruled grids, heavy graphics, form widgets, sparse or absent text layers, or pages whose signals could not be gathered.
+
+The pre-screen reads geometry the PDF already carries (text-span boxes, straight lines, image and path bounding boxes, annotations) without decoding any pixels, so it costs a small fraction of one model pass. It is recall-biased: an ambiguous page always runs the model. A skipped page is processed exactly like a page where the model ran and found no regions, and on plain single-column prose that output is identical at a fraction of the cost.
+
+Two behaviors to know:
+
+- On the OCR path the pre-screen skips inference only; page rasters are still produced because OCR consumes them.
+- Skipped pages are auditable: `metadata.pdf.layout_gated_pages` lists them (1-indexed), and `metadata.pdf.layout_gate_reasons` records each page's decision reason (`multi_column`, `table_grid`, `plain_text`, and so on).
+
+Note that `auto` trades the model's per-paragraph refinements on skipped pages (heading promotion, code and formula tagging) for throughput; content and reading order are unchanged. Keep `always` when you need the model's classification on every page.
 
 ## Table Structure Models
 

--- a/docs-site/src/content/docs/guides/layout-detection.mdx
+++ b/docs-site/src/content/docs/guides/layout-detection.mdx
@@ -147,7 +147,7 @@ The pre-screen reads geometry the PDF already carries (text-span boxes, straight
 Two behaviors to know:
 
 - On the OCR path the pre-screen skips inference only; page rasters are still produced because OCR consumes them.
-- Skipped pages are auditable: `metadata.pdf.layout_gated_pages` lists them (1-indexed), and `metadata.pdf.layout_gate_reasons` records each page's decision reason (`multi_column`, `table_grid`, `plain_text`, and so on).
+- Skipped pages are auditable: `metadata.format.layout_gated_pages` lists them (1-indexed), and `metadata.format.layout_gate_reasons` records each page's decision reason (`multi_column`, `table_grid`, `plain_text`, and so on). The `format` object is tagged `format_type: "pdf"`.
 
 Note that `auto` trades the model's per-paragraph refinements on skipped pages (heading promotion, code and formula tagging) for throughput; content and reading order are unchanged. Keep `always` when you need the model's classification on every page.
 


### PR DESCRIPTION
Implements #1322.

## What

`LayoutDetectionConfig` gains a `strategy` field: `always` (default, unchanged behavior) or `auto`. In auto mode a cheap per-page pre-screen decides whether the render + ONNX layout pass can help. Pages with nothing to find keep the native path.

## How it works

| Piece | Behavior |
|---|---|
| Gate (`pdf/layout_gate.rs`) | Recall-biased pre-screen on geometry the PDF already carries: column gutters, word grids, ruled lines, graphics coverage, form widgets, sparse or missing text. Any signal failure selects the page. |
| Markdown path | Gated pages skip render and inference. |
| OCR path | Gated pages skip inference only. OCR reuses the layout rasters, and gate-skipped placeholders are never fed to OCR. |
| All pages gated | Runner returns before engine init. Identical to layout off. |
| Audit trail | `metadata.format.layout_gated_pages` and `layout_gate_reasons`, per page. |
| CLI | `--layout-strategy always` or `auto`, validated; works in `extract` and `batch`. |

## Compatibility

`strategy` is serde-defaulted to `always`. Existing configs, TOML files, REST bodies, and unregenerated bindings behave bit-for-bit as before.

A gated page processes exactly like a page where the model ran and found no regions. That state already exists and is tested.

## Validation: zero regressions on 4,391 pages

Five public-domain corpora. Three arms per document: `always`, `auto`, layout off. Release build.

The audit: every page the gate skipped was re-extracted with `strategy: always` and diffed (whitespace-insensitive, threshold 0.98). A false negative is any skipped page whose forced-layout text materially differs.

| corpus | docs | pages | gate-skipped | false negatives | auto vs always similarity |
|---|---|---|---|---|---|
| test_documents (xberg fixtures) | 97 | 508 | 78 (15%) | **0** | **1.0000** |
| arxiv | 134 | 2083 | 189 (9%) | **0** | **1.0000** |
| govdocs1 | 129 | 1329 | 336 (25%) | **0** | **1.0000** |
| fed_fomc | 30 | 379 | 38 (10%) | **0** | **1.0000** |
| irs_forms | 25 | 92 | 0 (0%) | **0** | **1.0000** |
| **total** | **415** | **4391** | **641 (15%)** | **0** | **1.0000** |

Per-page gate decisions (`plain_text` is the skip; everything else runs the model):

| corpus | `plain_text` | `table_grid` | `graphics_heavy` | `multi_column` | `ruled_lines` | `form_widgets` | `no_text_layer` | `sparse_text` |
|---|---|---|---|---|---|---|---|---|
| test_documents | 78 | 182 | 145 | 15 | 30 | | 39 | 19 |
| arxiv | 189 | 1242 | 232 | 195 | 214 | | 3 | 8 |
| govdocs1 | 336 | 431 | 397 | 46 | 25 | 2 | 44 | 48 |
| fed_fomc | 38 | 333 | 8 | | | | | |
| irs_forms | | 1 | | 7 | 4 | 80 | | |

Forms select on widgets. FOMC minutes are table-dense, so the recall bias runs the model on **90%** of their pages. arXiv selects on tables, columns, and figures.

Cost per arm (CPU-bound, 26-CPU container, batch mode):

| corpus | off ms/pg | auto ms/pg | always ms/pg | auto saves |
|---|---|---|---|---|
| govdocs1 | 20.3 | 309.7 | 361.8 | **14.4%** |
| test_documents | 18.3 | 369.6 | 423.9 | **12.8%** |
| arxiv | 29.2 | 321.8 | 341.7 | **5.8%** |
| fed_fomc | 19.9 | 358.0 | 357.7 | ~0% |
| irs_forms | 37.6 | 372.7 | 369.9 | ~0% |

These corpora were picked to stress the gate with structure, so savings are modest by design. The deployment case in #1322 (born-digital, **~94%** single-column) is where the every-page model cost dominates and `auto` pays off.

## The ingest itself

Some numbers from the validation run, because they turned out to be fun.

What the pod claimed vs what it was:

| advertised | actual |
|---|---|
| **252** cores, **944 GB** RAM | cgroup quota **26.35 CPUs** |
| 1x A100-80GB | idle (`ort` is built without the CUDA execution provider) |

`xberg batch` vs one `xberg extract` process per document, same documents, `always` arm:

| invocation | ms/page | ONNX session loads |
|---|---|---|
| one process per document | **~1,400** | 2 per document |
| `batch`, 50-file chunks | **~360** | 2 per chunk |

About **three quarters** of the per-document CLI cost was model loading, not inference.

Wall clock for all 415 docs, three arms each:

| corpus | wall |
|---|---|
| arxiv | 1406s |
| govdocs1 | 909s |
| test_documents | 463s |
| fed_fomc | 273s |
| irs_forms | 70s |
| **total** | **52 min** |

The run doubles as an end-to-end demo: every document went through `--layout-strategy auto` and `always` in batch mode, exercising the gate, the audit metadata, and the CLI surface.

<details>
<summary>Everything used to produce the tables (harness, corpora, invocation)</summary>

Build and invocation on the pod (Ubuntu 24.04, glibc 2.39):

```bash
cargo build --release -p xberg-cli --no-default-features \
  --features core-cli,pdf-surface,layout-detection

for corpus in test_documents fed_fomc irs_forms arxiv govdocs1; do
  python3 harness.py --binary target/release/xberg --corpus "$corpus" \
    --n 150 --mode batch --workers 13 --max-threads 26
done
```

Documents over 40 pages were excluded by the cheap layout-off arm before the model arms ran. GovDocs1 came from bulk zipfiles 000-002 (direct S3), arXiv from the export mirror, IRS and Federal Reserve from their canonical URLs, and test_documents is this repo's fixture submodule.

`harness.py`:

```python
#!/usr/bin/env python3
"""A/B validation harness for xberg LayoutStrategy::Auto (upstream PR #1325).

Three arms per document, all through the xberg CLI:
  A  --layout --layout-strategy always --use-layout-for-markdown
  B  --layout --layout-strategy auto   --use-layout-for-markdown
  C  (layout off)

Metrics per corpus:
  - ms/page per arm (wall clock around the CLI call, models pre-warmed)
  - gate pass rate (pages selected / total) from B's metadata
  - B-vs-A output similarity, whole doc and per page
  - skipped-page QA: for every page B's gate skipped (metadata
    layout_gated_pages), diff that page's text between B and A. A is the
    forced-layout run, so any above-threshold delta is a false negative,
    recorded with the gate's stated reason for auditing.

Usage:
  python3 harness.py --binary /path/to/xberg --corpus arxiv --n 10
  python3 harness.py --binary /path/to/xberg --corpus all --n 500  (pod)

Outputs results/<corpus>.jsonl (per doc) and prints a summary table.
"""

from __future__ import annotations

import argparse
import concurrent.futures
import difflib
import functools
import json
import subprocess
import sys
import time
import urllib.request
from pathlib import Path

import corpora

FETCH_RETRIES = 3
SIMILARITY_FN_THRESHOLD = 0.98  # below this, a skipped page counts as a false negative
MAX_PAGES_PER_DOC = 40  # skip pathological documents in sampled runs


def fetch(url: str, dest: Path) -> bool:
    for attempt in range(FETCH_RETRIES):
        try:
            request = urllib.request.Request(url, headers={"User-Agent": corpora.USER_AGENT})
            with urllib.request.urlopen(request, timeout=120) as response:
                data = response.read()
            if not data.startswith(b"%PDF"):
                return False
            dest.write_bytes(data)
            return True
        except Exception:
            if attempt == FETCH_RETRIES - 1:
                return False
            time.sleep(2 * (attempt + 1))
    return False


MAX_THREADS_PER_PROCESS = 0  # set from --max-threads; 0 = leave CLI default


def _set_max_threads(value: int) -> None:
    global MAX_THREADS_PER_PROCESS
    MAX_THREADS_PER_PROCESS = value


def run_arm(binary: str, pdf: Path, arm: str) -> tuple[float, dict] | None:
    args = [binary, "extract", str(pdf), "--format", "json", "--extract-pages", "true"]
    if MAX_THREADS_PER_PROCESS:
        args += ["--max-threads", str(MAX_THREADS_PER_PROCESS)]
    if arm == "always":
        args += ["--layout", "--layout-strategy", "always", "--use-layout-for-markdown"]
    elif arm == "auto":
        args += ["--layout", "--layout-strategy", "auto", "--use-layout-for-markdown"]
    started = time.perf_counter()
    proc = subprocess.run(args, capture_output=True, text=True, timeout=1800)
    elapsed_ms = (time.perf_counter() - started) * 1000.0
    if proc.returncode != 0:
        return None
    try:
        return elapsed_ms, json.loads(proc.stdout)
    except json.JSONDecodeError:
        return None


def find_key(obj, key):
    if isinstance(obj, dict):
        if key in obj:
            return obj[key]
        for value in obj.values():
            hit = find_key(value, key)
            if hit is not None:
                return hit
    elif isinstance(obj, list):
        for value in obj:
            hit = find_key(value, key)
            if hit is not None:
                return hit
    return None


def page_texts(result: dict) -> list[str]:
    pages = find_key(result, "pages")
    if isinstance(pages, list) and pages and isinstance(pages[0], dict):
        return [page.get("content") or page.get("text") or "" for page in pages]
    return []


SIMILARITY_MAX_CHARS = 40_000  # SequenceMatcher is quadratic; cap the diff window


def normalized(text: str) -> str:
    return "".join(text.split())


def similarity(a: str, b: str) -> float:
    left, right = normalized(a), normalized(b)
    if left == right:
        return 1.0
    return difflib.SequenceMatcher(
        None, left[:SIMILARITY_MAX_CHARS], right[:SIMILARITY_MAX_CHARS], autojunk=False
    ).ratio()


def evaluate_doc(binary: str, pdf: Path) -> dict | None:
    arms = {}
    for arm in ("off", "auto", "always"):
        run = run_arm(binary, pdf, arm)
        if run is None:
            return None
        arms[arm] = run

    _, auto_json = arms["auto"]
    _, always_json = arms["always"]
    gated = find_key(auto_json, "layout_gated_pages") or []
    reasons = find_key(auto_json, "layout_gate_reasons") or []
    auto_pages = page_texts(auto_json)
    always_pages = page_texts(always_json)
    page_count = max(len(auto_pages), len(always_pages), 1)
    if page_count > MAX_PAGES_PER_DOC:
        return None

    false_negatives = []
    for page_number in gated:
        index = page_number - 1
        if index >= len(auto_pages) or index >= len(always_pages):
            continue
        score = similarity(auto_pages[index], always_pages[index])
        if score < SIMILARITY_FN_THRESHOLD:
            false_negatives.append(
                {
                    "page": page_number,
                    "similarity": round(score, 4),
                    "reason": reasons[index] if index < len(reasons) else "unknown",
                }
            )

    doc_similarity = similarity(
        find_key(auto_json, "content") or "", find_key(always_json, "content") or ""
    )
    return {
        "doc": pdf.stem,
        "pages": page_count,
        "ms_per_page": {arm: round(arms[arm][0] / page_count, 1) for arm in arms},
        "gated_pages": len(gated),
        "gate_reasons": reasons,
        "auto_vs_always_similarity": round(doc_similarity, 4),
        "false_negatives": false_negatives,
    }


def build_row(
    doc: str,
    ms_by_arm: dict[str, float],
    auto_result: dict,
    always_result: dict,
) -> dict:
    gated = find_key(auto_result, "layout_gated_pages") or []
    reasons = find_key(auto_result, "layout_gate_reasons") or []
    auto_pages = page_texts(auto_result)
    always_pages = page_texts(always_result)
    page_count = max(len(auto_pages), len(always_pages), 1)

    false_negatives = []
    for page_number in gated:
        index = page_number - 1
        if index >= len(auto_pages) or index >= len(always_pages):
            continue
        score = similarity(auto_pages[index], always_pages[index])
        if score < SIMILARITY_FN_THRESHOLD:
            false_negatives.append(
                {
                    "page": page_number,
                    "similarity": round(score, 4),
                    "reason": reasons[index] if index < len(reasons) else "unknown",
                }
            )

    doc_similarity = similarity(
        find_key(auto_result, "content") or "", find_key(always_result, "content") or ""
    )
    return {
        "doc": doc,
        "pages": page_count,
        "ms_per_page": {arm: round(ms / page_count, 1) for arm, ms in ms_by_arm.items()},
        "gated_pages": len(gated),
        "gate_reasons": reasons,
        "auto_vs_always_similarity": round(doc_similarity, 4),
        "false_negatives": false_negatives,
    }


BATCH_CHUNK = 50  # files per batch invocation: bounds order-mismatch blast radius


def run_batch(
    binary: str, pdfs: list[Path], arm: str, concurrent: int
) -> tuple[list[float], list[dict], float] | None:
    """One `xberg batch` invocation over `pdfs`; results align with input order."""
    args = [binary, "batch", *[str(p) for p in pdfs], "--format", "json", "--extract-pages", "true"]
    args += ["--max-concurrent", str(concurrent)]
    if MAX_THREADS_PER_PROCESS:
        args += ["--max-threads", str(MAX_THREADS_PER_PROCESS)]
    if arm in ("auto", "always"):
        args += ["--layout", "--layout-strategy", arm, "--use-layout-for-markdown"]
    started = time.perf_counter()
    proc = subprocess.run(args, capture_output=True, text=True, timeout=7200)
    wall_ms = (time.perf_counter() - started) * 1000.0
    if proc.returncode != 0:
        return None
    try:
        data = json.loads(proc.stdout)
    except json.JSONDecodeError:
        return None
    results = data.get("results") or []
    if len(results) != len(pdfs):
        print(f"batch arm={arm}: {len(results)} results for {len(pdfs)} inputs; skipping chunk", file=sys.stderr)
        return None
    per_file_ms = data.get("per_file_ms") or [wall_ms / len(pdfs)] * len(pdfs)
    return per_file_ms, results, data.get("total_ms") or wall_ms


def evaluate_corpus_batch(
    binary: str, pdfs: list[Path], concurrent: int
) -> tuple[list[dict], dict[str, float]]:
    """Batch-mode evaluation: off arm first as a cheap page-count pre-filter,
    then layout arms over the surviving files. Returns rows and per-arm
    corpus wall-clock ms (extraction only, model loads amortized)."""
    rows: list[dict] = []
    wall_ms = {"off": 0.0, "auto": 0.0, "always": 0.0}
    for start in range(0, len(pdfs), BATCH_CHUNK):
        chunk = pdfs[start : start + BATCH_CHUNK]
        off = run_batch(binary, chunk, "off", concurrent)
        if off is None:
            continue
        off_ms, off_results, off_total = off
        wall_ms["off"] += off_total

        kept = [
            index
            for index, result in enumerate(off_results)
            if 1 <= len(page_texts(result)) <= MAX_PAGES_PER_DOC
        ]
        survivors = [chunk[index] for index in kept]
        if not survivors:
            continue

        auto = run_batch(binary, survivors, "auto", concurrent)
        always = run_batch(binary, survivors, "always", concurrent)
        if auto is None or always is None:
            continue
        auto_ms, auto_results, auto_total = auto
        always_ms, always_results, always_total = always
        wall_ms["auto"] += auto_total
        wall_ms["always"] += always_total

        for position, chunk_index in enumerate(kept):
            row = build_row(
                survivors[position].stem,
                {
                    "off": off_ms[chunk_index],
                    "auto": auto_ms[position],
                    "always": always_ms[position],
                },
                auto_results[position],
                always_results[position],
            )
            rows.append(row)
            fn_note = f" FN={len(row['false_negatives'])}" if row["false_negatives"] else ""
            print(f"  {row['doc']}: {row['pages']}p gated={row['gated_pages']}{fn_note}", file=sys.stderr)
    return rows, wall_ms


def summarize(corpus: str, rows: list[dict]) -> str:
    if not rows:
        return f"{corpus}: no documents evaluated"
    total_pages = sum(row["pages"] for row in rows)
    total_gated = sum(row["gated_pages"] for row in rows)
    total_fn = sum(len(row["false_negatives"]) for row in rows)
    mean = lambda arm: sum(row["ms_per_page"][arm] * row["pages"] for row in rows) / total_pages
    fn_rate = (total_fn / total_gated * 100) if total_gated else 0.0
    return (
        f"{corpus:<14} docs={len(rows):<4} pages={total_pages:<6} "
        f"off={mean('off'):7.1f} auto={mean('auto'):8.1f} always={mean('always'):8.1f} ms/pg  "
        f"gated={total_gated}/{total_pages} ({total_gated / total_pages * 100:.0f}%)  "
        f"FN={total_fn}/{total_gated or 1} ({fn_rate:.1f}%)"
    )


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--binary", required=True)
    parser.add_argument("--corpus", default="all", choices=[*corpora.CORPORA, "all"])
    parser.add_argument("--n", type=int, default=10)
    parser.add_argument("--workers", type=int, default=1)
    parser.add_argument("--max-threads", type=int, default=0, help="cap each extraction's internal thread pools")
    parser.add_argument("--mode", choices=["perdoc", "batch"], default="perdoc")
    parser.add_argument("--workdir", default="work")
    args = parser.parse_args()
    global MAX_THREADS_PER_PROCESS
    MAX_THREADS_PER_PROCESS = args.max_threads

    names = list(corpora.CORPORA) if args.corpus == "all" else [args.corpus]
    results_dir = Path("results")
    results_dir.mkdir(exist_ok=True)

    for name in names:
        workdir = Path(args.workdir) / name
        workdir.mkdir(parents=True, exist_ok=True)
        try:
            sample = corpora.CORPORA[name](args.n)
        except Exception as error:
            print(f"{name}: sampler failed ({error}); skipping corpus", file=sys.stderr)
            continue

        def materialize(entry):
            doc_id, source = entry
            if source.startswith("/") or source.startswith("~"):
                path = Path(source).expanduser()
                return path if path.is_file() else None
            pdf = workdir / f"{doc_id}.pdf"
            if pdf.exists() or fetch(source, pdf):
                return pdf
            return None

        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as fetch_pool:
            fetched = fetch_pool.map(materialize, sample)
        pdfs = [pdf for pdf in fetched if pdf is not None][: args.n]

        if args.mode == "batch":
            corpus_started = time.perf_counter()
            rows, wall_ms = evaluate_corpus_batch(args.binary, pdfs, args.workers)
            corpus_wall_s = time.perf_counter() - corpus_started
            wall_note = (
                f"{name} wall: total={corpus_wall_s:.0f}s "
                f"off={wall_ms['off'] / 1000:.0f}s auto={wall_ms['auto'] / 1000:.0f}s "
                f"always={wall_ms['always'] / 1000:.0f}s"
            )
        else:
            wall_note = ""
            rows = []
            # Processes, not threads: the page-diff QA is pure-Python CPU work
            # that would serialize on the GIL across a thread pool.
            with concurrent.futures.ProcessPoolExecutor(
                max_workers=args.workers,
                initializer=_set_max_threads,
                initargs=(args.max_threads,),
            ) as pool:
                for row in pool.map(functools.partial(evaluate_doc, args.binary), pdfs):
                    if row is None:
                        continue
                    rows.append(row)
                    fn_note = f" FN={len(row['false_negatives'])}" if row["false_negatives"] else ""
                    print(f"  {row['doc']}: {row['pages']}p gated={row['gated_pages']}{fn_note}", file=sys.stderr)
        (results_dir / f"{name}.jsonl").write_text("\n".join(json.dumps(row) for row in rows))
        print(summarize(name, rows), flush=True)
        if wall_note:
            print(wall_note, flush=True)


if __name__ == "__main__":
    main()

```

`corpora.py`:

```python
"""Corpus samplers for the LayoutStrategy::Auto A/B validation.

Every corpus is freely accessible with no API token:
  - remote samplers return (doc_id, https_url) pairs with direct PDF links,
  - local samplers return (doc_id, absolute_path) pairs over directories the
    pod bootstrap prepared (git clones, unzipped bulk archives).

Sample sizes are arguments so the same code runs a 5-doc local smoke and a
full pod run.
"""

from __future__ import annotations

import os
import random
from pathlib import Path

USER_AGENT = "xberg-layout-ab-validation (research; xberg-io/xberg issue 1322)"


def arxiv(n: int, seed: int = 7) -> list[tuple[str, str]]:
    """arXiv PDFs: multi-column scientific text, formulas, figures.

    Deterministic sample of IDs across months; invalid IDs 404 and are
    skipped by the fetcher, so oversample.
    """
    rng = random.Random(seed)
    months = ["2401", "2306", "2211", "2109", "2005", "1901", "1706"]
    pairs = []
    for _ in range(n * 2):
        month = rng.choice(months)
        number = rng.randint(1, 9999)
        arxiv_id = f"{month}.{number:05d}"
        pairs.append((f"arxiv_{arxiv_id}", f"https://export.arxiv.org/pdf/{arxiv_id}"))
    return pairs


def irs_forms(n: int, seed: int = 7) -> list[tuple[str, str]]:
    """IRS fillable forms: widget annotations, ruled grids."""
    forms = [
        "f1040", "f1040s1", "f1040s2", "f1040s3", "fw9", "fw4", "f941",
        "f1065", "f1120", "f4868", "f8949", "f2848", "f709", "f990",
        "f5471", "f6251", "f8283", "f8606", "f8863", "f4562", "f8829",
        "f2441", "f5695", "f8917", "f3903",
    ]
    return [(f"irs_{name}", f"https://www.irs.gov/pub/irs-pdf/{name}.pdf") for name in forms[:n]]


def fed_fomc(n: int, seed: int = 7) -> list[tuple[str, str]]:
    """Federal Reserve FOMC minutes: single-column prose with embedded
    financial tables; US government work, predictable date URLs."""
    dates = [
        "20240131", "20240320", "20240501", "20240612", "20240731", "20240918",
        "20231213", "20231101", "20230920", "20230726", "20230614", "20230503",
        "20230322", "20230201", "20221214", "20221102", "20220921", "20220727",
        "20220615", "20220504", "20220316", "20220126", "20211215", "20211103",
        "20210922", "20210728", "20210616", "20210428", "20210317", "20210127",
    ]
    return [
        (f"fomc_{date}", f"https://www.federalreserve.gov/monetarypolicy/files/fomcminutes{date}.pdf")
        for date in dates[:n]
    ]


def _local_dir(env_var: str, default: str, prefix: str, n: int, seed: int = 7) -> list[tuple[str, str]]:
    root = Path(os.environ.get(env_var, default)).expanduser()
    if not root.is_dir():
        raise FileNotFoundError(f"{env_var} directory not found: {root}")
    pdfs = sorted(root.rglob("*.pdf"))
    rng = random.Random(seed)
    rng.shuffle(pdfs)
    return [(f"{prefix}_{path.stem[:48]}", str(path)) for path in pdfs[:n]]


def test_documents(n: int, seed: int = 7) -> list[tuple[str, str]]:
    """xberg's curated test_documents corpus (pdf/ + pdf_scanned/ + more).

    Set XBERG_TEST_DOCS to the checkout root; defaults to the local worktree.
    """
    return _local_dir(
        "XBERG_TEST_DOCS",
        "~/projects/kreuzberg-layout-auto/test_documents",
        "xtd",
        n,
        seed,
    )


def govdocs1(n: int, seed: int = 7) -> list[tuple[str, str]]:
    """GovDocs1 PDFs extracted from bulk zipfiles (see pod bootstrap).

    Set GOVDOCS_DIR to the directory holding the unzipped files.
    """
    return _local_dir("GOVDOCS_DIR", "work/govdocs1_bulk", "govdocs", n, seed)


def doclaynet(n: int, seed: int = 7) -> list[tuple[str, str]]:
    """DocLayNet-extra page PDFs (optional; ~7.5 GB bulk download on the pod).

    Set DOCLAYNET_DIR to the extracted PDF directory.
    """
    return _local_dir("DOCLAYNET_DIR", "work/doclaynet/PDF", "dln", n, seed)


CORPORA = {
    "arxiv": arxiv,
    "irs_forms": irs_forms,
    "fed_fomc": fed_fomc,
    "test_documents": test_documents,
    "govdocs1": govdocs1,
    "doclaynet": doclaynet,
}

```

</details>

Bindings are intentionally untouched. The new field and metadata flow through generated bindings on regeneration.
