### PR TITLE
fix(tests): build page-marker tests without feature-gated with_page

### DIFF
--- a/crates/xberg/src/core/pipeline/page_markers.rs
+++ b/crates/xberg/src/core/pipeline/page_markers.rs
@@ -69,6 +69,14 @@ mod tests {
         InternalElement::text(ElementKind::Paragraph, text, 0)
     }
 
+    // `InternalElement::with_page` is cfg-gated out of lean builds such as
+    // `--no-default-features --features layout-tract`. ~keep
+    fn paragraph_on_page(text: &str, page: u32) -> InternalElement {
+        let mut element = paragraph(text);
+        element.page = Some(page);
+        element
+    }
+
     #[test]
     fn converts_flat_marker_paragraphs_to_raw_blocks() {
         let mut doc = InternalDocument::new("pdf");
@@ -108,9 +116,9 @@ mod tests {
     #[test]
     fn uses_element_page_numbers_when_present() {
         let mut doc = InternalDocument::new("pdf");
-        doc.push_element(paragraph("Page three text.").with_page(3));
+        doc.push_element(paragraph_on_page("Page three text.", 3));
         doc.push_element(InternalElement::text(ElementKind::PageBreak, "", 0));
-        doc.push_element(paragraph("Page seven text.").with_page(7));
+        doc.push_element(paragraph_on_page("Page seven text.", 7));
 
         inject_page_marker_elements(&mut doc, DEFAULT_FORMAT);
 


### PR DESCRIPTION
## Problem

`cargo clippy --locked -p xberg --no-default-features --features "layout-tract" --all-targets -- -D warnings` fails on main (`ae07e17a6c`):

```
error[E0599]: no method named `with_page` found for struct `types::internal::InternalElement`
   --> crates/xberg/src/core/pipeline/page_markers.rs:111:56
```

Both `Rust (ubuntu-24.04-arm)` and `Rust (macos-latest)` are red on main at the `Clippy no-ORT tract layout` step (run 30340446151).

## Root cause

`InternalElement::with_page` is `#[cfg(any(ocr, office, pdf, paddle-ocr, xml, hwpx, quality, chunking))]`; `layout-tract` matches none of them. The page-marker unit tests added in #1330 live in an ungated module and call it. #1330 was merged with no check runs on its head, so this never appeared on the PR.

## Fix

A local test helper sets the public `page` field instead. Test code only; no change to the cfg gate and no production code touched.

## Validation

- `cargo clippy --locked -p xberg --no-default-features --features "layout-tract" --all-targets -- -D warnings` — reproduces the failure before the change, clean after
- `cargo clippy --locked -p xberg --no-default-features --features "ocr,auto-rotate-tract" --all-targets -- -D warnings`
- `cargo check --locked -p xberg --no-default-features`
- `cargo test --locked -p xberg --no-default-features --features layout-tract --lib page_markers` — 7 pass; same suite under `--features full` — 9 pass
- `cargo fmt --all -- --check`, `poly hooks run pre-commit`

No CHANGELOG entry: no user-visible behavior change, matching #1329 and #1331.
