### PR TITLE
helm: add ingress.extraLabels

### DIFF
--- a/charts/xberg/README.md
+++ b/charts/xberg/README.md
@@ -32,7 +32,9 @@ Values are validated against `values.schema.json`. Common keys:
 | `image.tag`          | `""`               | Defaults to the chart `appVersion`.                     |
 | `service.type`       | `ClusterIP`        | Service type.                                            |
 | `service.port`       | `80`               | Service port.                                            |
-| `ingress.enabled`    | `false`            | Enable Ingress.                                          |
+| `ingress.enabled`     | `false`            | Enable Ingress.                                          |
+| `ingress.extraLabels` | `{}`               | Extra labels on the Ingress resource.                    |
+| `ingress.annotations` | `{}`               | Annotations on the Ingress resource.                     |
 | `resources`          | 512Mi/500m → 2Gi/2 | Container requests and limits.                           |
 | `autoscaling.enabled`| `false`            | Enable a HorizontalPodAutoscaler.                        |
 | `xberg.logLevel`     | `info`             | Log level: trace, debug, info, warn, error.             |

--- a/charts/xberg/templates/ingress.yaml
+++ b/charts/xberg/templates/ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "xberg.fullname" . }}
   labels:
     {{- include "xberg.labels" . | nindent 4 }}
+    {{- with .Values.ingress.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/xberg/values.schema.json
+++ b/charts/xberg/values.schema.json
@@ -66,6 +66,7 @@
       "properties": {
         "enabled": { "type": "boolean" },
         "className": { "type": "string" },
+        "extraLabels": { "type": "object" },
         "annotations": { "type": "object" },
         "hosts": { "type": "array" },
         "tls": { "type": "array" }

--- a/charts/xberg/values.yaml
+++ b/charts/xberg/values.yaml
@@ -68,6 +68,8 @@ ingress:
   enabled: false
   # -- Ingress class name (e.g. "nginx")
   className: ""
+  # -- Extra labels on the Ingress resource
+  extraLabels: {}
   # -- Ingress annotations
   annotations: {}
   # -- Ingress hosts


### PR DESCRIPTION
## Related

#1334 

## Description

This PR adds support for `ingress.extraLabels` to the Xberg Helm chart.

Changes:
- `values.yaml`: add `ingress.extraLabels: {}` with an empty default.
- `values.schema.json`: extend the `ingress` schema with `extraLabels` as an object.
- `templates/ingress.yaml`: append `.Values.ingress.extraLabels` to `metadata.labels` using `with`/`toYaml`, preserving standard Helm labels and keeping extra labels additive.
- `README.md`: document `ingress.extraLabels` (and `ingress.annotations`) in the configuration table.

Example usage:

```yaml
ingress:
  enabled: true
  extraLabels:
    router: public
    environment: production
Rendered snippet:
metadata:
  labels:
    app.kubernetes.io/name: xberg
    helm.sh/chart: xberg-1.0.0-rc.25
    router: public
    environment: production
Validation:
- helm lint charts/xberg passes.
- helm template with ingress.enabled=true and sample ingress.extraLabels shows the expected labels on the Ingress resource.

## Checklist

- [x] CI passing
- [x] Tests added where applicable
