### PR TITLE
test: point remaining suites at pdf/ fixture directory

### DIFF
--- a/crates/xberg/tests/batch_orchestration.rs
+++ b/crates/xberg/tests/batch_orchestration.rs
@@ -205,13 +205,13 @@ async fn test_batch_documents_preserves_order() {
 async fn test_multipage_pdf_extraction() {
     use helpers::{get_test_file_path, skip_if_missing};
 
-    if skip_if_missing("pdfs/multi_page.pdf") {
+    if skip_if_missing("pdf/multi_page.pdf") {
         tracing::debug!("Skipping multi-page PDF test: test file not available");
         return;
     }
 
     let config = ExtractionConfig::default();
-    let pdf_path = get_test_file_path("pdfs/multi_page.pdf");
+    let pdf_path = get_test_file_path("pdf/multi_page.pdf");
 
     let start = Instant::now();
     let result = helpers::extract_uri_document(&pdf_path, None, &config).await;
@@ -230,7 +230,7 @@ async fn test_multipage_pdf_extraction() {
 async fn test_concurrent_pdf_extractions() {
     use helpers::{get_test_file_path, skip_if_missing};
 
-    if skip_if_missing("pdfs/simple.pdf") {
+    if skip_if_missing("pdf/simple.pdf") {
         tracing::debug!("Skipping concurrent PDF test: test file not available");
         return;
     }
@@ -240,7 +240,7 @@ async fn test_concurrent_pdf_extractions() {
     let mut paths: Vec<UriBatchInput> = Vec::new();
     for _ in 0..10 {
         paths.push(UriBatchInput {
-            path: get_test_file_path("pdfs/simple.pdf"),
+            path: get_test_file_path("pdf/simple.pdf"),
             config: None,
         });
     }

--- a/crates/xberg/tests/batch_processing.rs
+++ b/crates/xberg/tests/batch_processing.rs
@@ -35,7 +35,7 @@ async fn test_batch_extract_file_multiple_formats() {
         return;
     }
 
-    if skip_if_missing("pdfs/fake_memo.pdf")
+    if skip_if_missing("pdf/fake_memo.pdf")
         || skip_if_missing("documents/fake.docx")
         || skip_if_missing("text/fake_text.txt")
     {
@@ -45,7 +45,7 @@ async fn test_batch_extract_file_multiple_formats() {
     let config = ExtractionConfig::default();
 
     let paths: Vec<UriBatchInput> = vec![
-        get_test_file_path("pdfs/fake_memo.pdf"),
+        get_test_file_path("pdf/fake_memo.pdf"),
         get_test_file_path("documents/fake.docx"),
         get_test_file_path("text/fake_text.txt"),
     ]
@@ -86,14 +86,14 @@ fn test_batch_extract_file_sync_variant() {
         return;
     }
 
-    if skip_if_missing("pdfs/fake_memo.pdf") || skip_if_missing("text/fake_text.txt") {
+    if skip_if_missing("pdf/fake_memo.pdf") || skip_if_missing("text/fake_text.txt") {
         return;
     }
 
     let config = ExtractionConfig::default();
 
     let paths: Vec<UriBatchInput> = vec![
-        get_test_file_path("pdfs/fake_memo.pdf"),
+        get_test_file_path("pdf/fake_memo.pdf"),
         get_test_file_path("text/fake_text.txt"),
     ]
     .into_iter()

--- a/crates/xberg/tests/ocr_quality.rs
+++ b/crates/xberg/tests/ocr_quality.rs
@@ -144,11 +144,11 @@ fn layout_delta(truth_lines: usize, ocr_lines: usize) -> f64 {
 
 #[test]
 fn test_ocr_quality_simple_text_high_accuracy() {
-    if skip_if_missing("pdfs/fake_memo.pdf") {
+    if skip_if_missing("pdf/fake_memo.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/fake_memo.pdf");
+    let file_path = get_test_file_path("pdf/fake_memo.pdf");
 
     let truth_result = extract_uri_document_blocking(&file_path, None, &ExtractionConfig::default())
         .expect("Should extract ground truth text");
@@ -218,11 +218,11 @@ fn test_ocr_quality_simple_text_high_accuracy() {
 
 #[test]
 fn test_ocr_quality_numeric_accuracy() {
-    if skip_if_missing("pdfs/embedded_images_tables.pdf") {
+    if skip_if_missing("pdf/embedded_images_tables.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/embedded_images_tables.pdf");
+    let file_path = get_test_file_path("pdf/embedded_images_tables.pdf");
 
     let truth_result = extract_uri_document_blocking(&file_path, None, &ExtractionConfig::default())
         .expect("Should extract ground truth text");
@@ -283,11 +283,11 @@ fn test_ocr_quality_numeric_accuracy() {
 
 #[test]
 fn test_ocr_quality_layout_preservation() {
-    if skip_if_missing("pdfs/fake_memo.pdf") {
+    if skip_if_missing("pdf/fake_memo.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/fake_memo.pdf");
+    let file_path = get_test_file_path("pdf/fake_memo.pdf");
 
     let truth_result = extract_uri_document_blocking(&file_path, None, &ExtractionConfig::default())
         .expect("Should extract ground truth text");
@@ -342,11 +342,11 @@ fn test_ocr_quality_layout_preservation() {
 
 #[test]
 fn test_ocr_quality_technical_document() {
-    if skip_if_missing("pdfs/code_and_formula.pdf") {
+    if skip_if_missing("pdf/code_and_formula.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/code_and_formula.pdf");
+    let file_path = get_test_file_path("pdf/code_and_formula.pdf");
 
     let truth_result = extract_uri_document_blocking(&file_path, None, &ExtractionConfig::default())
         .expect("Should extract ground truth text");
@@ -399,11 +399,11 @@ fn test_ocr_quality_technical_document() {
 
 #[test]
 fn test_ocr_consistency_across_runs() {
-    if skip_if_missing("pdfs/fake_memo.pdf") {
+    if skip_if_missing("pdf/fake_memo.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/fake_memo.pdf");
+    let file_path = get_test_file_path("pdf/fake_memo.pdf");
     let ocr_config = ExtractionConfig {
         ocr: Some(OcrConfig {
             backend: "tesseract".to_string(),
@@ -460,11 +460,11 @@ fn test_ocr_consistency_across_runs() {
 
 #[test]
 fn test_ocr_consistency_with_different_psm() {
-    if skip_if_missing("pdfs/fake_memo.pdf") {
+    if skip_if_missing("pdf/fake_memo.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/fake_memo.pdf");
+    let file_path = get_test_file_path("pdf/fake_memo.pdf");
 
     let config_psm3 = ExtractionConfig {
         ocr: Some(OcrConfig {
@@ -533,7 +533,7 @@ fn test_ocr_consistency_with_different_psm() {
 
 #[test]
 fn test_ocr_quality_multi_page_consistency() {
-    if skip_if_missing("pdfs/a_course_in_machine_learning_ciml_v0_9_all.pdf") {
+    if skip_if_missing("pdf/a_course_in_machine_learning_ciml_v0_9_all.pdf") {
         return;
     }
 
@@ -542,7 +542,7 @@ fn test_ocr_quality_multi_page_consistency() {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/a_course_in_machine_learning_ciml_v0_9_all.pdf");
+    let file_path = get_test_file_path("pdf/a_course_in_machine_learning_ciml_v0_9_all.pdf");
 
     let truth_result = extract_uri_document_blocking(&file_path, None, &ExtractionConfig::default())
         .expect("Should extract ground truth text");
@@ -597,11 +597,11 @@ fn test_ocr_quality_multi_page_consistency() {
 
 #[test]
 fn test_ocr_quality_with_tables() {
-    if skip_if_missing("pdfs/embedded_images_tables.pdf") {
+    if skip_if_missing("pdf/embedded_images_tables.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/embedded_images_tables.pdf");
+    let file_path = get_test_file_path("pdf/embedded_images_tables.pdf");
 
     let ocr_config = ExtractionConfig {
         ocr: Some(OcrConfig {

--- a/crates/xberg/tests/pdf_integration.rs
+++ b/crates/xberg/tests/pdf_integration.rs
@@ -36,11 +36,11 @@ fn test_corrupted_pdf_returns_error_not_panic() {
 
 #[test]
 fn test_pdf_password_protected_fails_gracefully() {
-    if skip_if_missing("pdfs/copy_protected.pdf") {
+    if skip_if_missing("pdf/copy_protected.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/copy_protected.pdf");
+    let file_path = get_test_file_path("pdf/copy_protected.pdf");
     let result = extract_uri_document_blocking(&file_path, None, &ExtractionConfig::default());
 
     match result {
@@ -68,11 +68,11 @@ fn test_pdf_password_protected_fails_gracefully() {
 
 #[test]
 fn test_pdf_password_protected_succeeds_with_correct_password() {
-    if skip_if_missing("pdfs/copy_protected.pdf") {
+    if skip_if_missing("pdf/copy_protected.pdf") {
         return;
     }
 
-    let file_path = get_test_file_path("pdfs/copy_protected.pdf");
+    let file_path = get_test_file_path("pdf/copy_protected.pdf");
 
     let config = ExtractionConfig {
         pdf_options: Some(PdfConfig {


### PR DESCRIPTION
## Problem

Four test suites (`ocr_quality`, `pdf_integration`, `batch_orchestration`, `batch_processing`) reference fixtures under `pdfs/`, but the test_documents directory is `pdf/`. Every fixture-backed test in them skips silently via `skip_if_missing` — 42 tests report pass without running (`ocr_quality` completes in 0.00s on main).

## Fix

Flip the 28 path references to `pdf/`. Every referenced file exists there; no fixture changes. The same issue in `page_markers.rs` is already fixed in #1330 (no file overlap).

## Validation

- `cargo test -p xberg --features full --test pdf_integration --test batch_orchestration --test batch_processing` — 32 pass
- `cargo test -p xberg --features full --test ocr_quality` — 10 pass, 21s (0.00s before, all skipped)
- `cargo fmt --all -- --check`, `git diff --check` clean
