### PR TITLE
fix: contain rasterizer panics; fix non-exhaustive match breaking main

### DIFF
--- a/crates/xberg/src/pdf/render.rs
+++ b/crates/xberg/src/pdf/render.rs
@@ -369,6 +369,34 @@ pub(crate) fn normalize_rendered_page_for_ocr(
     rotate_png_page_if_needed(png_data, width, height, ocr_page_correction_degrees(rotation_degrees))
 }
 
+/// Contain a panic raised while rasterizing one page, turning it into an
+/// ordinary `pdf_oxide::Error` for that page.
+///
+/// Rasterization runs third-party code over attacker-controlled geometry, and a
+/// malformed page can violate an invariant the rasterizer only asserts: on a PDF
+/// whose content streams fail to inflate (`FlateDecode` recovery exhausted),
+/// tiny-skia 0.12.0 unwraps an `AlphaRun` in `break_run` (`alpha_runs.rs:170`)
+/// that is `None`, and panics. There is no newer tiny-skia to upgrade to —
+/// 0.12.0 is the current release.
+///
+/// Because render calls run synchronously on a Tokio worker, that panic unwinds
+/// through the async boundary and fails the entire request with a 500, so a
+/// single bad page costs the caller every other page's text as well. Containing
+/// it here is the same treatment the text path gives the total-order sort panic
+/// (#1198): the page becomes an `Err`, callers fall back to their existing
+/// render-failure handling, and the rest of the document still extracts.
+fn guard_render_panic(
+    page_index: usize,
+    render: impl FnOnce() -> std::result::Result<pdf_oxide::rendering::RenderedImage, pdf_oxide::Error>,
+) -> std::result::Result<pdf_oxide::rendering::RenderedImage, pdf_oxide::Error> {
+    super::oxide::guard_oxide_panic(render, |message| {
+        pdf_oxide::Error::InvalidPdf(format!(
+            "page {} could not be rasterized: the rasterizer panicked and was contained ({message})",
+            page_index + 1
+        ))
+    })
+}
+
 /// Render a page using safeguards for extreme dimensions (wide vector diagrams,
 /// CAD sheets, etc.). This is the root-cause fix for render failures on such
 /// inputs during force_ocr / VLM / layout paths.
@@ -392,8 +420,13 @@ pub(crate) fn render_page_with_safeguards(
         );
     }
     let options = pdf_oxide::rendering::RenderOptions::with_dpi(safe_dpi);
+    // The panic guard sits inside the capture wrapper, not around it, so a
+    // panicking page still lets the wrapper take its thread-local buffer back
+    // instead of leaving it armed on a pooled thread.
     render_page_capturing_glyph_drops(page_index, || {
-        pdf_oxide::rendering::render_page(doc, page_index, &options)
+        guard_render_panic(page_index, || {
+            pdf_oxide::rendering::render_page(doc, page_index, &options)
+        })
     })
 }
 
@@ -684,6 +717,25 @@ mod tests {
             res.is_ok(),
             "wide page render should succeed thanks to safeguard, got: {:?}",
             res.err()
+        );
+    }
+
+    // A rasterizer panic used to unwind through the Tokio worker and fail the
+    // whole extraction with a 500, so the other pages' text was lost with it.
+    #[test]
+    fn test_guard_render_panic_contains_panic_as_page_error() {
+        // Matched rather than `expect_err`, which would require RenderedImage: Debug.
+        let message = match guard_render_panic(3, || panic!("simulated tiny-skia unwrap")) {
+            Ok(_) => panic!("panic must not escape the guard"),
+            Err(error) => error.to_string(),
+        };
+        assert!(
+            message.contains("page 4"),
+            "error should name the 1-based page: {message}"
+        );
+        assert!(
+            message.contains("simulated tiny-skia unwrap"),
+            "error should carry the panic message: {message}"
         );
     }
 

--- a/crates/xberg/src/rendering/doctags.rs
+++ b/crates/xberg/src/rendering/doctags.rs
@@ -77,6 +77,9 @@ pub(crate) fn render_doctags(doc: &InternalDocument) -> String {
         match elem.kind {
             ElementKind::QuoteStart | ElementKind::QuoteEnd | ElementKind::GroupStart | ElementKind::GroupEnd => {}
             ElementKind::FootnoteRef => {}
+            // Reviewer comments are annotations on the document, not content of
+            // it. djot, plain and the comrak bridge all drop them here too.
+            ElementKind::CommentRef | ElementKind::CommentDefinition => {}
             ElementKind::PageBreak => {
                 out.push_str("<page_break>\n");
             }


### PR DESCRIPTION
Two independent fixes. The first is a prerequisite for building the second, which is why they share a PR — happy to split if you prefer.

## 1. `fix(doctags)`: `main` does not compile with `--features pdf`

`ElementKind` gained `CommentDefinition` and `CommentRef` in _"feat(docx): give reviewer comments their own node kind"_, but the DocTags renderer from #1388 matches `ElementKind` exhaustively and never got the arms:

```
$ cargo check -p xberg --features pdf
error[E0004]: non-exhaustive patterns: `ElementKind::CommentDefinition` and `ElementKind::CommentRef` not covered
   --> crates/xberg/src/rendering/doctags.rs:77:15
error: could not compile `xberg` (lib) due to 1 previous error
```

Reproduced on `425b81f5f5` with no local changes. Both variants are dropped in body position, matching what `djot.rs`, `plain.rs` and `comrak_bridge.rs` already do with them.

## 2. `fix(pdf)`: a rasterizer panic fails the whole extraction

`render_page_with_safeguards` calls `pdf_oxide::rendering::render_page` unguarded, and tiny-skia 0.12.0 can panic on a page with damaged content streams (reproduction below):

```
thread 'tokio-rt-worker' panicked at tiny-skia-0.12.0/src/alpha_runs.rs:170:51:
called `Option::unwrap()` on a `None` value
```

`break_run` unwraps an `AlphaRun` its own invariant says cannot be `None`; degenerate coverage runs from a damaged page violate that. Because render calls run synchronously on a Tokio worker, the panic unwinds through the async boundary and takes the entire extraction with it — over the REST API that is a `500`, so one bad page costs the caller every other page's text.

### Reproduction

Against `ghcr.io/xberg-io/xberg:1.0.14`, with a PDF whose FlateDecode streams have been corrupted in place:

```
$ curl -F "files=@corrupt.pdf" http://localhost:8000/extract
HTTP 500
{"error_type":"Error","message":"batch task failed to join: task 35 panicked with
 message \"called `Option::unwrap()` on a `None` value\"","status_code":500}
```

`config={"force_ocr":true}` panics identically, so no retry rescues it. tiny-skia 0.12.0 is the current release — there is no upstream version to upgrade to.

### Fix

Route the call through the existing `guard_oxide_panic`, which the text path already uses for the total-order sort panic (#1198). The page becomes an ordinary `Err` that callers handle with their existing render-failure path, and the rest of the document still extracts.

The guard sits _inside_ `render_page_capturing_glyph_drops` rather than around it, so a panicking page still lets the wrapper reclaim its thread-local capture buffer instead of leaving it armed on a pooled thread.

### Tests

`test_guard_render_panic_contains_panic_as_page_error` asserts the panic is converted to an error naming the 1-based page and carrying the panic message. `cargo test -p xberg --features pdf --lib -- rendering::doctags pdf::render` → 53 passed.

Found while debugging PDF extraction for [ORKL](https://orkl.eu), which uses xberg for its threat-intel report corpus.
