### PR TITLE
fix(paddle-ocr): warn when requested languages exceed the selected model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **#1346**: PaddleOCR emits a `ProcessingWarning` when requested languages are not covered by
+  the single selected recognition model (previously their text was silently dropped), and OCR
+  metadata now reports the recognition model actually used instead of joining every requested
+  language.
+
 ## [1.0.4] - 2026-07-30
 
 ### Added

--- a/crates/xberg/src/extractors/pdf/ocr.rs
+++ b/crates/xberg/src/extractors/pdf/ocr.rs
@@ -597,6 +597,26 @@ fn render_selected_pages_from_document(
     Ok(images)
 }
 
+/// Accumulate per-page backend warnings without repeating identical entries.
+///
+/// A backend that warns about its configuration (e.g. paddle-ocr's unsupported
+/// language warning) emits the same warning on every page; one copy per
+/// document is enough.
+#[cfg(all(any(feature = "ocr", feature = "ocr-pipeline"), feature = "pdf"))]
+fn extend_warnings_deduped(
+    accumulated: &mut Vec<crate::types::ProcessingWarning>,
+    new: Vec<crate::types::ProcessingWarning>,
+) {
+    for warning in new {
+        if !accumulated
+            .iter()
+            .any(|w| w.source == warning.source && w.message == warning.message)
+        {
+            accumulated.push(warning);
+        }
+    }
+}
+
 /// Build mixed text from native extraction and per-page OCR results.
 ///
 /// For each page boundary, if the page is in `ocr_page_numbers` (1-indexed),
@@ -760,7 +780,7 @@ pub(crate) async fn extract_mixed_ocr_native(
                     let (text, _tables, _elements, doc, usage, page_texts, _rasters, formulas) = result?;
                     accumulated_llm_usage.extend(usage);
                     if let Some(d) = doc {
-                        accumulated_warnings.extend(d.processing_warnings);
+                        extend_warnings_deduped(&mut accumulated_warnings, d.processing_warnings);
                     }
                     for mut formula in formulas {
                         formula.page = (page_idx + 1) as u32;
@@ -791,7 +811,7 @@ pub(crate) async fn extract_mixed_ocr_native(
                         .await?;
                     accumulated_llm_usage.extend(usage);
                     if let Some(d) = doc {
-                        accumulated_warnings.extend(d.processing_warnings);
+                        extend_warnings_deduped(&mut accumulated_warnings, d.processing_warnings);
                     }
                     for mut formula in formulas {
                         formula.page = (*page_idx + 1) as u32;
@@ -2592,6 +2612,24 @@ fn inject_layout_config_to_backend(
 #[cfg(all(test, feature = "ocr"))]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "pdf")]
+    #[test]
+    fn test_extend_warnings_deduped_drops_identical_keeps_distinct() {
+        use std::borrow::Cow;
+
+        let warning = |msg: &str| crate::types::ProcessingWarning {
+            source: Cow::Borrowed("paddle-ocr"),
+            message: Cow::Owned(msg.to_string()),
+        };
+
+        let mut accumulated = vec![warning("a")];
+        extend_warnings_deduped(&mut accumulated, vec![warning("a"), warning("b")]);
+        extend_warnings_deduped(&mut accumulated, vec![warning("a"), warning("b")]);
+
+        let messages: Vec<&str> = accumulated.iter().map(|w| w.message.as_ref()).collect();
+        assert_eq!(messages, vec!["a", "b"]);
+    }
 
     #[cfg(feature = "ocr")]
     fn t() -> OcrQualityThresholds {

--- a/crates/xberg/src/paddle_ocr/backend.rs
+++ b/crates/xberg/src/paddle_ocr/backend.rs
@@ -450,8 +450,7 @@ impl OcrBackend for PaddleOcrBackend {
         };
 
         let languages = config.effective_languages();
-        let primary_lang = languages[0].as_str();
-        let paddle_lang = map_language_code(primary_lang).unwrap_or("en");
+        let (paddle_lang, language_warnings) = super::select_paddle_language(&languages);
 
         let ocr_image_bytes: std::borrow::Cow<'_, [u8]> = if config.auto_rotate {
             match self.detect_and_rotate(image_bytes) {
@@ -547,7 +546,7 @@ impl OcrBackend for PaddleOcrBackend {
 
         let metadata = Metadata {
             format: Some(FormatMetadata::Ocr(OcrMetadata {
-                language: config.effective_languages().join("+"),
+                language: paddle_lang.to_string(),
                 psm: 3,
                 output_format: "text".to_string(),
                 table_count,
@@ -570,9 +569,10 @@ impl OcrBackend for PaddleOcrBackend {
             mime_type: Cow::Borrowed("text/plain"),
             metadata,
             tables,
-            detected_languages: Some(config.effective_languages()),
+            detected_languages: Some(languages),
             ocr_elements: ocr_elements_opt,
             ocr_internal_document: Some(ocr_doc),
+            processing_warnings: language_warnings,
             ..Default::default()
         })
     }

--- a/crates/xberg/src/paddle_ocr/mod.rs
+++ b/crates/xberg/src/paddle_ocr/mod.rs
@@ -146,3 +146,106 @@ pub(crate) fn map_language_code(xberg_code: &str) -> Option<&'static str> {
         _ => None,
     }
 }
+
+/// Select the PaddleOCR recognition language for a request and report what the
+/// selection cannot cover.
+///
+/// PaddleOCR loads one recognition model per call, chosen from the first
+/// requested language. Any additional language whose script family the selected
+/// model does not cover will not be recognized, so a `ProcessingWarning` is
+/// emitted instead of silently dropping its text (#1346). An unmapped first
+/// language falls back to the English model, also with a warning.
+#[cfg(feature = "paddle-ocr")]
+pub(crate) fn select_paddle_language(languages: &[String]) -> (&'static str, Vec<crate::types::ProcessingWarning>) {
+    use std::borrow::Cow;
+
+    let mut warnings = Vec::new();
+    let primary = languages.first().map(String::as_str).unwrap_or("eng");
+    let paddle_lang = match map_language_code(primary) {
+        Some(code) => code,
+        None => {
+            warnings.push(crate::types::ProcessingWarning {
+                source: Cow::Borrowed("paddle-ocr"),
+                message: Cow::Owned(format!(
+                    "requested language '{primary}' is not supported by paddle-ocr; falling back to the 'en' recognition model"
+                )),
+            });
+            "en"
+        }
+    };
+
+    let family = language_to_script_family(paddle_lang);
+    let uncovered: Vec<&str> = languages
+        .iter()
+        .skip(1)
+        .map(String::as_str)
+        .filter(|lang| map_language_code(lang).is_none_or(|code| language_to_script_family(code) != family))
+        .collect();
+
+    if !uncovered.is_empty() {
+        warnings.push(crate::types::ProcessingWarning {
+            source: Cow::Borrowed("paddle-ocr"),
+            message: Cow::Owned(format!(
+                "paddle-ocr uses a single recognition model per run; requested languages [{}] are not covered by the selected '{paddle_lang}' model and their text may be dropped",
+                uncovered.join(", ")
+            )),
+        });
+    }
+
+    (paddle_lang, warnings)
+}
+
+#[cfg(all(test, feature = "paddle-ocr"))]
+mod language_selection_tests {
+    use super::select_paddle_language;
+
+    fn langs(codes: &[&str]) -> Vec<String> {
+        codes.iter().map(|c| c.to_string()).collect()
+    }
+
+    #[test]
+    fn test_single_language_no_warnings() {
+        let (lang, warnings) = select_paddle_language(&langs(&["rus"]));
+        assert_eq!(lang, "cyrillic");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_same_family_languages_no_warnings() {
+        let (lang, warnings) = select_paddle_language(&langs(&["fra", "deu", "spa"]));
+        assert_eq!(lang, "french");
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_cross_family_language_warns() {
+        let (lang, warnings) = select_paddle_language(&langs(&["eng", "rus"]));
+        assert_eq!(lang, "en");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("rus"));
+        assert!(warnings[0].message.contains("'en'"));
+    }
+
+    #[test]
+    fn test_unmapped_primary_falls_back_with_warning() {
+        let (lang, warnings) = select_paddle_language(&langs(&["xyz"]));
+        assert_eq!(lang, "en");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("xyz"));
+    }
+
+    #[test]
+    fn test_unmapped_secondary_warns() {
+        let (lang, warnings) = select_paddle_language(&langs(&["eng", "xyz"]));
+        assert_eq!(lang, "en");
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].message.contains("xyz"));
+    }
+
+    #[test]
+    fn test_empty_list_defaults_to_english() {
+        let (lang, warnings) = select_paddle_language(&[]);
+        assert_eq!(lang, "en");
+        assert!(warnings.is_empty());
+    }
+}

--- a/crates/xberg/tests/paddle_ocr_integration.rs
+++ b/crates/xberg/tests/paddle_ocr_integration.rs
@@ -125,6 +125,53 @@ async fn test_ocr_hello_world_english() {
     );
 }
 
+/// Requested languages the selected recognition model cannot cover must surface
+/// as a `ProcessingWarning` instead of silently dropping their text (#1346),
+/// and OCR metadata must report the model actually used rather than every
+/// requested language.
+#[tokio::test]
+#[ignore = "requires ONNX Runtime and downloaded models"]
+async fn test_ocr_uncovered_language_emits_warning() {
+    let image_path = test_documents_dir().join("images/test_hello_world.png");
+    assert!(image_path.exists(), "Test image not found: {:?}", image_path);
+
+    let image_bytes = std::fs::read(&image_path).expect("Failed to read image");
+
+    let config = PaddleOcrConfig::new("en").with_cache_dir(test_cache_dir());
+    let backend = PaddleOcrBackend::with_config(config).expect("Failed to create backend");
+
+    let ocr_config = OcrConfig {
+        backend: "paddle-ocr".to_string(),
+        language: vec!["en".to_string(), "ru".to_string()],
+        ..Default::default()
+    };
+
+    let extraction: ExtractedDocument = backend
+        .process_image(&image_bytes, &ocr_config)
+        .await
+        .expect("OCR failed");
+
+    assert_eq!(
+        extraction.processing_warnings.len(),
+        1,
+        "expected one uncovered-language warning, got: {:?}",
+        extraction.processing_warnings
+    );
+    let warning = &extraction.processing_warnings[0];
+    assert_eq!(warning.source, "paddle-ocr");
+    assert!(
+        warning.message.contains("[ru]") && warning.message.contains("'en'"),
+        "warning should name the uncovered language and the selected model: {}",
+        warning.message
+    );
+
+    let language = match &extraction.metadata.format {
+        Some(xberg::types::FormatMetadata::Ocr(ocr)) => ocr.language.clone(),
+        other => panic!("expected OCR metadata, got: {:?}", other),
+    };
+    assert_eq!(language, "en", "metadata must report the model actually used");
+}
+
 /// Test PP-OCRv6 recognition on English across all three v6 tiers.
 ///
 /// v6 routes English (a v6-unified family) to the unified recognition model at the


### PR DESCRIPTION
## Problem

`language=['en','ru']` on a mixed Cyrillic/Latin scan returns Latin-only output — everything after the first list entry is silently ignored, and OCR metadata reports `eng+rus` as if both were applied (#1346).

## Root cause

`process_image` picks the recognition model from `effective_languages()[0]` only, unknown codes silently fall back to the English model, and the metadata field joins the full requested list regardless of what ran.

## Fix

- `select_paddle_language` keeps the existing model choice but emits a `ProcessingWarning` naming requested languages the selected model's script family can't cover (`['fra','deu']` stays quiet, `['eng','rus']` warns), plus one for an unmapped first language falling back to `en`.
- Metadata now reports the model actually used.
- PDF per-page accumulation dedupes identical backend warnings, so an N-page doc gets one warning, not N.

Model selection itself is unchanged. Auto-picking a covering family (cyrillic reads Latin fine) would fix the common case for real — happy to do that as a follow-up if you want it, kept out here to stay a pure visibility fix.

## Validation

- `cargo test -p xberg --lib --features full paddle` — 69 pass (6 new selection + 1 dedup test)
- `cargo test -p xberg --features full --test paddle_ocr_integration test_ocr_uncovered_language_emits_warning -- --ignored` — pass against live models
- clippy `-D warnings`: `full`, `layout-tract`, `ocr,auto-rotate-tract`; `cargo check --no-default-features` (+ `ocr-wasm`); fmt clean

Fixes #1346
