### PR TITLE
fix(layout): use CPU for RT-DETR auto acceleration on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   language.
 - **#1344**: A hard layout-inference failure (for example a CoreML `ExecuteKernel` runtime error)
   now surfaces a `ProcessingWarning` instead of silently returning byte-identical no-layout output
-  with empty `processing_warnings`; the failure is also logged at `warn` level.
+  with empty `processing_warnings`; the failure is also logged at `warn` level. macOS auto
+  acceleration uses CPU for RT-DETR, whose current export fails under CoreML.
 
 ### Changed
 

--- a/crates/xberg/src/extractors/pdf/layout_runner.rs
+++ b/crates/xberg/src/extractors/pdf/layout_runner.rs
@@ -475,6 +475,15 @@ type LayoutForMarkdownOptional = (
     Option<crate::types::ProcessingWarning>,
 );
 
+pub(super) fn layout_failure_warning(error: &crate::XbergError) -> crate::types::ProcessingWarning {
+    crate::types::ProcessingWarning {
+        source: std::borrow::Cow::Borrowed("layout"),
+        message: std::borrow::Cow::Owned(format!(
+            "layout detection failed ({error}); document extracted without layout hints"
+        )),
+    }
+}
+
 #[cfg(all(feature = "pdf", feature = "layout-detection"))]
 pub(super) async fn maybe_run_layout_for_markdown(
     content: &[u8],
@@ -529,12 +538,7 @@ pub(super) async fn maybe_run_layout_for_markdown(
                 error = %e,
                 "layout-for-markdown: detection failed, continuing without layout hints"
             );
-            let warning = crate::types::ProcessingWarning {
-                source: std::borrow::Cow::Borrowed("layout"),
-                message: std::borrow::Cow::Owned(format!(
-                    "layout detection failed ({e}); document extracted without layout hints"
-                )),
-            };
+            let warning = layout_failure_warning(&e);
             (None, None, None, None, None, Some(warning))
         }
     }

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -328,9 +328,11 @@ async fn run_ocr_with_layout(
     Option<Vec<crate::types::ExtractedImage>>,
     Vec<crate::types::Formula>,
     OcrLayoutGateDecisions,
+    Option<crate::types::ProcessingWarning>,
 )> {
     let default_ocr_config = crate::core::config::OcrConfig::default();
     let ocr_config = config.ocr.as_ref().unwrap_or(&default_ocr_config);
+    let mut layout_warning = None;
 
     #[cfg(all(feature = "pdf", feature = "layout-detection"))]
     let mut ocr_layout_gate_decisions: OcrLayoutGateDecisions = (None, None);
@@ -362,6 +364,7 @@ async fn run_ocr_with_layout(
                         error = %error,
                         "OCR layout detection failed; continuing without layout assembly"
                     );
+                    layout_warning = Some(layout_runner::layout_failure_warning(&error));
                     None
                 }
             }
@@ -415,6 +418,7 @@ async fn run_ocr_with_layout(
             pipeline_rasters,
             pipeline_formulas,
             ocr_layout_gate_decisions,
+            layout_warning,
         ));
     }
 
@@ -441,6 +445,7 @@ async fn run_ocr_with_layout(
         ocr_rasters,
         formulas,
         ocr_layout_gate_decisions,
+        layout_warning,
     ))
 }
 
@@ -681,17 +686,30 @@ impl PdfExtractor {
         let (text, extraction_method) = if config.effective_disable_ocr() {
             (native_text, ExtractionMethod::Native)
         } else if config.force_ocr {
-            let (ocr_text, ocr_tbls, ocr_elems, ocr_doc, llm_usage, ocr_pts, ocr_rstrs, formulas, gate_audit) =
-                run_ocr_with_layout(
-                    content,
-                    config,
-                    path,
-                    #[cfg(feature = "layout-detection")]
-                    markdown_layout_images.take(),
-                    #[cfg(feature = "layout-detection")]
-                    markdown_layout_detections.take(),
-                )
-                .await?;
+            let (
+                ocr_text,
+                ocr_tbls,
+                ocr_elems,
+                ocr_doc,
+                llm_usage,
+                ocr_pts,
+                ocr_rstrs,
+                formulas,
+                gate_audit,
+                layout_warning,
+            ) = run_ocr_with_layout(
+                content,
+                config,
+                path,
+                #[cfg(feature = "layout-detection")]
+                markdown_layout_images.take(),
+                #[cfg(feature = "layout-detection")]
+                markdown_layout_detections.take(),
+            )
+            .await?;
+            if let Some(warning) = layout_warning {
+                crate::core::diagnostics::push_warning_deduped(&mut ocr_fallback_warnings, warning);
+            }
             ocr_layout_gate_audit = gate_audit;
             ocr_tables = ocr_tbls;
             ocr_elements = ocr_elems;
@@ -846,7 +864,11 @@ impl PdfExtractor {
                                 ocr_rstrs,
                                 formulas,
                                 gate_audit,
+                                layout_warning,
                             )) => {
+                                if let Some(warning) = layout_warning {
+                                    crate::core::diagnostics::push_warning_deduped(&mut ocr_fallback_warnings, warning);
+                                }
                                 ocr_layout_gate_audit = gate_audit;
                                 ocr_tables = ocr_tbls;
                                 ocr_elements = ocr_elems;

--- a/crates/xberg/src/extractors/pdf/mod.rs
+++ b/crates/xberg/src/extractors/pdf/mod.rs
@@ -332,7 +332,10 @@ async fn run_ocr_with_layout(
 )> {
     let default_ocr_config = crate::core::config::OcrConfig::default();
     let ocr_config = config.ocr.as_ref().unwrap_or(&default_ocr_config);
+    #[cfg(all(feature = "pdf", feature = "layout-detection"))]
     let mut layout_warning = None;
+    #[cfg(not(all(feature = "pdf", feature = "layout-detection")))]
+    let layout_warning = None;
 
     #[cfg(all(feature = "pdf", feature = "layout-detection"))]
     let mut ocr_layout_gate_decisions: OcrLayoutGateDecisions = (None, None);

--- a/crates/xberg/src/layout/models/rtdetr.rs
+++ b/crates/xberg/src/layout/models/rtdetr.rs
@@ -3,6 +3,9 @@ use std::time::Instant;
 use image::RgbImage;
 use ndarray::{Array, Array2, Array4};
 
+use crate::core::config::acceleration::AccelerationConfig;
+#[cfg(target_os = "macos")]
+use crate::core::config::acceleration::ExecutionProviderType;
 use crate::inference::{InferenceSession, InferenceTensor, default_backend};
 use crate::layout::error::LayoutError;
 use crate::layout::models::LayoutModel;
@@ -14,6 +17,19 @@ const DEFAULT_THRESHOLD: f32 = 0.3;
 
 /// RT-DETR input resolution.
 const INPUT_SIZE: u32 = 640;
+
+fn effective_acceleration(accel: Option<&AccelerationConfig>) -> Option<AccelerationConfig> {
+    // The current RT-DETR export fails under CoreML; keep auto reliable while preserving explicit CoreML.
+    #[cfg(target_os = "macos")]
+    if accel.is_none_or(|config| config.provider == ExecutionProviderType::Auto) {
+        return Some(AccelerationConfig {
+            provider: ExecutionProviderType::Cpu,
+            device_id: accel.map_or(0, |config| config.device_id),
+        });
+    }
+
+    accel.cloned()
+}
 
 /// Docling RT-DETR v2 layout detection model.
 ///
@@ -44,11 +60,12 @@ impl RtDetrModel {
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn from_file(
         path: &str,
-        accel: Option<&crate::core::config::acceleration::AccelerationConfig>,
+        accel: Option<&AccelerationConfig>,
         thread_budget: usize,
     ) -> Result<Self, LayoutError> {
+        let accel = effective_acceleration(accel);
         let session = default_backend()
-            .load_with_thread_budget(std::path::Path::new(path), accel, thread_budget)
+            .load_with_thread_budget(std::path::Path::new(path), accel.as_ref(), thread_budget)
             .map_err(|e| LayoutError::Inference(e.to_string()))?;
         let input_names: Vec<String> = session.input_names().to_vec();
         Ok(Self { session, input_names })
@@ -59,12 +76,10 @@ impl RtDetrModel {
     /// Used where there is no filesystem path to read from, e.g. WASM builds where
     /// the JS host fetches and hands over the model weights directly. Uses the same
     /// engine-neutral [`crate::inference`] seam as [`Self::from_file`].
-    pub(crate) fn from_bytes(
-        model_bytes: &[u8],
-        accel: Option<&crate::core::config::acceleration::AccelerationConfig>,
-    ) -> Result<Self, LayoutError> {
+    pub(crate) fn from_bytes(model_bytes: &[u8], accel: Option<&AccelerationConfig>) -> Result<Self, LayoutError> {
+        let accel = effective_acceleration(accel);
         let session = default_backend()
-            .load_from_memory(model_bytes, accel)
+            .load_from_memory(model_bytes, accel.as_ref())
             .map_err(|e| LayoutError::Inference(e.to_string()))?;
         let input_names: Vec<String> = session.input_names().to_vec();
         Ok(Self { session, input_names })
@@ -433,6 +448,10 @@ impl LayoutModel for RtDetrModel {
 #[cfg(test)]
 mod tests {
     use super::clamp_output_box;
+    #[cfg(target_os = "macos")]
+    use super::effective_acceleration;
+    #[cfg(target_os = "macos")]
+    use crate::core::config::acceleration::{AccelerationConfig, ExecutionProviderType};
 
     #[test]
     fn output_boxes_are_already_in_portrait_source_coordinates() {
@@ -446,5 +465,31 @@ mod tests {
         let bbox = clamp_output_box([-5.0, 32.0, 650.0, 340.0], 640, 320);
 
         assert_eq!([bbox.x1, bbox.y1, bbox.x2, bbox.y2], [0.0, 32.0, 640.0, 320.0]);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn rtdetr_auto_uses_cpu_but_explicit_coreml_is_preserved() {
+        assert_eq!(
+            effective_acceleration(None).expect("auto must resolve").provider,
+            ExecutionProviderType::Cpu
+        );
+
+        let automatic = AccelerationConfig {
+            provider: ExecutionProviderType::Auto,
+            device_id: 2,
+        };
+        let automatic = effective_acceleration(Some(&automatic)).expect("auto must resolve");
+        assert_eq!(automatic.provider, ExecutionProviderType::Cpu);
+        assert_eq!(automatic.device_id, 2);
+
+        let coreml = AccelerationConfig {
+            provider: ExecutionProviderType::CoreMl,
+            device_id: 0,
+        };
+        assert_eq!(
+            effective_acceleration(Some(&coreml)).expect("explicit CoreML must be preserved"),
+            coreml
+        );
     }
 }

--- a/crates/xberg/tests/layout_for_markdown.rs
+++ b/crates/xberg/tests/layout_for_markdown.rs
@@ -16,7 +16,27 @@ mod helpers;
 use helpers::extract_uri_document_blocking;
 
 use helpers::{get_test_file_path, test_documents_available};
+#[cfg(target_os = "macos")]
+use xberg::core::config::{AccelerationConfig, ExecutionProviderType};
 use xberg::core::config::{ExtractionConfig, OutputFormat, layout::LayoutDetectionConfig};
+
+#[cfg(target_os = "macos")]
+fn accelerated_layout(provider: ExecutionProviderType) -> LayoutDetectionConfig {
+    LayoutDetectionConfig {
+        acceleration: Some(AccelerationConfig {
+            provider,
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn has_layout_warning(warnings: &[xberg::types::ProcessingWarning]) -> bool {
+    warnings
+        .iter()
+        .any(|warning| warning.source == "layout" && warning.message.contains("layout detection failed"))
+}
 
 /// Extract `relative_path` (from `test_documents/`) with the given config.
 fn extract_md(relative_path: &str, config: &ExtractionConfig) -> String {
@@ -141,6 +161,81 @@ fn test_use_layout_for_markdown_preserves_native_headings() {
     assert_eq!(
         baseline_headings, layout_headings,
         "layout geometry must preserve native heading texts and levels"
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires layout model files and CoreML"]
+fn test_auto_layout_avoids_coreml_failure() {
+    if !test_documents_available() {
+        return;
+    }
+
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        disable_ocr: true,
+        layout: Some(accelerated_layout(ExecutionProviderType::Auto)),
+        use_layout_for_markdown: true,
+        ..Default::default()
+    };
+    let path = get_test_file_path("pdf/tiny.pdf");
+    let result = extract_uri_document_blocking(&path, None, &config).expect("auto layout extraction should succeed");
+
+    assert!(!result.content.trim().is_empty());
+    assert!(
+        !has_layout_warning(&result.processing_warnings),
+        "auto layout unexpectedly degraded: {:?}",
+        result.processing_warnings
+    );
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+#[ignore = "requires layout model files and CoreML"]
+fn test_coreml_layout_failure_emits_processing_warning() {
+    if !test_documents_available() {
+        return;
+    }
+
+    let config = ExtractionConfig {
+        output_format: OutputFormat::Markdown,
+        disable_ocr: true,
+        layout: Some(accelerated_layout(ExecutionProviderType::CoreMl)),
+        use_layout_for_markdown: true,
+        ..Default::default()
+    };
+    let path = get_test_file_path("pdf/tiny.pdf");
+    let result =
+        extract_uri_document_blocking(&path, None, &config).expect("extraction should soft-fail to native text");
+
+    assert!(
+        has_layout_warning(&result.processing_warnings),
+        "expected a caller-visible layout warning, got {:?}",
+        result.processing_warnings
+    );
+}
+
+#[cfg(all(target_os = "macos", feature = "ocr"))]
+#[test]
+#[ignore = "requires layout model files, CoreML, and Tesseract"]
+fn test_coreml_ocr_layout_failure_emits_processing_warning() {
+    if !test_documents_available() {
+        return;
+    }
+
+    let config = ExtractionConfig {
+        force_ocr: true,
+        layout: Some(accelerated_layout(ExecutionProviderType::CoreMl)),
+        ..Default::default()
+    };
+    let path = get_test_file_path("pdf/tiny.pdf");
+    let result = extract_uri_document_blocking(&path, None, &config).expect("OCR should continue without layout");
+
+    assert!(
+        has_layout_warning(&result.processing_warnings),
+        "expected a caller-visible OCR layout warning, got {:?}",
+        result.processing_warnings
     );
 }
 


### PR DESCRIPTION
## Problem

On macOS arm64, `acceleration.provider="auto"` still selects CoreML for RT-DETR. Session setup succeeds, inference fails with ORT `ExecuteKernel`, and extraction continues without layout. Current main now warns on the markdown path, but the OCR layout path still logs and discards the same failure.

Fixes #1344.

## Root cause

Auto selection checks whether CoreML is available, not whether this RT-DETR export can execute on it.

## Fix

Resolve RT-DETR auto acceleration to CPU on macOS in both file- and byte-backed constructors. Explicit providers and the global `XBERG_ORT_EP` override remain unchanged.

Reuse the shared layout warning for OCR and deduplicate it through the existing diagnostics helper.

## Validation

- Auto extraction completed layout detection with nested and global acceleration config.
- Explicit CoreML reproduced the failure and returned one layout warning from markdown and OCR paths.
- `cargo clippy --locked -p xberg --features full --all-targets -- -D warnings`
- `RUSTFLAGS="-D warnings" cargo check --locked -p xberg-cli --no-default-features --features pdf-ocr`
- `cargo clippy --locked -p xberg-cli --no-default-features --features pdf-ocr -- -D warnings`
- `cargo clippy --locked -p xberg-cli --no-default-features --features all -- -D warnings`
- `cargo test --locked -p xberg-cli --no-default-features --features pdf-ocr feature_profile_tests` (7 passed)
