### PR TITLE
fix: CI Rust jobs no longer pass when a cargo test leg fails

### DIFF
--- a/scripts/ci/rust/run-unit-tests.sh
+++ b/scripts/ci/rust/run-unit-tests.sh
@@ -58,13 +58,17 @@ echo "=== Starting cargo test ==="
 # NOTE: We intentionally avoid `--all-features` for the `xberg` crate because
 TEST_LOG="/tmp/cargo-test-$$.log"
 
+# ~keep The whole `{ ... } | tee` pipeline is the `if` condition, where `set -e`
+# ~keep is suspended (bash suppresses errexit for every command in an `if` test),
+# ~keep so the block's status is the LAST leg's. Each leg needs `|| exit` to stop
+# ~keep the block and surface its own failure; pipefail carries it past `tee`.
 if ! {
   # ~keep `--all-targets` runs --lib --bins --tests --examples --benches but excludes
   # ~keep `--doc`. The xberg crate still has rustdoc examples for private/internal
   # ~keep APIs; `cargo test -p xberg --features full --doc` currently fails those
   # ~keep examples because rustdoc compiles them as an external crate.
   echo "=== cargo test -p xberg --features full ==="
-  RUST_BACKTRACE=full cargo test --locked -p xberg --features full --all-targets --verbose
+  RUST_BACKTRACE=full cargo test --locked -p xberg --features full --all-targets --verbose || exit
 
   echo "=== cargo test --workspace (all features, excluding xberg) ==="
   extra_excludes=()
@@ -90,7 +94,7 @@ if ! {
     ${extra_excludes[@]+"${extra_excludes[@]}"} \
     --all-features \
     --all-targets \
-    --verbose
+    --verbose || exit
 
   echo "=== cargo test -p xberg-gliner (explicit features) ==="
   # cuda/metal cannot build on CPU-only runners, so xberg-gliner gets an
@@ -107,7 +111,7 @@ if ! {
   fi
   RUST_BACKTRACE=full cargo test --locked -p xberg-gliner \
     ${gliner_features[@]+"${gliner_features[@]}"} \
-    --all-targets --verbose
+    --all-targets --verbose || exit
 } 2>&1 | tee "$TEST_LOG"; then
   echo "=== Test execution failed ==="
   echo "Last 50 lines of test output:"


### PR DESCRIPTION
## Problem

CI Rust jobs stay green when `cargo test` legs fail (#1327). Run 30303798636 passed while the xberg leg died at link on ubuntu-arm and aborted mid-suite on macos.

## Root cause

`run-unit-tests.sh` wraps the three legs in `if ! { leg1; leg2; leg3; } | tee`. The whole pipeline is the `if` condition, where bash suspends `set -e`, so a failed leg doesn't stop the block and the block's exit status is only the last leg's (xberg-gliner).

## Fix

`|| exit` on each leg: the block stops at the first failing leg and `pipefail` carries its status past `tee`. Fail-fast, so later legs are skipped once one fails.

## Validation

Ran the script with a `cargo` shim that fails at the Nth `test` invocation:

- old script, leg 1 fails: exit 0, all legs ran, prints `=== Tests complete ===` — the masking
- fixed, leg 1 / 2 / 3 fails: exit 1 at that leg, diagnostics branch fires
- fixed, all pass: exit 0

`bash -n` clean; shellcheck reports nothing new (SC2054 on the gliner features array is pre-existing).

Would you rather keep one-run-full-signal (run all legs, fail at the end)? I can switch.
